### PR TITLE
fix typo in utils.hamming_distance_countfuncs

### DIFF
--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -393,7 +393,7 @@ hamming_distance_countfuncs = AddFuncDict(
         "edge_weight_func": lambda n1, n2: wrapped_hamming_distance(n1.label, n2.label),
         "accum_func": sum,
     },
-    names="HammingParsimony",
+    name="HammingParsimony",
 )
 """Provides functions to count hamming distance parsimony.
 For use with :meth:`historydag.HistoryDag.weight_count`."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -55,7 +55,7 @@ def test_dp_templatefuncs():
     template = templatedict + templatedict1
 
     startfunc, ewfunc, accumfunc = template.values()
-    assert hamming_distance_countfuncs.names == "HammingParsimony"
+    assert hamming_distance_countfuncs.names == ("HammingParsimony",)
     assert template.names == ("sum0", "min1")
     assert startfunc("doesnotmatter") == (0, 1)
     assert ewfunc("somenode", "someother") == (0, 1)


### PR DESCRIPTION
hamming_distance_countfuncs in utils.py was incorrectly specified with the `names` keyword taking a string, but should have had just the `name` keyword taking that string. This caused the demo code to fail.