### PR TITLE
21 Fix Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ with open('sample_data/toy_trees.p', 'rb') as fh:
 	ete_trees = pickle.load(fh)
 
 dag = hdag.history_dag_from_etes(ete_trees, ['sequence'])
-dag.count_trees()  # 1041
+dag.count_histories()  # 1041
 
 dag.add_all_allowed_edges()
-dag.count_trees()  # 3431531
+dag.count_histories()  # 3431531
 
 dag.hamming_parsimony_count()  # Shows counts of trees of different parsimony scores
 dag.trim_optimal_weight()
@@ -59,7 +59,7 @@ trees = [tree for tree in dag]
 
 # Another method for fetching all trees in the dag is provided, but the order
 # will not match index order:
-scrambled_trees = list(dag.get_trees())
+scrambled_trees = list(dag.get_histories())
 
 
 # Union is implemented as dag merging, including with sequences of dags
@@ -74,7 +74,7 @@ newdag = dag[0] | (dag[i] for i in range(3,5))
     * `history_dag_from_newicks`
     * `history_dag_from_etes`
 * Trees can be extracted from the history DAG with methods like
-    * `HistoryDag.get_trees`
+    * `HistoryDag.get_histories`
     * `HistoryDag.sample`
     * `HistoryDag.to_ete`
     * `HistoryDag.to_newick` and `HistoryDag.to_newicks`

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ with open('sample_data/toy_trees.p', 'rb') as fh:
 dag = hdag.history_dag_from_etes(ete_trees, ['sequence'])
 dag.count_histories()  # 1041
 
-dag.add_all_allowed_edges()
+dag.make_complete()
 dag.count_histories()  # 3431531
 
 dag.hamming_parsimony_count()  # Shows counts of trees of different parsimony scores

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -133,7 +133,7 @@ of ``explode_nodes``).
 We can find even more new trees by adding all edges which connect
 nodes whose child clades are compatible:
 
->>> dag.add_all_allowed_edges()
+>>> dag.make_complete()
 1048
 >>> dag.count_histories()
 3431531

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -11,11 +11,12 @@ A history DAG is a way to represent a collection of trees whose nodes
 sequence.
 
 In its simplest form, a history DAG may represent a single tree. To construct
-such a history DAG from a tree, we annotate each node in the tree with its child clades.
-The **clade** beneath a tree node is the set of leaf node labels
+such a history DAG from a tree, we annotate each node in the tree with its
+child clades.  The **clade** beneath a tree node is the set of leaf node labels
 reachable from that node, or the set containing the node's own label if it is
-itself a leaf. The **child clades** of a node are the set of clades
-beneath that node's children.
+itself a leaf. We also refer to this set as a node's **clade union**, since it
+is the union of the node's child clades. The **child clades** of a node are the
+set of clades beneath that node's children.
 
 After annotating each node with its child clades, a **UA (universal ancestor)
 node** is added as a parent of the original tree's root node. The resulting

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -19,7 +19,7 @@ beneath that node's children.
 
 After annotating each node with its child clades, a **UA (universal ancestor)
 node** is added as a parent of the original tree's root node. The resulting
-structure is an example of a history DAG which we call a **clade tree**:
+structure is an example of a history DAG which we call a **history**:
 
 |pic1| -> |pic2|
 
@@ -35,13 +35,13 @@ parent node associated to an edge, must be the same as the clade below the
 child node that the edge targets.
 
 After converting multiple trees with the same set of leaf labels to clade
-trees, those clade trees can be unioned to create a history DAG that represents
+trees, those histories can be unioned to create a history DAG that represents
 at least those trees used to create it. Any structure in the resulting history
 DAG which contains the UA node and all leaves, and has exactly one edge for
-each node-child clade pair, is a clade tree. Clade trees represent labeled
+each node-child clade pair, is a history. Histories represent labeled
 trees by the inverse of the correspondence introduced above:
 
-For example, the clade tree highlighted in red in this image:
+For example, the history highlighted in red in this image:
 
 .. image:: figures/history_dag_example.svg
    :width: 100%
@@ -105,7 +105,7 @@ Now, we will create a history DAG using the ``sequence`` attribute as the data
 for node labels:
 
 >>> dag = hdag.history_dag_from_etes(ete_trees, ['sequence'])
->>> dag.count_trees()
+>>> dag.count_histories()
 1041
 >>> dag.count_topologies()
 389
@@ -134,7 +134,7 @@ nodes whose child clades are compatible:
 
 >>> dag.add_all_allowed_edges()
 1048
->>> dag.count_trees()
+>>> dag.count_histories()
 3431531
 
 After such edge additions, all the trees in the DAG are no longer guaranteed to
@@ -191,7 +191,7 @@ Now we can trim to only the trees with 48 unique node labels:
 
 >>> dag.trim_optimal_weight(** node_count_funcs, optimal_func=min)
 
-Finally, we can sample a single clade tree from the history DAG, and make it an
+Finally, we can sample a single history from the history DAG, and make it an
 ete tree for further rendering/processing:
 
 >>> t = dag.sample().to_ete()
@@ -208,7 +208,7 @@ index-order:
 Another method for fetching all trees in the dag is provided, but the order
 will not match index order:
 
->>> scrambled_trees = list(dag.get_trees())
+>>> scrambled_trees = list(dag.get_histories())
 
 
 History DAGs can be merged using the :meth:`historydag.HistoryDag.merge`

--- a/historydag/__init__.py
+++ b/historydag/__init__.py
@@ -6,7 +6,7 @@ from .dag import (  # noqa
     from_newick,
     history_dag_from_newicks,
     history_dag_from_etes,
-    history_dag_from_clade_trees,
+    history_dag_from_histories,
 )
 
 from . import _version

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -72,7 +72,10 @@ class HistoryDagNode:
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, HistoryDagNode):
-            return (self.label, self.child_clades()) == (other.label, other.child_clades())
+            return (self.label, self.child_clades()) == (
+                other.label,
+                other.child_clades(),
+            )
         else:
             raise NotImplementedError
 
@@ -101,16 +104,15 @@ class HistoryDagNode:
         return not self.__lt__(other)
 
     def empty_copy(self) -> "HistoryDagNode":
-        """Returns a HistoryDagNode object with the same clades, label, and attr dictionary, but
-        no descendant edges."""
+        """Returns a HistoryDagNode object with the same clades, label, and
+        attr dictionary, but no descendant edges."""
         return HistoryDagNode(
             self.label, {clade: EdgeSet() for clade in self.clades}, deepcopy(self.attr)
         )
 
-    # def node_self(self) -> "HistoryDagNode":
-    #     """Deprecated name for :meth:`empty_copy`"""
-    #     return self.empty_copy()
-    # [Walrus]
+    def node_self(self) -> "HistoryDagNode":
+        """Deprecated name for :meth:`empty_copy`"""
+        return self.empty_copy()
 
     def clade_union(self) -> FrozenSet[Label]:
         r"""Returns the union of this node's child clades
@@ -120,43 +122,40 @@ class HistoryDagNode:
         else:
             return frozenset().union(*self.clades.keys())
 
-    # def under_clade(self) -> FrozenSet[Label]:
-    #     """Deprecated name for :meth:`clade_union`"""
-    #     return self.clade_union()
-    # [Walrus]
+    def under_clade(self) -> FrozenSet[Label]:
+        """Deprecated name for :meth:`clade_union`"""
+        return self.clade_union()
 
     def is_leaf(self) -> bool:
         """Returns whether this is a leaf node."""
         return not bool(self.clades)
 
     def is_ua_node(self) -> bool:
-        """Returns whether this is the source node in the DAG, from which all others are reachable."""
+        """Returns whether this is the source node in the DAG, from which all
+        others are reachable."""
         return False
 
-    # def is_root(self) -> bool:
-    #     """Deprecated name for :meth:`is_ua_node`"""
-    #     return self.is_ua_node()
-    # [Walrus]
+    def is_root(self) -> bool:
+        """Deprecated name for :meth:`is_ua_node`"""
+        return self.is_ua_node()
 
     def child_clades(self) -> frozenset:
         """Returns the node's child clades, or a frozenset containing a
         frozenset if this node is a UANode."""
         return frozenset(self.clades.keys())
 
-    # def partitions(self) -> frozenset:
-    #     """Deprecated name for :meth:`child_clades`"""
-    #     return self.child_clades()
-    # # [Walrus]
+    def partitions(self) -> frozenset:
+        """Deprecated name for :meth:`child_clades`"""
+        return self.child_clades()
 
     def sorted_child_clades(self) -> tuple:
         """Returns the node's child clades as a sorted tuple containing leaf
         labels in sorted tuples."""
         return tuple(sorted([tuple(sorted(clade)) for clade in self.clades.keys()]))
 
-    # def sorted_partitions(self) -> frozenset:
-    #     """Deprecated name for :meth:`sorted_child_clades`"""
-    #     return self.sorted_child_clades()
-    # # [Walrus]
+    def sorted_partitions(self) -> tuple:
+        """Deprecated name for :meth:`sorted_child_clades`"""
+        return self.sorted_child_clades()
 
     def children(
         self, clade: Set[Label] = None
@@ -348,7 +347,8 @@ class UANode(HistoryDagNode):
         return newnode
 
     def is_ua_node(self) -> bool:
-        """Returns whether this is the source node in the DAG, from which all others are reachable."""
+        """Returns whether this is the source node in the DAG, from which all
+        others are reachable."""
         return True
 
 
@@ -547,7 +547,8 @@ class HistoryDag:
         return pickle.dumps(self.__getstate__())
 
     def get_histories(self) -> Generator["HistoryDag", None, None]:
-        """Return a generator containing all internally labeled trees in the history DAG.
+        """Return a generator containing all internally labeled trees in the
+        history DAG.
 
         Note that each history is a history DAG, containing a UA node.
 
@@ -559,10 +560,9 @@ class HistoryDag:
         for history in self.dagroot._get_subhistories():
             yield HistoryDag(history)
 
-    # def get_trees(self) -> frozenset:
-    #     """Deprecated name for :meth:`get_histories`"""
-    #     return self.get_histories()
-    # # [Walrus]
+    def get_trees(self) -> Generator["HistoryDag", None, None]:
+        """Deprecated name for :meth:`get_histories`"""
+        return self.get_histories()
 
     def get_leaves(self) -> Generator["HistoryDag", None, None]:
         """Return a generator containing all leaf nodes in the history DAG."""
@@ -754,10 +754,9 @@ class HistoryDag:
                     return False
         return True
 
-    # def is_clade_tree(self) -> bool:
-    #     """Deprecated name for :meth:`is_history`"""
-    #     return self.is_history()
-    # # [Walrus]
+    def is_clade_tree(self) -> bool:
+        """Deprecated name for :meth:`is_history`"""
+        return self.is_history()
 
     def copy(self) -> "HistoryDag":
         """Uses bytestring serialization, and is guaranteed to copy:
@@ -1349,10 +1348,9 @@ class HistoryDag:
                 )
         return self.dagroot._dp_data
 
-    # def postorder_cladetree_accum(*args, **kwargs) -> Weight:
-    #     """Deprecated name for :meth:`postorder_history_accum`"""
-    #     return self.postorder_history_accum(*args, **kwargs)
-    # # [Walrus]
+    def postorder_cladetree_accum(self, *args, **kwargs) -> Weight:
+        """Deprecated name for :meth:`postorder_history_accum`"""
+        return self.postorder_history_accum(*args, **kwargs)
 
     def optimal_weight_annotate(
         self,
@@ -1469,10 +1467,9 @@ class HistoryDag:
         """
         return self.unlabel().count_histories()
 
-    # def count_trees(self):
-    #     """Deprecated name for :meth:`count_histories`"""
-    #     return self.count_histories()
-    # # [Walrus]
+    def count_trees(self):
+        """Deprecated name for :meth:`count_histories`"""
+        return self.count_histories()
 
     def count_histories(
         self,
@@ -1634,7 +1631,6 @@ class HistoryDag:
         )
 
         return self.dagroot._dp_data
-
 
     def count_paths_to_leaf(
         self,
@@ -2304,10 +2300,9 @@ def history_dag_from_histories(treelist: Sequence[HistoryDag]) -> HistoryDag:
     dag.merge(treelist)
     return dag
 
-# def history_dag_from_clade_trees(*args, **kwargs) -> HistoryDag:
-#     """Deprecated name for :meth:`history_dag_from_histories`"""
-#     return history_dag_from_histories(*args, **kwargs)
-# # [Walrus]
+def history_dag_from_clade_trees(*args, **kwargs) -> HistoryDag:
+    """Deprecated name for :meth:`history_dag_from_histories`"""
+    return history_dag_from_histories(*args, **kwargs)
 
 
 def history_dag_from_nodes(nodes: Sequence[HistoryDagNode]) -> HistoryDag:

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -62,7 +62,7 @@ def access_nodefield_default(fieldname: str, default: Any) -> Any:
         default: A value that should be returned if one of the arguments is the DAG UA node.
 
     For example, instead of
-    `lambda n1, n2: default if n1.is_root() or n2.is_root() else func(n1.label.fieldname, n2.label.fieldname)`,
+    `lambda n1, n2: default if n1.is_ua_node() or n2.is_ua_node() else func(n1.label.fieldname, n2.label.fieldname)`,
     this wrapper allows one to write `access_nodefield_default(fieldname, default)(func)`.
     """
 
@@ -111,7 +111,7 @@ def ignore_uanode(default: Any) -> Callable[[F], F]:
         @wraps(func)
         def wrapper(*args: "HistoryDagNode", **kwargs: Any):
             for node in args:
-                if node.is_root():
+                if node.is_ua_node():
                     return default
             else:
                 return func(*args, **kwargs)
@@ -473,15 +473,15 @@ def make_newickcountfuncs(
     )
 
 
-def _cladetree_method(method):
+def _history_method(method):
     """HistoryDagNode method decorator to ensure that the method is only run on
-    history DAGs which are clade trees."""
+    history DAGs which are histories."""
 
     @wraps(method)
     def wrapper(self, *args, **kwargs):
-        if not self.is_clade_tree():
+        if not self.is_history():
             raise ValueError(
-                "to_newick requires the history DAG to be a clade tree. "
+                "to_newick requires the history DAG to be a history. "
                 "To extract newicks from a general DAG, see to_newicks"
             )
         else:

--- a/scripts/agg_mut.py
+++ b/scripts/agg_mut.py
@@ -419,7 +419,7 @@ def summarize(dagpath, treedir, outfile, csv_data, print_header):
     """output summary information about the provided input file(s)"""
     dag = load_dag(dagpath)
     data = []
-    data.append(("before_collapse_n_trees", dag.count_trees()))
+    data.append(("before_collapse_n_trees", dag.count_histories()))
     data.append(("before_collapse_n_nodes", len(list(dag.preorder()))))
     wc = dag.weight_count(edge_weight_func=dist)
     data.append(("before_collapse_max_pars", max(wc.keys())))
@@ -427,7 +427,7 @@ def summarize(dagpath, treedir, outfile, csv_data, print_header):
     dag.add_all_allowed_edges()
     dag.trim_optimal_weight(edge_weight_func=dist)
     dag.convert_to_collapsed()
-    data.append(("n_trees", dag.count_trees()))
+    data.append(("n_trees", dag.count_histories()))
     wc = dag.weight_count(edge_weight_func=dist)
     data.append(("parsimony_score", min(wc.keys())))
     data.append(("avg_node_parents", dag.internal_avg_parents()))
@@ -989,7 +989,7 @@ def make_testcase(pickled_forest, outdir, num_trees, random_seed):
     for tree in trees[1:]:
         newdag.merge(tree)
     write_dag(newdag, outdir / "full_dag.pb", from_mutseqs=False)
-    print(f"Test case dag contains {newdag.count_trees()} trees")
+    print(f"Test case dag contains {newdag.count_histories()} trees")
 
 @cli.command("change-ref")
 @click.argument("in_pb")

--- a/scripts/parsimony.py
+++ b/scripts/parsimony.py
@@ -538,7 +538,7 @@ def _cli_parsimony_score_from_files(
 def summarize_dag(dag):
     """print summary information about the provided history DAG."""
     print("DAG contains")
-    print("trees: ", dag.count_trees())
+    print("trees: ", dag.count_histories())
     print("nodes: ", len(list(dag.preorder())))
     print("edges: ", sum(len(list(node.children())) for node in dag.preorder()))
     print("parsimony scores: ", dag.weight_count())

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -56,9 +56,9 @@ def test_fulltree():
     dag = hdag.history_dag_from_etes([etetree], ["sequence"])
     dag.convert_to_collapsed()
     dag._check_valid()
-    assert set(deterministic_newick(tree.to_ete()) for tree in dag.get_histories()) == set(
-        {deterministic_newick(etetree2)}
-    )
+    assert set(
+        deterministic_newick(tree.to_ete()) for tree in dag.get_histories()
+    ) == set({deterministic_newick(etetree2)})
 
 
 def test_twotrees():
@@ -89,7 +89,7 @@ def test_collapse():
 def test_add_allowed_edges():
     # See that adding only edges that preserve parent labels preserves parsimony
     dag = hdag.history_dag_from_etes(trees, ["sequence"])
-    dag.add_all_allowed_edges(preserve_parent_labels=True)
+    dag.make_complete(preserve_parent_labels=True)
     dag._check_valid()
     c = dag.weight_count()
     assert min(c) == max(c)
@@ -100,7 +100,7 @@ def test_add_allowed_edges():
     collapsed_dag._check_valid()
     collapsed_dag.convert_to_collapsed()
     collapsed_dag._check_valid()
-    collapsed_dag.add_all_allowed_edges(adjacent_labels=False)
+    collapsed_dag.make_complete(adjacent_labels=False)
     collapsed_dag._check_valid()
     assert all(
         parent.label != target.label

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -33,7 +33,7 @@ def collapse_adjacent_sequences(tree: ete3.TreeNode) -> ete3.TreeNode:
 etetree = list(
     hdag.history_dag_from_etes(
         [ete3.TreeNode(newick=newickstring3, format=1)], ["sequence"]
-    ).get_trees()
+    ).get_histories()
 )[0].to_ete(features=["sequence"])
 etetree2 = utils.collapse_adjacent_sequences(etetree.copy())
 
@@ -56,7 +56,7 @@ def test_fulltree():
     dag = hdag.history_dag_from_etes([etetree], ["sequence"])
     dag.convert_to_collapsed()
     dag._check_valid()
-    assert set(deterministic_newick(tree.to_ete()) for tree in dag.get_trees()) == set(
+    assert set(deterministic_newick(tree.to_ete()) for tree in dag.get_histories()) == set(
         {deterministic_newick(etetree2)}
     )
 
@@ -65,8 +65,8 @@ def test_twotrees():
     dag = hdag.history_dag_from_etes([etetree, etetree2], ["sequence"])
     dag.convert_to_collapsed()
     dag._check_valid()
-    assert dag.count_trees() == 1
-    assert {deterministic_newick(tree.to_ete()) for tree in dag.get_trees()} == {
+    assert dag.count_histories() == 1
+    assert {deterministic_newick(tree.to_ete()) for tree in dag.get_histories()} == {
         deterministic_newick(etetree2)
     }
 
@@ -78,12 +78,12 @@ def test_collapse():
     allcollapsedtrees = [utils.collapse_adjacent_sequences(tree) for tree in trees]
     collapsed_dag = hdag.history_dag_from_etes(allcollapsedtrees, ["sequence"])
     collapsed_dag._check_valid()
-    maybecollapsedtrees = [tree.to_ete() for tree in uncollapsed_dag.get_trees()]
+    maybecollapsedtrees = [tree.to_ete() for tree in uncollapsed_dag.get_histories()]
     assert all(utils.is_collapsed(tree) for tree in maybecollapsedtrees)
-    n_before = uncollapsed_dag.count_trees()
+    n_before = uncollapsed_dag.count_histories()
     uncollapsed_dag.merge(collapsed_dag)
     uncollapsed_dag._check_valid()
-    assert n_before == uncollapsed_dag.count_trees()
+    assert n_before == uncollapsed_dag.count_histories()
 
 
 def test_add_allowed_edges():

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -54,9 +54,9 @@ def compare_dag_and_tree_parsimonies(
         s_weight == s_ete_weight
     ), "Downward sankoff on ete_Tree vs on the dag version of the tree produced different results"
 
-    s_labels = set(n.label.sequence for n in s.postorder() if not n.is_root())
+    s_labels = set(n.label.sequence for n in s.postorder() if not n.is_ua_node())
     s_ete_labels = set(
-        n.label.sequence for n in s_ete_as_dag.postorder() if not n.is_root()
+        n.label.sequence for n in s_ete_as_dag.postorder() if not n.is_ua_node()
     )
     assert (
         len(s_ete_labels - s_labels) < 1
@@ -87,7 +87,7 @@ def check_sankoff_on_dag(
     ), "Downward pass of Sankoff on dag did not yield expected score"
 
     assert (
-        dag.count_trees() == dag.copy().count_trees()
+        dag.count_histories() == dag.copy().count_histories()
     ), "Resulting DAG had invalid internal node assignments"
 
 

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -193,20 +193,20 @@ def test_expand_ambiguities():
 
     for dag in dags:
         cdag = dag.copy()
-        print(cdag.count_trees())
+        print(cdag.count_histories())
         cdag.explode_nodes()
-        print(cdag.count_trees())
+        print(cdag.count_histories())
         cdag.trim_optimal_weight()
         cdag._check_valid()
-        print(cdag.count_trees())
+        print(cdag.count_histories())
         print(cdag.weight_count())
         checkset = {
             hdag.from_tree(tree, ["sequence"]).to_newick()
-            for cladetree in dag.get_trees()
+            for cladetree in dag.get_histories()
             for tree in disambiguate(cladetree.to_ete(features=["sequence"]))
         }
         print(len(checkset))
-        assert checkset == {cladetree.to_newick() for cladetree in cdag.get_trees()}
+        assert checkset == {cladetree.to_newick() for cladetree in cdag.get_histories()}
 
 
 #     newickset = {treeprint(tree) for tree in utils.disambiguate(tree2)}

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -91,12 +91,12 @@ def _testfactory(resultfunc, verify_func, collapse_invariant=False, accum_func=C
     for dag, cdag in zip(dags, cdags):
         # check dags
         result = resultfunc(dag)
-        verify_result = accum_func([verify_func(tree) for tree in dag.get_trees()])
+        verify_result = accum_func([verify_func(tree) for tree in dag.get_histories()])
         assert result == verify_result
 
         # check cdags
         cresult = resultfunc(cdag)
-        cverify_result = accum_func([verify_func(tree) for tree in cdag.get_trees()])
+        cverify_result = accum_func([verify_func(tree) for tree in cdag.get_histories()])
         assert cresult == cverify_result
 
         # check they agree, if collapse_invariant.
@@ -112,7 +112,7 @@ def test_valid_dags():
         for node in dag.postorder():
             for clade in node.clades:
                 for target in node.clades[clade].targets:
-                    assert target.under_clade() == clade or node.is_root()
+                    assert target.clade_union() == clade or node.is_ua_node()
 
         # each clade has a descendant edge:
         for node in dag.postorder():
@@ -133,7 +133,7 @@ def test_count_topologies():
                 features=[],
                 feature_funcs={},
             )
-            for tree in dag.get_trees()
+            for tree in dag.get_histories()
         }
         print(checkset)
         assert dag.count_topologies_fast() == len(checkset)
@@ -173,7 +173,7 @@ def test_copy():
     # Copying the DAG gives the same DAG back, or at least a DAG expressing
     # the same trees
     _testfactory(
-        lambda dag: Counter(tree.to_newick() for tree in dag.copy().get_trees()),
+        lambda dag: Counter(tree.to_newick() for tree in dag.copy().get_histories()),
         lambda tree: tree.to_newick(),
     )
 
@@ -253,17 +253,17 @@ def test_min_weight():
     )
 
 
-def test_count_trees():
-    _testfactory(lambda dag: dag.count_trees(), lambda tree: 1, accum_func=sum)
+def test_count_histories():
+    _testfactory(lambda dag: dag.count_histories(), lambda tree: 1, accum_func=sum)
 
 
-def test_count_trees_expanded():
+def test_count_histories_expanded():
     for dag in dags + cdags:
         ndag = dag.copy()
         ndag.explode_nodes()
         assert (
-            dag.count_trees(expand_func=dagutils.sequence_resolutions)
-            == ndag.count_trees()
+            dag.count_histories(expand_func=dagutils.sequence_resolutions)
+            == ndag.count_histories()
         )
 
 
@@ -315,7 +315,7 @@ def test_valid_subtrees():
         for curr_dag_index in range(0, len(history_dag)):
             next_tree = history_dag[curr_dag_index]
             assert next_tree.to_newick() in history_dag.to_newicks()
-            assert next_tree.is_clade_tree()
+            assert next_tree.is_history()
 
 
 # this should check if the indexing algorithm accurately
@@ -334,7 +334,7 @@ def test_indexing_comprehensive():
         print("number of indexed trees: " + str(len(all_dags_indexed)))
         all_dags_indexed.remove(None)
 
-        # get the set of all actual dags from the get_trees
+        # get the set of all actual dags from the get_histories
         all_dags_true = set(history_dag.to_newicks())
 
         print("actual number of subtrees: " + str(len(all_dags_true)))

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -79,7 +79,7 @@ dags.append(
 
 compdags = [dag.copy() for dag in dags]
 for dag in compdags:
-    dag.add_all_allowed_edges()
+    dag.make_complete()
 dags.extend(compdags)
 
 cdags = [dag.copy() for dag in dags]
@@ -355,7 +355,7 @@ def test_indexing_comprehensive():
 def test_trim():
     for dag in dags + cdags:
         dag = dag.copy()
-        dag.add_all_allowed_edges()
+        dag.make_complete()
         dag._check_valid()
         dag.recompute_parents()
         dag._check_valid()
@@ -368,7 +368,7 @@ def test_trim():
 def test_from_nodes():
     for dag in dags + cdags:
         cdag = dag.copy()
-        cdag.add_all_allowed_edges()
+        cdag.make_complete()
         cdag.trim_optimal_weight()
         cdag._check_valid()
         wc = cdag.weight_count()
@@ -434,10 +434,10 @@ def test_sample_with_edge():
 def test_iter_covering_histories():
     for dag in dags + cdags:
         codag = dag.copy()
-        codag.add_all_allowed_edges()
+        codag.make_complete()
         trees = list(dag.iter_covering_histories())
         tdag = trees[0] | trees
-        tdag.add_all_allowed_edges()
+        tdag.make_complete()
         assert tdag.weight_count() == codag.weight_count()
 
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -96,7 +96,9 @@ def _testfactory(resultfunc, verify_func, collapse_invariant=False, accum_func=C
 
         # check cdags
         cresult = resultfunc(cdag)
-        cverify_result = accum_func([verify_func(tree) for tree in cdag.get_histories()])
+        cverify_result = accum_func(
+            [verify_func(tree) for tree in cdag.get_histories()]
+        )
         assert cresult == cverify_result
 
         # check they agree, if collapse_invariant.

--- a/tests/test_historydag.py
+++ b/tests/test_historydag.py
@@ -123,7 +123,7 @@ def test_preserve_attr():
         attr_func=lambda n: n.name,
     )
     dag._check_valid()
-    assert all(n.attr for n in dag.preorder(skip_root=True))
+    assert all(n.attr for n in dag.preorder(skip_ua_node=True))
 
     @utils.explode_label("sequence")
     def expand_func(seq):
@@ -136,10 +136,10 @@ def test_preserve_attr():
 
     dag.explode_nodes(expand_func=expand_func)
     dag._check_valid()
-    assert all(n.attr for n in dag.preorder(skip_root=True))
+    assert all(n.attr for n in dag.preorder(skip_ua_node=True))
     dag.convert_to_collapsed()
     dag._check_valid()
-    assert all(n.attr for n in dag.preorder(skip_root=True))
+    assert all(n.attr for n in dag.preorder(skip_ua_node=True))
 
 
 def test_ete_newick_agree():

--- a/tests/test_historydag.py
+++ b/tests/test_historydag.py
@@ -95,12 +95,12 @@ def test_from_tree():
     return G
 
 
-def test_is_clade_tree():
+def test_is_history():
     tree = ete3.Tree(newickstring2, format=1)
     print(tree.sequence)
     dag = from_tree(tree, ["sequence"])
     dag._check_valid()
-    assert dag.is_clade_tree()
+    assert dag.is_history()
 
 
 def test_from_tree_label():
@@ -161,9 +161,9 @@ def test_ete_newick_agree():
     }
     viaetes = {
         from_tree(tree.to_ete(**outkwargs), **inkwargs).to_newick(**outkwargs)
-        for tree in dag.get_trees()
+        for tree in dag.get_histories()
     }
-    vianewicks = {tree.to_newick(**outkwargs) for tree in dag.get_trees()}
+    vianewicks = {tree.to_newick(**outkwargs) for tree in dag.get_histories()}
     assert viaetes == vianewicks
 
 
@@ -236,7 +236,7 @@ def test_sample():
     namedict = {(str(x),): x for x in range(5)}
     dag = history_dag_from_newicks(newicks, ["name"])
     for i in range(10):
-        assert dag.sample().is_clade_tree()
+        assert dag.sample().is_history()
     sample = dag.sample()
     sample._check_valid()
     return sample.to_graphviz(namedict=namedict)

--- a/tests/test_support.py
+++ b/tests/test_support.py
@@ -72,7 +72,7 @@ def test_node_counts():
         node2count = dag.count_nodes()
         for node in node2count.keys():
             ground_truth = sum(
-                [node in set(tree.postorder()) for tree in dag.get_trees()]
+                [node in set(tree.postorder()) for tree in dag.get_histories()]
             )
             # print(
             #     f"\t node2count[node] = {node2count[node]} \t ground_truth = {ground_truth}"
@@ -90,8 +90,8 @@ def test_collapsed_node_counts():
         for node in node2count.keys():
             ground_truth = sum(
                 [
-                    node in set([n.under_clade() for n in tree.postorder()])
-                    for tree in dag.get_trees()
+                    node in set([n.clade_union() for n in tree.postorder()])
+                    for tree in dag.get_histories()
                 ]
             )
             print(
@@ -109,7 +109,7 @@ def test_edge_counts():
 
         for parent, node in edge2count.keys():
             ground_truth = 0
-            for tree in dag.get_trees():
+            for tree in dag.get_histories():
                 for curr_parent in tree.postorder():
                     if curr_parent != parent:
                         continue


### PR DESCRIPTION
This PR applies the name changes proposed in #21.

All previous method names remain, but all internal references to those names are removed.
Some attempt has been made to rename variables which make reference to these old names, but some may remain.

All tests pass, both with and without the deprecated method/function versions in the code.