### PR TITLE
Supertrees

### DIFF
--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -228,14 +228,15 @@ class UANode(HistoryDagNode):
         self.clades = {frozenset(): targetnodes}
         self.parents = set()
         self.attr = dict()
-        targetnodes.parent = self
         for child in self.children():
             child.parents.add(self)
 
     def node_self(self) -> "UANode":
         """Returns a UANode object with the same clades and label, but
         no descendant edges."""
-        return UANode(self.targetnodes)
+        newnode =  UANode(EdgeSet())
+        newnode.attr = deepcopy(self.attr)
+        return newnode
 
     def is_root(self):
         return True
@@ -940,7 +941,7 @@ class HistoryDag:
                 for label in expand_func(node.label)
             }
 
-        @utils.ignore_uanode(0)
+        @utils.ignore_uanode({'UA_Node': Counter({0: 1})})
         def edge_weight_func(parent, child):
             # This will handle 'adding' child node counts to the edge, so we
             # have accum_above_edge just return this result.

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -50,7 +50,7 @@ class HistoryDagNode:
             raise ValueError(
                 f"Internal nodes (those which are not the DAG UA root node) "
                 f"may not have exactly one child clade; Unifurcations cannot be expressed "
-                f"in the history DAG. A HistoryDagNode with {label} and clades {set(clades.keys())} is not allowed."
+                f"in the history DAG."
             )
 
     def __repr__(self) -> str:
@@ -122,9 +122,6 @@ class HistoryDagNode:
         if key not in self.clades:
             raise KeyError(
                 "Target clades' union is not a clade of this parent node: "
-                + str(key)
-                + " not in "
-                + str(self.clades)
             )
         else:
             target.parents.add(self)
@@ -375,7 +372,7 @@ class HistoryDag:
         r"""Graph union this history DAG with another."""
         if not self.dagroot == other.dagroot:
             raise ValueError(
-                f"The given HistoryDag must be a root node on identical taxa.\n{self.dagroot}\nvs\n{other.dagroot}"
+                f"The given HistoryDag must be a root node on identical taxa."
             )
         selforder = self.postorder()
         otherorder = other.postorder()
@@ -1390,7 +1387,6 @@ def from_tree(
         raise ValueError(
             "This tree's leaves are not labeled uniquely. Check your tree, "
             "or modify the label fields so that leaves are unique.\n"
-            + str(leaf_names(tree))
         )
 
     # Checking for unifurcation is handled in HistoryDagNode.__init__.

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -22,7 +22,7 @@ from collections import Counter
 from copy import deepcopy
 
 from historydag import utils
-from historydag.utils import Weight, Label, prod
+from historydag.utils import Weight, Label, UALabel, prod
 from historydag.counterops import counter_sum, counter_prod
 
 
@@ -47,9 +47,9 @@ class HistoryDagNode:
 
         if len(self.clades) == 1:
             raise ValueError(
-                f"Internal nodes (those which are not the DAG UA root node) "
-                f"may not have exactly one child clade; Unifurcations cannot be expressed "
-                f"in the history DAG."
+                "Internal nodes (those which are not the DAG UA root node) "
+                "may not have exactly one child clade; Unifurcations cannot be expressed "
+                "in the history DAG."
             )
 
     def __repr__(self) -> str:
@@ -128,6 +128,14 @@ class HistoryDagNode:
                 prob_norm=prob_norm,
             )
 
+    def remove_edge_by_clade_and_id(self, target: "HistoryDagNode", clade: frozenset):
+        key: frozenset
+        if self.is_root():
+            key = frozenset()
+        else:
+            key = clade
+        self.clades[key].remove_from_edgeset_byid(target)
+
     def remove_node(self, nodedict: Dict["HistoryDagNode", "HistoryDagNode"] = {}):
         r"""Recursively removes node self and any orphaned children from dag.
         May not work on root.
@@ -140,7 +148,7 @@ class HistoryDagNode:
             if not child.parents:
                 child.remove_node(nodedict=nodedict)
         for parent in self.parents:
-            parent.clades[self.under_clade()].remove_from_edgeset_byid(self)
+            parent.remove_edge_by_clade_and_id(self, self.under_clade())
         self.removed = True
 
     def _sample(self) -> "HistoryDagNode":
@@ -203,7 +211,7 @@ class HistoryDagNode:
             For example, `namefuncresult[&&NHX:feature1=val1:feature2=val2]`
         """
         if self.is_root():
-            return self.label
+            return self.label  # type: ignore
         else:
             if features is None:
                 features = self.label._fields
@@ -222,7 +230,7 @@ class UANode(HistoryDagNode):
     r"""A universal ancestor node, the root node of a HistoryDag"""
 
     def __init__(self, targetnodes: "EdgeSet"):
-        self.label = "UA_Node"
+        self.label = UALabel()
         # an empty frozenset is not used as a key in any other node
         self.targetnodes = targetnodes
         self.clades = {frozenset(): targetnodes}
@@ -234,7 +242,7 @@ class UANode(HistoryDagNode):
     def node_self(self) -> "UANode":
         """Returns a UANode object with the same clades and label, but
         no descendant edges."""
-        newnode =  UANode(EdgeSet())
+        newnode = UANode(EdgeSet())
         newnode.attr = deepcopy(self.attr)
         return newnode
 
@@ -251,7 +259,8 @@ class HistoryDag:
         attr: An attribute to contain data which will be preserved by copying (default and empty dict)
     """
 
-    def __init__(self, dagroot: UANode, attr: Any = {}):
+    def __init__(self, dagroot: HistoryDagNode, attr: Any = {}):
+        assert isinstance(dagroot, UANode)  # for typing
         self.attr = attr
         self.dagroot = dagroot
 
@@ -277,7 +286,7 @@ class HistoryDag:
             * edge_list: a tuple for each edge:
                     (origin node index, target node index, edge weight, edge probability)"""
         label_fields = list(self.dagroot.children())[0].label._fields
-        label_list: List[Tuple] = []
+        label_list: List[Optional[Tuple]] = []
         node_list: List[Tuple] = []
         edge_list: List[Tuple] = []
         label_indices: Dict[Label, int] = {}
@@ -389,13 +398,6 @@ class HistoryDag:
 
     def merge(self, other: "HistoryDag"):
         r"""Graph union this history DAG with another."""
-        if (
-            not self.dagroot.targetnodes.targets[0].under_clade()
-            == other.dagroot.targetnodes.targets[0].under_clade()
-        ):
-            raise ValueError(
-                f"The given HistoryDag must be a root node on identical taxa."
-            )
         selforder = self.postorder()
         otherorder = other.postorder()
         # hash and __eq__ are implemented for nodes, but we need to retrieve
@@ -907,7 +909,9 @@ class HistoryDag:
     def weight_counts_with_ambiguities(
         self,
         start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
-        edge_func: Callable[[Label, Label], Weight] = utils.hamming_distance,
+        edge_func: Callable[[Label, Label], Weight] = lambda l1, l2: (
+            0 if isinstance(l1, UALabel) else utils.hamming_distance(l1.sequence, l2.sequence)  # type: ignore
+        ),
         accum_func: Callable[[List[Weight]], Weight] = sum,
         expand_func: Callable[[Label], Iterable[Label]] = utils.sequence_resolutions,
     ):
@@ -921,7 +925,8 @@ class HistoryDag:
         Args:
             start_func: A function which assigns a weight to each leaf node
             edge_func: A function which assigns a weight to pairs of labels, with the
-                parent node label the first argument
+                parent node label the first argument. Must correctly handle the UA
+                node label which is a UALabel instead of a namedtuple.
             accum_func: A way to 'add' a list of weights together
             expand_func: A function which takes a label and returns a list of labels, such
                 as disambiguations of an ambiguous sequence.
@@ -933,6 +938,12 @@ class HistoryDag:
             but if two are the same, they come from different subtrees of the DAG.
         """
 
+        def wrapped_expand_func(label, is_root):
+            if is_root:
+                return [label]
+            else:
+                return expand_func(label)
+
         # The old direct implementation not using postorder_cladetree_accum was
         # more straightforward, and may be significantly faster.
         def leaf_func(node):
@@ -941,7 +952,6 @@ class HistoryDag:
                 for label in expand_func(node.label)
             }
 
-        @utils.ignore_uanode({'UA_Node': Counter({0: 1})})
         def edge_weight_func(parent, child):
             # This will handle 'adding' child node counts to the edge, so we
             # have accum_above_edge just return this result.
@@ -956,7 +966,7 @@ class HistoryDag:
                     ]
                 )
                 for childlabel, target_wc in child._dp_data.items()
-                for label in expand_func(parent.label)
+                for label in wrapped_expand_func(parent.label, parent.is_root())
             }
 
         def accum_within_clade(dictlist):
@@ -1153,7 +1163,7 @@ class HistoryDag:
                     newparent.add_edge(grandchild)
                     edgequeue.append([newparent, grandchild])
                 # Remove the edge we were fixing from old parent
-                parent.clades[clade].remove_from_edgeset_byid(child)
+                parent.remove_edge_by_clade_and_id(child, clade)
                 # Clean up the DAG:
                 # Delete old parent if it is no longer a valid node
                 if parent_clade_edges == 1:
@@ -1162,7 +1172,7 @@ class HistoryDag:
                     # edges added to new parent from the same clade.
                     upclade = parent.under_clade()
                     for grandparent in parent.parents:
-                        grandparent.clades[upclade].remove_from_edgeset_byid(parent)
+                        grandparent.remove_edge_by_clade_and_id(parent, upclade)
                     for child2 in parent.children():
                         child2.parents.remove(parent)
                         if not child2.parents:

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -88,7 +88,8 @@ class HistoryDagNode:
         return False
 
     def partitions(self) -> frozenset:
-        """Returns the node's child clades, or a frozenset containing a frozenset if this node is a UANode"""
+        """Returns the node's child clades, or a frozenset containing a
+        frozenset if this node is a UANode."""
         return frozenset(self.clades.keys())
 
     def children(
@@ -240,8 +241,8 @@ class UANode(HistoryDagNode):
             child.parents.add(self)
 
     def node_self(self) -> "UANode":
-        """Returns a UANode object with the same clades and label, but
-        no descendant edges."""
+        """Returns a UANode object with the same clades and label, but no
+        descendant edges."""
         newnode = UANode(EdgeSet())
         newnode.attr = deepcopy(self.attr)
         return newnode

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -118,9 +118,7 @@ class HistoryDagNode:
         # target clades must union to a clade of self
         key = frozenset() if self.is_root() else target.under_clade()
         if key not in self.clades:
-            raise KeyError(
-                "Target clades' union is not a clade of this parent node: "
-            )
+            raise KeyError("Target clades' union is not a clade of this parent node: ")
         else:
             target.parents.add(self)
             return self.clades[key].add_to_edgeset(
@@ -219,10 +217,11 @@ class HistoryDagNode:
             featurestr = ":".join(f"{name}={val}" for name, val in nameval_dict.items())
             return name_func(self) + (f"[&&NHX:{featurestr}]" if featurestr else "")
 
+
 class UANode(HistoryDagNode):
     r"""A universal ancestor node, the root node of a HistoryDag"""
 
-    def __init__(self, targetnodes: 'EdgeSet'):
+    def __init__(self, targetnodes: "EdgeSet"):
         self.label = "UA_Node"
         # an empty frozenset is not used as a key in any other node
         self.targetnodes = targetnodes
@@ -240,6 +239,7 @@ class UANode(HistoryDagNode):
 
     def is_root(self):
         return True
+
 
 class HistoryDag:
     r"""An object to represent a collection of internally labeled trees.
@@ -293,9 +293,10 @@ class HistoryDag:
             if node.label not in label_indices:
                 label_indices[node.label] = len(label_list)
                 label_list.append(None if node.is_root() else tuple(node.label))
-                assert label_list[
-                    label_indices[node.label]
-                ] == node.label or node.is_root()
+                assert (
+                    label_list[label_indices[node.label]] == node.label
+                    or node.is_root()
+                )
             node_list.append((label_indices[node.label], cladesets(node), node.attr))
             node_idx = len(node_list) - 1
             for eset in node.clades.values():
@@ -333,8 +334,7 @@ class HistoryDag:
         node_postorder = [
             UANode(EdgeSet())
             if label_list[labelidx] is None
-            else
-            HistoryDagNode(
+            else HistoryDagNode(
                 (Label(*label_list[labelidx])),
                 {unpack_labels(clade): EdgeSet() for clade in clades},
                 attr,
@@ -388,7 +388,10 @@ class HistoryDag:
 
     def merge(self, other: "HistoryDag"):
         r"""Graph union this history DAG with another."""
-        if not self.dagroot.targetnodes.targets[0].under_clade() == other.dagroot.targetnodes.targets[0].under_clade():
+        if (
+            not self.dagroot.targetnodes.targets[0].under_clade()
+            == other.dagroot.targetnodes.targets[0].under_clade()
+        ):
             raise ValueError(
                 f"The given HistoryDag must be a root node on identical taxa."
             )

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -774,7 +774,7 @@ class HistoryDag:
         start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
         edge_weight_func: Callable[
             ["HistoryDagNode", "HistoryDagNode"], Weight
-        ] = lambda n1, n2: utils.wrapped_hamming_distance(n1.label, n2.label),
+        ] = utils.wrapped_hamming_distance,
         accum_func: Callable[[List[Weight]], Weight] = sum,
         optimal_func: Callable[[List[Weight]], Weight] = min,
     ) -> Weight:
@@ -807,7 +807,7 @@ class HistoryDag:
         start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
         edge_weight_func: Callable[
             ["HistoryDagNode", "HistoryDagNode"], Weight
-        ] = lambda n1, n2: utils.wrapped_hamming_distance(n1.label, n2.label),
+        ] = utils.wrapped_hamming_distance,
         accum_func: Callable[[List[Weight]], Weight] = sum,
     ):
         r"""A template method for counting weights of trees expressed in the history DAG.
@@ -987,7 +987,7 @@ class HistoryDag:
         start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
         edge_weight_func: Callable[
             [HistoryDagNode, HistoryDagNode], Weight
-        ] = lambda n1, n2: utils.wrapped_hamming_distance(n1.label, n2.label),
+        ] = utils.wrapped_hamming_distance,
         accum_func: Callable[[List[Weight]], Weight] = sum,
         optimal_func: Callable[[List[Weight]], Weight] = min,
         eq_func: Callable[[Weight, Weight], bool] = lambda w1, w2: w1 == w2,

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -136,7 +136,7 @@ def hamming_distance(s1: str, s2: str) -> int:
 @access_nodefield_default("sequence", 0)
 def wrapped_hamming_distance(s1, s2) -> int:
     """The sitewise sum of base differences between sequence field contents of
-    two labels.
+    two nodes.
 
     Takes two HistoryDagNodes as arguments.
 
@@ -356,7 +356,7 @@ class AddFuncDict(UserDict):
 hamming_distance_countfuncs = AddFuncDict(
     {
         "start_func": lambda n: 0,
-        "edge_weight_func": lambda n1, n2: wrapped_hamming_distance(n1.label, n2.label),
+        "edge_weight_func": wrapped_hamming_distance,
         "accum_func": sum,
     },
     name="HammingParsimony",

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -19,41 +19,11 @@ from typing import (
 )
 
 Weight = Any
-NTLabel = NamedTuple
-Label = Union["UALabel", NTLabel]
+Label = NamedTuple
 F = TypeVar("F", bound=Callable[..., Any])
 
 bases = "AGCT-"
 ambiguous_dna_values.update({"?": bases, "-": "-"})
-
-
-class UALabel:
-    """A history DAG universal ancestor (UA) node label."""
-
-    _fields: Any = tuple()
-
-    def __init__(self):
-        pass
-
-    def __repr__(self):
-        return "UA_node"
-
-    def __hash__(self):
-        return 0
-
-    def __eq__(self, other):
-        if isinstance(other, UALabel):
-            return True
-        else:
-            return False
-
-    # For typing:
-    def __iter__(self):
-        raise RuntimeError("Attempted to iterate from dag root UALabel")
-
-    def _asdict(self):
-        raise RuntimeError("Attempted to iterate from dag root UALabel")
-
 
 # ######## Decorators ########
 def access_nodefield_default(fieldname: str, default: Any) -> Any:
@@ -71,8 +41,8 @@ def access_nodefield_default(fieldname: str, default: Any) -> Any:
     """
 
     def decorator(func):
+        @ignore_uanode(default)
         @access_field("label")
-        @ignore_ualabel(default)
         @access_field(fieldname)
         @wraps(func)
         def wrapper(*args: Label, **kwargs: Any) -> Weight:
@@ -104,18 +74,18 @@ def access_field(fieldname: str) -> Callable[[F], F]:
     return decorator
 
 
-def ignore_ualabel(default: Any) -> Callable[[F], F]:
-    """A decorator to return a default value if any argument is a UALabel.
+def ignore_uanode(default: Any) -> Callable[[F], F]:
+    """A decorator to return a default value if any argument is a UANode.
 
-    For instance, to allow distance between two labels to be zero if one
-    is UALabel
+    For instance, to allow distance between two nodes to be zero if one
+    is UANode
     """
 
     def decorator(func):
         @wraps(func)
-        def wrapper(*args: Union[Label, UALabel], **kwargs: Any):
-            for label in args:
-                if isinstance(label, UALabel):
+        def wrapper(*args: 'HistoryDagNode', **kwargs: Any):
+            for node in args:
+                if node.is_root():
                     return default
             else:
                 return func(*args, **kwargs)
@@ -142,14 +112,11 @@ def explode_label(labelfield: str):
     ) -> Callable[[Label], Iterable[Label]]:
         @wraps(func)
         def wrapfunc(label, *args, **kwargs):
-            if isinstance(label, UALabel):
-                yield label
-            else:
-                Label = type(label)
-                d = label._asdict()
-                for newval in func(d[labelfield], *args, **kwargs):
-                    d[labelfield] = newval
-                    yield Label(**d)
+            Label = type(label)
+            d = label._asdict()
+            for newval in func(d[labelfield], *args, **kwargs):
+                d[labelfield] = newval
+                yield Label(**d)
 
         return wrapfunc
 
@@ -165,16 +132,14 @@ def hamming_distance(s1: str, s2: str) -> int:
         raise ValueError("Sequences must have the same length!")
     return sum(x != y for x, y in zip(s1, s2))
 
-
-@ignore_ualabel(0)
-@access_field("sequence")
+@access_nodefield_default("sequence", 0)
 def wrapped_hamming_distance(s1, s2) -> int:
     """The sitewise sum of base differences between sequence field contents of
     two labels.
 
-    Takes two Labels as arguments.
+    Takes two HistoryDagNodes as arguments.
 
-    If l1 or l2 is a UALabel, returns 0.
+    If l1 or l2 is a UANode, returns 0.
     """
     return hamming_distance(s1, s2)
 

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -83,7 +83,7 @@ def ignore_uanode(default: Any) -> Callable[[F], F]:
 
     def decorator(func):
         @wraps(func)
-        def wrapper(*args: 'HistoryDagNode', **kwargs: Any):
+        def wrapper(*args: "HistoryDagNode", **kwargs: Any):
             for node in args:
                 if node.is_root():
                     return default
@@ -131,6 +131,7 @@ def hamming_distance(s1: str, s2: str) -> int:
     if len(s1) != len(s2):
         raise ValueError("Sequences must have the same length!")
     return sum(x != y for x, y in zip(s1, s2))
+
 
 @access_nodefield_default("sequence", 0)
 def wrapped_hamming_distance(s1, s2) -> int:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -36,11 +36,11 @@ newicklistlist = [
         "((CA, GG)CG, AA, (TT, (CC, GA)GC)GC)AG;",
     ],
     ["((AA, CT)CG, (TA, CC)CG)CC;", "((AA, CT)CA, (TA, CC)CC)CC;"],
-    # [
-    #     "((CA, GG)CA, AT, (TT, (CC, GA)CC)CC)AA;",
-    #     "((CA, GG)CA, AA, (TT, (CC, GA)CA)CA)AA;",
-    #     "((CA, GG)CG, AA, (TT, (CC, GA)GC)GC)AG;",
-    # ],
+    [
+        "((CA, GG)CA, AT, (TT, (CC, GA)CC)CC)AA;",
+        "((CA, GG)CA, AA, (TT, (CC, GA)CA)CA)AA;",
+        "((CA, GG)CG, AA, (TT, (CC, GA)GC)GC)AG;",
+    ],
 ]
 
 dags = [

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -99,7 +99,7 @@ def test_valid_dags():
         for node in dag.postorder():
             for clade in node.clades:
                 for target in node.clades[clade].targets:
-                    assert target.under_clade() == clade
+                    assert target.under_clade() == clade or node.is_root()
 
         # each clade has a descendant edge:
         for node in dag.postorder():
@@ -131,7 +131,7 @@ def test_parsimony():
     def parsimony(tree):
         tree.recompute_parents()
         return sum(
-            dagutils.wrapped_hamming_distance(list(node.parents)[0].label, node.label)
+            dagutils.wrapped_hamming_distance(list(node.parents)[0], node)
             for node in tree.postorder()
             if node.parents
         )
@@ -222,7 +222,7 @@ def test_min_weight():
     def parsimony(tree):
         tree.recompute_parents()
         return sum(
-            dagutils.wrapped_hamming_distance(list(node.parents)[0].label, node.label)
+            dagutils.wrapped_hamming_distance(list(node.parents)[0], node)
             for node in tree.postorder()
             if node.parents
         )

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -36,11 +36,11 @@ newicklistlist = [
         "((CA, GG)CG, AA, (TT, (CC, GA)GC)GC)AG;",
     ],
     ["((AA, CT)CG, (TA, CC)CG)CC;", "((AA, CT)CA, (TA, CC)CC)CC;"],
-    [
-        "((CA, GG)CA, AT, (TT, (CC, GA)CC)CC)AA;",
-        "((CA, GG)CA, AA, (TT, (CC, GA)CA)CA)AA;",
-        "((CA, GG)CG, AA, (TT, (CC, GA)GC)GC)AG;",
-    ],
+    # [
+    #     "((CA, GG)CA, AT, (TT, (CC, GA)CC)CC)AA;",
+    #     "((CA, GG)CA, AA, (TT, (CC, GA)CA)CA)AA;",
+    #     "((CA, GG)CG, AA, (TT, (CC, GA)GC)GC)AG;",
+    # ],
 ]
 
 dags = [

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -36,6 +36,11 @@ newicklistlist = [
         "((CA, GG)CG, AA, (TT, (CC, GA)GC)GC)AG;",
     ],
     ["((AA, CT)CG, (TA, CC)CG)CC;", "((AA, CT)CA, (TA, CC)CC)CC;"],
+    [
+        "((CA, GG)CA, AT, (TT, (CC, GA)CC)CC)AA;",
+        "((CA, GG)CA, AA, (TT, (CC, GA)CA)CA)AA;",
+        "((CA, GG)CG, AA, (TT, (CC, GA)GC)GC)AG;",
+    ],
 ]
 
 dags = [

--- a/tests/test_historydag.py
+++ b/tests/test_historydag.py
@@ -279,20 +279,6 @@ def test_explode_rejects_leaf_ambiguities():
         return
 
 
-def test_differentleaves():
-    # Make sure that a DAG will not be created from trees with different leaf
-    # labels
-    # First make sure the call works when the problem is fixed
-    history_dag_from_newicks(["((a, b)b, c)c;", "((a, b)b, c)c;"], ["name"])
-    try:
-        history_dag_from_newicks(["((z, b)b, c)c;", "((a, b)b, c)c;"], ["name"])
-        raise RuntimeError(
-            "history DAG was allowed to be constructed from trees with different leaf labels."
-        )
-    except ValueError:
-        return
-
-
 def test_print():
     tree1 = ete3.Tree(newickstring2, format=1)
     dag1 = from_tree(tree1, ["sequence"])

--- a/tests/test_historydag.py
+++ b/tests/test_historydag.py
@@ -93,6 +93,11 @@ def test_from_tree():
     G = dag.to_graphviz(namedict=namedict)
     return G
 
+def test_is_clade_tree():
+    tree = ete3.Tree(newickstring2, format=1)
+    print(tree.sequence)
+    dag = from_tree(tree, ["sequence"])
+    assert dag.is_clade_tree()
 
 def test_from_tree_label():
     tree = ete3.Tree(newickstring2, format=1)
@@ -222,6 +227,8 @@ def test_sample():
     newicks = ["((1, 2)2, 3)3;", "((1, 2)3, 3)3;", "((1, 2)1, 3)3;", "((1, 2)4, 3)4;"]
     namedict = {(str(x),): x for x in range(5)}
     dag = history_dag_from_newicks(newicks, ["name"])
+    for i in range(10):
+        assert dag.sample().is_clade_tree()
     sample = dag.sample()
     return sample.to_graphviz(namedict=namedict)
 

--- a/tests/test_historydag.py
+++ b/tests/test_historydag.py
@@ -173,7 +173,7 @@ def test_postorder():
         10,
         9,
         1,
-        "UA_node",
+        "UA_Node",
     ]
     # print([namedict[node.label] for node in postorder(dag)])
 
@@ -298,7 +298,6 @@ def test_eq():
     tree2 = ete3.Tree("((z, b)b, c)c;", format=1)
     dag2 = from_tree(tree2, ["name"])
     assert dag1.dagroot == dag1.copy().dagroot
-    assert dag1.dagroot != dag2.dagroot
 
 
 def test_to_graphviz():

--- a/tests/test_historydag.py
+++ b/tests/test_historydag.py
@@ -93,11 +93,13 @@ def test_from_tree():
     G = dag.to_graphviz(namedict=namedict)
     return G
 
+
 def test_is_clade_tree():
     tree = ete3.Tree(newickstring2, format=1)
     print(tree.sequence)
     dag = from_tree(tree, ["sequence"])
     assert dag.is_clade_tree()
+
 
 def test_from_tree_label():
     tree = ete3.Tree(newickstring2, format=1)
@@ -291,6 +293,7 @@ def test_eq():
     tree2 = ete3.Tree("((z, b)b, c)c;", format=1)
     dag2 = from_tree(tree2, ["name"])
     assert dag1.dagroot == dag1.copy().dagroot
+    assert list(dag1.dagroot.children())[0] != list(dag2.dagroot.children())[0]
 
 
 def test_to_graphviz():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,5 @@
 from historydag.utils import (
     hamming_distance,
-    UALabel,
     hist,
     AddFuncDict,
     hamming_distance_countfuncs,
@@ -20,11 +19,6 @@ def test_hamming_distance():
         "hamming distance allowed comparison of sequences with different lengths."
     )
 
-
-def test_ualabel():
-    assert UALabel() == UALabel()
-    assert UALabel() is not None
-    assert UALabel() != 0
 
 
 def test_hist():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,7 +20,6 @@ def test_hamming_distance():
     )
 
 
-
 def test_hist():
     hist(Counter([1, 2, 3, 3, 3, 3, 4]))
 


### PR DESCRIPTION
This PR allows history DAGs to be built from trees with multiple edge sets.

To do this, we add a subclass of `HistoryDagNode`, called `UANode` which overrides the constructor and a couple of methods. A `UANode`'s label is a `utils.UALabel` object, which is just a subclassed string whose value is fixed to `"UA_Node"`.

The `UANode`'s clades dictionary contains a single key, an empty frozenset, whose value is an `EdgeSet`. Anywhere that checks if an edge is allowed between two nodes based on child clades of the target relaxes the requirement when the parent node is a `UA_Node`. Edges are allowed between the `UA_Node` and any other node.