### PR TITLE
Wd-determinism

### DIFF
--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -68,13 +68,19 @@ class HistoryDagNode:
 
     def __le__(self, other: object) -> bool:
         if isinstance(other, HistoryDagNode):
-            return (self.label, self.sorted_partitions()) <= (other.label, other.sorted_partitions())
+            return (self.label, self.sorted_partitions()) <= (
+                other.label,
+                other.sorted_partitions(),
+            )
         else:
             raise NotImplementedError
 
     def __lt__(self, other: object) -> bool:
         if isinstance(other, HistoryDagNode):
-            return (self.label, self.sorted_partitions()) < (other.label, other.sorted_partitions())
+            return (self.label, self.sorted_partitions()) < (
+                other.label,
+                other.sorted_partitions(),
+            )
         else:
             raise NotImplementedError
 
@@ -113,12 +119,9 @@ class HistoryDagNode:
         return frozenset(self.clades.keys())
 
     def sorted_partitions(self) -> tuple:
-        """Returns the node's child clades as a sorted tuple containing
-        leaf labels in sorted tuples."""
-        return tuple(sorted([
-            tuple(sorted(clade))
-            for clade in self.clades.keys()
-        ]))
+        """Returns the node's child clades as a sorted tuple containing leaf
+        labels in sorted tuples."""
+        return tuple(sorted([tuple(sorted(clade)) for clade in self.clades.keys()]))
 
     def children(
         self, clade: Set[Label] = None

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -350,7 +350,7 @@ class HistoryDag:
         node_list: List[Tuple] = []
         edge_list: List[Tuple] = []
         label_indices: Dict[Label, int] = {}
-        node_indices = {id(node): idx for idx, node in enumerate(self.postorder())}
+        node_indices = {node: idx for idx, node in enumerate(self.postorder())}
 
         def cladesets(node):
             clades = {
@@ -374,7 +374,7 @@ class HistoryDag:
                     edge_list.append(
                         (
                             node_idx,
-                            node_indices[id(target)],
+                            node_indices[target],
                             eset.weights[idx],
                             eset.probs[idx],
                         )

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1048,7 +1048,7 @@ class HistoryDag:
         newicks = self.weight_count(**utils.make_newickcountfuncs(**kwargs)).elements()
         return [newick[1:-1] + ";" for newick in newicks]
 
-    def count_topologies_with_newicks(self, collapse_leaves: bool = False) -> int:
+    def count_topologies(self, collapse_leaves: bool = False) -> int:
         """Counts the number of unique topologies in the history DAG. This is
         achieved by counting the number of unique newick strings with only
         leaves labeled.
@@ -1073,7 +1073,7 @@ class HistoryDag:
         )
         return len(self.weight_count(**kwargs))
 
-    def count_topologies(self) -> int:
+    def count_topologies_fast(self) -> int:
         """Counts the number of unique topologies in the history DAG.
 
         This is achieved by creating a new history DAG in which all

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1075,6 +1075,9 @@ class HistoryDag:
 
         This is achieved by creating a new history DAG in which all
         internal nodes have matching labels.
+
+        This is only guaranteed to match the output of ``count_topologies_with_newicks``
+        if the DAG has all allowed edges added.
         """
         return self.unlabel().count_trees()
 

--- a/scripts/find_trees.sh
+++ b/scripts/find_trees.sh
@@ -14,19 +14,19 @@ print_help()
 {
     echo "DESCRIPTION:"
     echo "This script takes a fasta file as input (or a vcf file, and a file \
-    containing the reference sequence), and uses Usher and matOptimize to \
-    search for maximally parsimonious trees on those sequences. The output is \
-    a directory containing many MAT protobufs, each a tree on the same set of \
-    sequences. The first line of the fasta is expected to contain the name of \
-    the sequence that will be used as a reference (the sequence of the root \
-    node of the trees output). \
+containing the reference sequence), and uses Usher and matOptimize to \
+search for maximally parsimonious trees on those sequences. The output is \
+a directory containing many MAT protobufs, each a tree on the same set of \
+sequences. The first line of the fasta is expected to contain the name of \
+the sequence that will be used as a reference (the sequence of the root \
+node of the trees output). \
 \
 The total number of trees found will be, at maximum, the value passed to '-M' times the value passed to '-D' \
 times the value passed to -n."
     echo
     echo "Script requires Usher, matOptimize, and faToVcf."
     echo
-    echo "SYNTAX:    find_trees.sh -f INPUT_FASTA [-h|o|M|d]"
+    echo "SYNTAX:    find_trees.sh -f INPUT_FASTA [-h|o|M|d|D|v|r]"
     echo
     echo "OPTIONS:"
     echo "-f    Provide an input fasta file (-f or -v REQUIRED)"
@@ -76,7 +76,7 @@ mkdir $OUTDIR
 TMPDIR=$OUTDIR/tmp
 mkdir $TMPDIR
 
-if [-n "${FASTA}"]
+if [ -n "${FASTA}" ]
 then
     # Sequences are provided in a fasta file:
     REFID=$(head -1 $FASTA)
@@ -92,17 +92,17 @@ fi
 
 
 echo "($REFID)1;" > $TMPDIR/starttree.nh
+echo $REFID > $OUTDIR/refid.txt
 for ((run=1;run<=NRUNS;run++)); do
-    echo optimize $run
+    echo Building alternative initial trees: iteration $run / $NRUNS ...
     # place samples in the tree in up to MAX_ALTERNATE_PLACEMENTS different
     # ways
-    usher -t $TMPDIR/starttree.nh -v $VCF -o $TMPDIR/mat.pb -d $TMPDIR/ushertree/ -M $MAX_ALTERNATE_PLACEMENTS
+    echo "\tOptimizing each resulting tree $DRIFTING_MOVES times ..."
+    usher -t $TMPDIR/starttree.nh -v $VCF -o $TMPDIR/mat.pb -d $TMPDIR/ushertree/ -M $MAX_ALTERNATE_PLACEMENTS >& $TMPDIR/usher.log
     for intree in $TMPDIR/ushertree/*.nh; do
-        # Optimize each resulting tree DRIFTING_MOVES times
-        usher -t $intree -v $VCF -o $TMPDIR/mat.pb
+        usher -t $intree -v $VCF -o $TMPDIR/mat.pb >> $TMPDIR/usher-optimize.log 2>&1
         for ((optrun=1;optrun<=DRIFTING_TIMES;optrun++)); do
-            echo optimize $run
-            matOptimize -i $TMPDIR/mat.pb -o $TMPDIR/opt_mat.pb -d $DRIFTING_MOVES
+            matOptimize -i $TMPDIR/mat.pb -o $TMPDIR/opt_mat.pb -d $DRIFTING_MOVES >> $TMPDIR/matoptimize.log 2>&1
             mv $TMPDIR/opt_mat.pb $TMPDIR/mat.pb
             cp $TMPDIR/mat.pb $OUTDIR/${run}$(basename $intree)${optrun}.pb
         done

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -165,12 +165,6 @@ def test_copy():
         lambda tree: tree.to_newick(),
     )
 
-def test_deterministic_order():
-    with open('refdag.p', 'wb') as fh:
-        fh.write(pickle.dumps(dags[-1]))
-    with open('refdag.p', 'rb') as fh:
-        refdag = pickle.load(fh)
-    assert tuple(refdag.preorder()) == tuple(dags[-1].preorder())
 
 def test_newicks():
     # See that the to_newicks method agrees with to_newick applied to all trees in DAG.

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -124,12 +124,12 @@ def test_count_topologies():
             for tree in dag.get_trees()
         }
         print(checkset)
-        assert dag.count_topologies() == len(checkset)
+        assert dag.count_topologies_fast() == len(checkset)
 
 
 def test_count_topologies_equals_newicks():
     for dag in dags:
-        assert dag.count_topologies() == dag.count_topologies_with_newicks()
+        assert dag.count_topologies_fast() == dag.count_topologies()
 
 
 def test_parsimony():
@@ -293,7 +293,7 @@ def test_topology_count_collapse():
             )
         )
     )
-    assert dag.count_topologies_with_newicks(collapse_leaves=True) == 2
+    assert dag.count_topologies(collapse_leaves=True) == 2
 
 
 # this tests is each of the trees indexed are valid subtrees

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -165,6 +165,12 @@ def test_copy():
         lambda tree: tree.to_newick(),
     )
 
+def test_deterministic_order():
+    with open('refdag.p', 'wb') as fh:
+        fh.write(pickle.dumps(dags[-1]))
+    with open('refdag.p', 'rb') as fh:
+        refdag = pickle.load(fh)
+    assert tuple(refdag.preorder()) == tuple(dags[-1].preorder())
 
 def test_newicks():
     # See that the to_newicks method agrees with to_newick applied to all trees in DAG.


### PR DESCRIPTION
This PR fixes an issue where during pickling (and therefore also during copying), a node's child clades were stored in an unordered container, resulting in unpredictable and nondeterministic scrambling of node children. This issue was captured in the new tests contained in `test_determinism`.