### PR TITLE
Wd topologies explore

### DIFF
--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -807,11 +807,11 @@ class HistoryDag:
         utils.hist(self.weight_counts_with_ambiguities())
 
     def label_uncertainty_summary(self):
-        """Print information about nodes which have the same child clades but
+        """Print information about internal nodes which have the same child clades but
         different labels."""
         duplicates = list(
             Counter(
-                node.partitions() for node in self.preorder(skip_root=True)
+                node.partitions() for node in self.preorder(skip_root=True) if not node.is_leaf()
             ).values()
         )
         print(

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -802,7 +802,7 @@ class HistoryDag:
 
     def leaf_path_uncertainty_dag(self, leaf_label):
         """Compute the DAG of possible paths leading to `leaf_label`.
-        
+
         Args:
             leaf_label: The node label of the leaf of interest
 
@@ -810,8 +810,11 @@ class HistoryDag:
             parent_dictionary: A dictionary keyed by node labels, with sets
                 of possible parent node labels.
         """
-        parent_dictionary = {node.label: set() for node in self.dagroot.children()
-                             if leaf_label in node.under_clade()}
+        parent_dictionary = {
+            node.label: set()
+            for node in self.dagroot.children()
+            if leaf_label in node.under_clade()
+        }
 
         for node in self.preorder(skip_root=True):
             for clade, eset in node.clades.items():
@@ -826,18 +829,19 @@ class HistoryDag:
         return parent_dictionary
 
     def leaf_path_uncertainty_graphviz(self, leaf_label):
-        """send output of leaf_path_uncertainty_dag to graphviz for rendering
+        """send output of leaf_path_uncertainty_dag to graphviz for rendering.
 
         Returns:
-            The graphviz DAG object, and a dictionary mapping node names to labels"""
+            The graphviz DAG object, and a dictionary mapping node names to labels
+        """
         G = gv.Digraph("Path DAG to leaf", node_attr={})
         parent_d = self.leaf_path_uncertainty_dag(leaf_label)
         label_ids = {key: str(idnum) for idnum, key in enumerate(parent_d)}
         for key in parent_d:
             if key == leaf_label:
-                G.node(label_ids[key], shape='octagon')
+                G.node(label_ids[key], shape="octagon")
             elif len(parent_d[key]) == 0:
-                G.node(label_ids[key], shape='invtriangle')
+                G.node(label_ids[key], shape="invtriangle")
             else:
                 G.node(label_ids[key])
         for key, parentset in parent_d.items():
@@ -856,11 +860,13 @@ class HistoryDag:
         utils.hist(self.weight_counts_with_ambiguities())
 
     def label_uncertainty_summary(self):
-        """Print information about internal nodes which have the same child clades but
-        different labels."""
+        """Print information about internal nodes which have the same child
+        clades but different labels."""
         duplicates = list(
             Counter(
-                node.partitions() for node in self.preorder(skip_root=True) if not node.is_leaf()
+                node.partitions()
+                for node in self.preorder(skip_root=True)
+                if not node.is_leaf()
             ).values()
         )
         print(
@@ -1038,8 +1044,10 @@ class HistoryDag:
 
     def count_topologies(self) -> int:
         """Counts the number of unique topologies in the history DAG.
-        This is achieved by creating a new history DAG in which all internal nodes have
-        matching labels."""
+
+        This is achieved by creating a new history DAG in which all
+        internal nodes have matching labels.
+        """
         return self.unlabel().count_trees()
 
     def count_trees(

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -440,8 +440,8 @@ class HistoryDag:
         return HistoryDag(self.dagroot._sample())
 
     def unlabel(self) -> "HistoryDag":
-        """Sets all internal node labels to be identical, and merges nodes
-        so that all histories in the DAG have unique topologies."""
+        """Sets all internal node labels to be identical, and merges nodes so
+        that all histories in the DAG have unique topologies."""
 
         newdag = self.copy()
         model_label = next(self.preorder(skip_root=True)).label
@@ -451,13 +451,12 @@ class HistoryDag:
         for node in newdag.preorder(skip_root=True):
             if not node.is_leaf():
                 node.label = internal_label
-        
+
         # Use merging method to eliminate duplicate nodes, by starting with
         # a subdag with no duplicate nodes.
         ret = newdag.sample()
         ret.merge(newdag)
         return ret
-
 
     def is_clade_tree(self) -> bool:
         """Returns whether history DAG is a clade tree.
@@ -806,6 +805,24 @@ class HistoryDag:
         print(f"Nodes:\t{sum(1 for _ in self.postorder())}")
         print(f"Trees:\t{self.count_trees()}")
         utils.hist(self.weight_counts_with_ambiguities())
+
+    def label_uncertainty_summary(self):
+        """Print information about nodes which have the same child clades but
+        different labels."""
+        duplicates = list(
+            Counter(
+                node.partitions() for node in self.preorder(skip_root=True)
+            ).values()
+        )
+        print(
+            "Mean unique labels per unique child clade set:",
+            sum(duplicates) / len(duplicates),
+        )
+        print("Maximum duplication:", max(duplicates))
+        print(
+            "Counts of duplication numbers by unique child clade set:",
+            Counter(duplicates),
+        )
 
     # ######## Abstract dp method and derivatives: ########
 

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -305,18 +305,18 @@ class HistoryDag:
 
     def __getitem__(self, key) -> "HistoryDag":
         r"""Returns the sub-history below the current history dag corresponding to the given index."""
+        length = self.count_trees()
         if key < 0:
-            key = len(self) + key
+            key = length + key
         if isinstance(key, slice) or not type(key) == int:
             raise TypeError(f"History DAG indices must be integers, not {type(key)}")
-        if not (key >= 0 and key < len(self)):
+        if not (key >= 0 and key < length):
             raise IndexError
         self.count_trees()
         return HistoryDag(self.dagroot._get_subtree_by_subid(key))
 
     def __len__(self) -> int:
-        self.count_trees()
-        return self.dagroot._dp_data
+        return self.count_trees()
 
     def __or__(self, other) -> "HistoryDag":
         newdag = self.copy()

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -439,6 +439,26 @@ class HistoryDag:
         leaf nodes). Returns a new HistoryDagNode object."""
         return HistoryDag(self.dagroot._sample())
 
+    def unlabel(self) -> "HistoryDag":
+        """Sets all internal node labels to be identical, and merges nodes
+        so that all histories in the DAG have unique topologies."""
+
+        newdag = self.copy()
+        model_label = next(self.preorder(skip_root=True)).label
+        # initialize empty/default value for each item in model_label
+        field_values = tuple(type(item)() for item in model_label)
+        internal_label = type(model_label)(*field_values)
+        for node in newdag.preorder(skip_root=True):
+            if not node.is_leaf():
+                node.label = internal_label
+        
+        # Use merging method to eliminate duplicate nodes, by starting with
+        # a subdag with no duplicate nodes.
+        ret = newdag.sample()
+        ret.merge(newdag)
+        return ret
+
+
     def is_clade_tree(self) -> bool:
         """Returns whether history DAG is a clade tree.
 

--- a/scripts/agg_mut.py
+++ b/scripts/agg_mut.py
@@ -1,4 +1,5 @@
 import ete3
+import random
 import dag_pb2 as dpb
 from collections import Counter
 import bte as mat
@@ -92,23 +93,27 @@ def process_from_mat(file, refseqid):
             node.delete(prevent_nondicotomic=False)
     return tree
 
+def load_MAD_pbdata(filename):
+    with open(filename, 'rb') as fh:
+        pb_data = dpb.data()
+        pb_data.ParseFromString(fh.read())
+    return pb_data
+
 def load_dag(dagname):
-    if dagname.split('.')[-1] == 'p':
+    last_suffix = dagname.split('.')[-1]
+    if last_suffix == 'p':
         with open(dagname, 'rb') as fh:
             dag, refseqtuple = pickle.load(fh)
             dag.refseq = refseqtuple
             return dag
-    elif dagname.split('.')[-1] == 'json':
+    elif last_suffix == 'json':
         with open(dagname, 'r') as fh:
             json_dict = json.load(fh)
         return unflatten(json_dict)
-    elif dagname.split('.')[-1] == 'pb':
-        with open(dagname, 'rb') as fh:
-            pb_data = dpb.data()
-            pb_data.ParseFromString(fh.read())
-        return pb_to_dag(pb_data)
+    elif last_suffix == 'pb':
+        return pb_to_dag(load_MAD_pbdata(dagname))
     else:
-        raise ValueError("Unrecognized file format. Provide either pickled dag (*.p), or json serialized dags (*.json).")
+        raise ValueError("Unrecognized file format. Provide either pickled dag (*.p), or json serialized dags (*.json), or protobuf (*.pb).")
 
 class Encoder(json.JSONEncoder):
     def default(self, obj):
@@ -118,9 +123,9 @@ class Encoder(json.JSONEncoder):
             return list(obj)
         return json.JSONEncoder.default(self, obj)
 
-def write_dag(dag, dagpath, sort=False):
+def write_dag(dag, dagpath, sort=False, **kwargs):
     """Write to pickle file, json, or MAD protobuf (`pb`)"""
-    extension = dagpath.split('.')[-1].lower()
+    extension = str(dagpath).split('.')[-1].lower()
     if extension == 'p':
         with open(dagpath, 'wb') as fh:
             fh.write(pickle.dumps((dag, dag.refseq)))
@@ -129,22 +134,43 @@ def write_dag(dag, dagpath, sort=False):
             fh.write(json.dumps(flatten(dag, sort_compact_genomes=sort), cls=Encoder))
     elif extension == 'pb':
         with open(dagpath, 'wb') as fh:
-            fh.write(dag_to_mad_pb(dag).SerializeToString())
+            fh.write(dag_to_mad_pb(dag, **kwargs).SerializeToString())
     else:
         raise ValueError("unrecognized output file extension. Supported extensions are .p and .json.")
 
 def sequence_to_cg(sequence, ref_seq):
-    cg = {idx: (old_base, new_base) for idx, (old_base, new_base) in zip(ref_seq, sequence) if old_base != new_base}
+    cg = {zero_idx + 1: (old_base, new_base)
+          for zero_idx, (old_base, new_base) in enumerate(zip(ref_seq, sequence))
+          if old_base != new_base}
     return frozendict(cg)
 
 def cg_to_sequence(cg, ref_seq):
     newseq = []
-    for idx, ref_nuc in enumerate(ref_seq):
-        if idx in cg:
-            newseq.append(cg[idx][1])
-        else:
-            newseq.append(ref_nuc)
+    newseq = list(ref_seq)
+    for idx, (ref_base, newbase) in cg.items():
+        if ref_base != newseq[idx - 1]:
+            print("cg_to_sequence warning: reference base doesn't match cg reference base")
+        newseq[idx - 1] = newbase
     return ''.join(newseq)
+
+def _test_sequence_cg_convert():
+    seqs = [
+        'AAAA',
+        'TAAT',
+        'CTGA',
+        'TGCA',
+    ]
+    for refseq in seqs:
+        for seq in seqs:
+            cg = sequence_to_cg(seq, refseq)
+            reseq = cg_to_sequence(cg, refseq)
+            if reseq != seq:
+                print("\nUnmatched reconstructed sequence:")
+                print("ref sequence:", refseq)
+                print("sequence:", seq)
+                print("cg:", cg)
+                print("reconstructed sequence:", reseq)
+                assert False
 
 def cg_diff(parent_cg, child_cg):
     """Yields mutations in the format (parent_nuc, child_nuc, sequence_index)
@@ -160,37 +186,83 @@ def cg_diff(parent_cg, child_cg):
             new_base = child_cg[key][1]
         else:
             new_base = parent_cg[key][0]
-        yield (parent_base, new_base, key)
+        if parent_base != new_base:
+            yield (parent_base, new_base, key)
 
-def dag_to_mad_pb(dag, add_leaf_seqs=False):
+def str_mut_from_tups(tup_muts):
+    for tup_mut in tup_muts:
+        par_nuc, child_nuc, idx = tup_mut
+        yield par_nuc + str(idx) + child_nuc
+
+def _test_cg_diff():
+    cgs = [
+        frozendict({287: ('C', 'G')}),
+        frozendict({287: ('C', 'G'), 318: ('C', 'A'), 495: ('C', 'T')}),
+        frozendict({287: ('C', 'G'), 80: ('A', 'C'), 257: ('C', 'G'), 591: ('G', 'A')}),
+        frozendict({287: ('C', 'G'), 191: ('A', 'G'), 492: ('C', 'G'), 612: ('C', 'G'), 654: ('A', 'G')}),
+        frozendict({287: ('C', 'G'), 318: ('C', 'A'), 495: ('C', 'T')}),
+    ]
+    for parent_cg in cgs:
+        for child_cg in cgs:
+            assert apply_muts(parent_cg, str_mut_from_tups(cg_diff(parent_cg, child_cg))) == child_cg
+            assert all(par_nuc != child_nuc for par_nuc, child_nuc, idx in cg_diff(parent_cg, child_cg))
+
+def string_seq_diff(parent_seq, child_seq):
+    return ((par_nuc, child_nuc, zero_idx + 1)
+            for zero_idx, (par_nuc, child_nuc) in enumerate(zip(parent_seq, child_seq))
+            if par_nuc != child_nuc)
+
+
+
+def dag_to_mad_pb(dag, leaf_data_func=None, from_mutseqs=True):
     """convert a DAG with compact genome data on each node, to a MAD protobuf with mutation
     information on edges.
+
+    Args:
+        dag: the history DAG to be converted
+        leaf_data_func: a function taking a DAG node and returning a string to store
+            in the protobuf node_name field `condensed_leaves` of leaf nodes
+        from_mutseqs: if True, passed DAG must contain compact genomes in mutseq label
+            attributes. Otherwise, DAG must contain string sequences in sequence label attributes.
     """
-    refseqid, refseq = dag.refseq
+    if from_mutseqs:
+        refseqid, refseq = dag.refseq
+        def mut_func(pnode, cnode):
+            if pnode.is_root():
+                parent_seq = frozendict()
+            else:
+                parent_seq = pnode.label.mutseq
+            return cg_diff(parent_seq, child.label.mutseq)
+    else:
+        refseq = next(dag.preorder(skip_root=True)).label.sequence
+        refseqid = 'unknown_seq_id'
+        def mut_func(pnode, cnode):
+            if pnode.is_root():
+                parent_seq = refseq
+            else:
+                parent_seq = pnode.label.sequence
+            return string_seq_diff(parent_seq, cnode.label.sequence)
+
     node_dict = {}
     data = dpb.data()
     for idx, node in enumerate(dag.postorder()):
         node_dict[node] = idx
         node_name = data.node_names.add()
         node_name.node_id = idx
-        if add_leaf_seqs:
+        if leaf_data_func is not None:
             if node.is_leaf():
-                node_name.condensed_leaves.append(cg_to_sequence(node.label.mutseq, refseq))
+                node_name.condensed_leaves.append(leaf_data_func(node))
 
     for node in dag.postorder():
-        if node.is_root():
-            parent_seq = frozendict()
-        else:
-            parent_seq = node.label.mutseq
         for cladeidx, (clade, edgeset) in enumerate(node.clades.items()):
             for child in edgeset.targets:
                 edge = data.edges.add()
                 edge.parent_node = node_dict[node]
                 edge.parent_clade = cladeidx
                 edge.child_node = node_dict[child]
-                for par_nuc, child_nuc, idx in cg_diff(parent_seq, child.label.mutseq):
+                for par_nuc, child_nuc, idx in mut_func(node, child):
                     mut = edge.edge_mutations.add()
-                    mut.position = idx + 1
+                    mut.position = idx
                     mut.par_nuc = nuc_codes[par_nuc.upper()]
                     mut.mut_nuc.append(nuc_codes[child_nuc.upper()])
     data.reference_seq = refseq
@@ -266,7 +338,7 @@ def pb_to_dag(pbdata):
     node_index_d = {record.node_id: idx for idx, record in enumerate(pbdata.node_names)}
     node_list = [(label_dict[node_compact_genomes[node_record.node_id]],
                   child_clades[node_record.node_id],
-                  None)
+                  {"node_id": node_record.node_id})
                  for node_record in pbdata.node_names]
     
     edge_list = [(node_index_d[edge.parent_node], node_index_d[edge.child_node], 0, 1)
@@ -521,14 +593,14 @@ def find_leaf_sequence(infile, reference_seq_fasta, outfile, leaf_id, leaf_id_fi
             oldbase = mut[0]
             newbase = mut[-1]
             # muts seem to be 1-indexed!
-            idx = int(mut[1:-1]) - 1
+            zero_idx = int(mut[1:-1]) - 1
             if reverse:
                 newbase, oldbase = oldbase, newbase
-            if idx > len(sequence):
-                print(idx, len(sequence))
-            if sequence[idx] != oldbase:
+            if zero_idx > len(sequence):
+                print(zero_idx, len(sequence))
+            if sequence[zero_idx] != oldbase:
                 print("warning: sequence does not have expected (old) base at site")
-            sequence = sequence[: idx] + newbase + sequence[idx + 1 :]
+            sequence = sequence[: zero_idx] + newbase + sequence[zero_idx + 1 :]
         return sequence
     fasta_data = load_fasta(reference_seq_fasta)
     ((_, refseq_constant), ) = fasta_data.items()
@@ -689,6 +761,97 @@ def unflatten(flat_dag):
     dag = HistoryDag(node_postorder[-1][0])
     dag.refseq = tuple(flat_dag["refseq"])
     return dag
+
+
+@cli.command("make-testcase")
+@click.argument("pickled_forest")
+@click.argument("outdir")
+@click.option("-n", "--num_trees")
+@click.option("-s", "--random_seed", default=1)
+def make_testcase(pickled_forest, outdir, num_trees, random_seed):
+    random.seed(random_seed)
+    outdir = Path(outdir)
+    outdir.mkdir(exist_ok=True)
+    with open(pickled_forest, 'rb') as fh:
+        forest = pickle.load(fh)
+    dag = forest._forest
+    trees = [dag.sample() for _ in range(int(num_trees))]
+    refseqs = [next(tree.preorder(skip_root=True)).label.sequence for tree in trees]
+    assert len(set(refseqs)) == 1
+    # These dags have full sequence strings instead of compact genomes, which
+    # is why we pass from_mutseqs to write_dag (which passes it on to
+    # dag_to_mad_pb)
+    for idx, tree in enumerate(trees):
+        write_dag(tree, outdir / f"tree_{str(idx)}.pb", from_mutseqs=False)
+    newdag = trees[0]
+    for tree in trees[1:]:
+        newdag.merge(tree)
+    write_dag(newdag, outdir / "full_dag.pb", from_mutseqs=False)
+    print(f"Test case dag contains {newdag.count_trees()} trees")
+
+@cli.command("change-ref")
+@click.argument("in_pb")
+@click.argument("out_dag")
+@click.argument("new_ref_fasta")
+def change_ref(in_pb, out_dag, new_ref_fasta):
+    """Change the reference sequence on the provided protobuf DAG, and output
+    to a new protobuf file"""""
+    pbdata = load_MAD_pbdata(in_pb)
+    oldref = pbdata.reference_seq
+    ((newrefid, newref),) = load_fasta(new_ref_fasta).items()
+    if len(newref) != len(oldref):
+        raise ValueError("New reference length does not match old reference length")
+    # use new ref as reference sequence
+    newstart_cg = sequence_to_cg(oldref, newref)
+    # find DAG UA node:
+    parent_edges = {}
+    child_edges = {}
+    for edge in pbdata.edges:
+        if edge.parent_node in child_edges:
+            child_edges[edge.parent_node].append(edge)
+        else:
+            child_edges[edge.parent_node] = [edge]
+        if edge.child_node in parent_edges:
+            parent_edges[edge.child_node].append(edge)
+        else:
+            parent_edges[edge.child_node] = [edge]
+    ua_node_set = set(child_edges.keys()) - set(parent_edges.keys())
+    (ua_node_id, ) = set(child_edges.keys()) - set(parent_edges.keys())
+    # add newmuts to all edges descending from DAG UA node:
+    for edge in child_edges[ua_node_id]:
+        child_cg = newstart_cg.copy()
+        for mut in edge.edge_mutations:
+            mutstring = nuc_lookup[mut.par_nuc] + str(mut.position) + nuc_lookup[mut.mut_nuc[0]]
+            sequence.mutate(child_cg, mutstring)
+        # clear edge mutations
+        while len(edge.edge_mutations) > 0:
+            edge.edge_mutations.pop()
+        for (old_base, new_base, idx) in cg_diff(frozendict(), child_cg):
+            mut = edge.edge_mutations.add()
+            mut.position = idx
+            mut.par_nuc = nuc_codes[old_base]
+            mut.mut_nuc.append(nuc_codes[new_base])
+    pbdata.reference_seq = newref
+    pbdata.reference_id = newrefid
+    # load and export modified pbdata to fix internal mutations' parent bases
+    dag = pb_to_dag(pbdata)
+    write_dag(dag, out_dag)
+    
+@cli.command('test')
+def _cli_test():
+    """Run all functions beginning with _test_ in this script
+    (They must take no arguments)"""
+    namespace = globals()
+    print("Running all test functions:")
+    for key, val in namespace.items():
+        if '_test_' in key and key[:6] == '_test_':
+            try:
+                print(key + '\t', end='')
+                val()
+                print("Passed")
+            except:
+                print("FAILED")
+                raise
 
 
 ## TODO this needs to be updated to apply recorded mutations at each node

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -126,10 +126,12 @@ def test_count_topologies():
         print(checkset)
         assert dag.count_topologies() == len(checkset)
 
+
 def test_unlabel():
     for dag in dags:
         udag = dag.unlabel()
         assert dag.count_topologies() == udag.count_trees()
+
 
 def test_parsimony():
     # test parsimony counts without ete
@@ -328,10 +330,10 @@ def test_indexing_comprehensive():
         assert all_dags_true == all_dags_indexed
 
         # verify the lengths match
-        assert (
-            len(history_dag) == len(all_dags_indexed)
-        )
+        assert len(history_dag) == len(all_dags_indexed)
         assert len(all_dags_indexed) == len(all_dags_true)
 
         # test the for each loop
-        assert set(history_dag.to_newicks()) == set({tree.to_newick() for tree in history_dag})
+        assert set(history_dag.to_newicks()) == set(
+            {tree.to_newick() for tree in history_dag}
+        )

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -127,10 +127,9 @@ def test_count_topologies():
         assert dag.count_topologies() == len(checkset)
 
 
-def test_unlabel():
+def test_count_topologies_equals_newicks():
     for dag in dags:
-        udag = dag.unlabel()
-        assert dag.count_topologies() == udag.count_trees()
+        assert dag.count_topologies() == dag.count_topologies_with_newicks()
 
 
 def test_parsimony():
@@ -294,7 +293,7 @@ def test_topology_count_collapse():
             )
         )
     )
-    assert dag.count_topologies(collapse_leaves=True) == 2
+    assert dag.count_topologies_with_newicks(collapse_leaves=True) == 2
 
 
 # this tests is each of the trees indexed are valid subtrees

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -126,6 +126,10 @@ def test_count_topologies():
         print(checkset)
         assert dag.count_topologies() == len(checkset)
 
+def test_unlabel():
+    for dag in dags:
+        udag = dag.unlabel()
+        assert dag.count_topologies() == udag.count_trees()
 
 def test_parsimony():
     # test parsimony counts without ete


### PR DESCRIPTION
* Adds a faster way of counting topologies in the DAG, by setting all internal labels to be the same, and combining nodes according to their child clade sets
* Provides new methods to compute path DAGs (in label space) for a given leaf node label like the one attached (although maybe without the self loops)
[outdag.pdf](https://github.com/matsengrp/historydag/files/8929850/outdag.pdf)

Tests related to topology counting and newick string generation are modified to remain meaningful.