### PR TITLE
Consistent Clade Ordering

### DIFF
--- a/scripts/agg_mut.py
+++ b/scripts/agg_mut.py
@@ -406,12 +406,14 @@ def summarize(dagpath, treedir, csv_data, print_header):
     node_counts = dag.weight_count(edge_weight_func=lambda n1, n2: 1)
     data.append(("tree_min_n_nodes", min(node_counts.keys())))
     data.append(("tree_max_n_nodes", max(node_counts.keys())))
+    data.append(("n_nodes_unlabeled", len(list(dag.unlabel().preorder()))))
     data.append(("n_tree_roots", len(list(dag.dagroot.children()))))
     if treedir:
         treepath = Path(treedir)
         treefiles = list(treepath.glob('*.pb'))
         wc = count_parsimony(treefiles)
         data.append(("n_input_trees", len(treefiles)))
+        data.append(("n_unique_inputs", count_unique(treefiles)))
         data.append(("input_min_pars", min(wc.keys())))
         data.append(("input_max_pars", max(wc.keys())))
     if csv_data:
@@ -555,12 +557,16 @@ class TreeComparer:
     def __hash__(self):
         return hash(self.tree)
 
-@cli.command('count-unique')
-@click.argument('trees', nargs=-1, type=click.Path(exists=True))
 def count_unique(trees):
     """Count the number of unique trees represented by MAT protobufs passed to this function"""
     ushertrees = {TreeComparer(process_from_mat(str(file), 'node_1')) for file in trees}
-    print(len(ushertrees))
+    return len(ushertrees)
+
+@cli.command('count-unique')
+@click.argument('trees', nargs=-1, type=click.Path(exists=True))
+def cli_count_unique(trees):
+    """Count the number of unique trees represented by MAT protobufs passed to this function"""
+    print(count_unique(trees))
 
 @cli.command('find-duplicates')
 @click.option('-t', '--tree', help='tree in which to search for duplicate samples')

--- a/scripts/agg_mut.py
+++ b/scripts/agg_mut.py
@@ -239,6 +239,10 @@ def dag_to_mad_pb(dag, leaf_data_func=None, from_mutseqs=True):
             else:
                 parent_seq = pnode.label.mutseq
             return cg_diff(parent_seq, child.label.mutseq)
+
+        def key_func(cladeitem):
+            clade, _ = cladeitem
+            return sorted(sorted(idx for idx in label.mutseq) for label in clade)
     else:
         refseq = next(dag.preorder(skip_root=True)).label.sequence
         refseqid = 'unknown_seq_id'
@@ -248,6 +252,10 @@ def dag_to_mad_pb(dag, leaf_data_func=None, from_mutseqs=True):
             else:
                 parent_seq = pnode.label.sequence
             return string_seq_diff(parent_seq, cnode.label.sequence)
+
+        def key_func(cladeitem):
+            clade, _ = cladeitem
+            return sorted(sorted(idx for idx in sequence_to_cg(label.sequence, refseq)) for label in clade)
 
     node_dict = {}
     data = dpb.data()
@@ -260,7 +268,7 @@ def dag_to_mad_pb(dag, leaf_data_func=None, from_mutseqs=True):
                 node_name.condensed_leaves.append(leaf_data_func(node))
 
     for node in dag.postorder():
-        for cladeidx, (clade, edgeset) in enumerate(node.clades.items()):
+        for cladeidx, (clade, edgeset) in enumerate(sorted(node.clades.items(), key=key_func)):
             for child in edgeset.targets:
                 edge = data.edges.add()
                 edge.parent_node = node_dict[node]


### PR DESCRIPTION
Implements clade ordering in the `agg_mut.py` script, which exports history DAGs to MAD protobufs

https://github.com/matsengrp/larch/issues/9