### PR TITLE
V1 docs changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ dag.trim_optimal_weight(**node_count_funcs, optimal_func=min)
 
 # Sample a tree from the dag and make it an ete tree
 t = dag.sample().to_ete()
+
+# the history DAG also supports indexing and iterating:
+t = dag[0].to_ete()
+trees = [tree for tree in dag]
+
+# Another method for fetching all trees in the dag is provided, but the order
+# will not match index order:
+scrambled_trees = list(dag.get_trees())
+
+
+# Union is implemented as dag merging, including with sequences of dags
+newdag = dag[0] | dag[1]
+newdag = dag[0] | (dag[i] for i in range(3,5))
 ```
 
 ### Highlights
@@ -87,7 +100,6 @@ meet the following criteria:
 * The label attributes used to construct history DAG labels must be unique,
     because history DAG nodes which represent leaves must be labeled uniquely.
 
-In addition, all the trees in the collection must have identical sets of leaf labels.
 
 ## Documentation
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -198,3 +198,22 @@ ete tree for further rendering/processing:
 
 The :meth:`historydag.HistoryDag.to_ete` method allows full control over
 mapping of history DAG node attributes to :class:`ete3.Tree` node attributes.
+
+We can also retrieve trees in the history DAG by index, and iterate in
+index-order:
+
+>>> t = dag[0].to_ete()
+>>> trees = [tree for tree in dag]
+
+Another method for fetching all trees in the dag is provided, but the order
+will not match index order:
+
+>>> scrambled_trees = list(dag.get_trees())
+
+
+History DAGs can be merged using the :meth:`historydag.HistoryDag.merge`
+method, or equivalently using the ``or`` operator. This supports merging with
+sequences of history DAGs.
+
+>>> newdag = dag[0] | dag[1]
+>>> newdag = dag[0] | (dag[i] for i in range(3,5))


### PR DESCRIPTION
Change historyDAG docs to reflect changes in new release, including:

* trees in history DAG need not have the same leaf label sets
* the history DAG is now an iterable, indexable container that supports the union operator