### PR TITLE
Node utils

### DIFF
--- a/historydag/__init__.py
+++ b/historydag/__init__.py
@@ -9,6 +9,8 @@ from .dag import (  # noqa
     history_dag_from_clade_trees,
 )
 
+from .parsimony import disambiguate_history, treewise_sankoff_in_dag
+
 from . import _version
 
 __version__ = _version.get_versions()["version"]

--- a/historydag/__init__.py
+++ b/historydag/__init__.py
@@ -11,4 +11,6 @@ from .dag import (  # noqa
 
 from . import _version
 
+from . import parsimony # noqa
+
 __version__ = _version.get_versions()["version"]

--- a/historydag/__init__.py
+++ b/historydag/__init__.py
@@ -9,8 +9,6 @@ from .dag import (  # noqa
     history_dag_from_clade_trees,
 )
 
-from .parsimony import disambiguate_history, treewise_sankoff_in_dag
-
 from . import _version
 
 __version__ = _version.get_versions()["version"]

--- a/historydag/__init__.py
+++ b/historydag/__init__.py
@@ -11,6 +11,6 @@ from .dag import (  # noqa
 
 from . import _version
 
-from . import parsimony # noqa
+from . import parsimony  # noqa
 
 __version__ = _version.get_versions()["version"]

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -476,12 +476,12 @@ class HistoryDag:
         """Return a generator containing all leaf nodes in the history DAG."""
         return (node for node in self.postorder() if node.is_leaf())
 
-    def count_nodes(self) -> int:
-        """Return the number of nodes in the DAG, not counting the UA node"""
+    def num_nodes(self) -> int:
+        """Return the number of nodes in the DAG, not counting the UA node."""
         return sum(1 for _ in self.preorder(skip_root=True))
 
-    def count_leaves(self) -> int:
-        """Return the number of leaf nodes in the DAG"""
+    def num_leaves(self) -> int:
+        """Return the number of leaf nodes in the DAG."""
         return sum(1 for _ in self.get_leaves())
 
     def sample(self, edge_selector=lambda e: True) -> "HistoryDag":
@@ -497,7 +497,8 @@ class HistoryDag:
         return HistoryDag(self.dagroot._sample(edge_selector=edge_selector))
 
     def nodes_above_node(self, node) -> Set[HistoryDagNode]:
-        """Return a set of nodes from which the passed node is reachable along directed edges."""
+        """Return a set of nodes from which the passed node is reachable along
+        directed edges."""
         self.recompute_parents()
         mask_true = set()
         nodequeue = {node}
@@ -511,9 +512,11 @@ class HistoryDag:
     def sample_with_node(self, node) -> "HistoryDag":
         """Samples a history which contains ``node`` from the history DAG.
 
-        Sampling is likely unbiased from the distribution of trees in the DAG, conditioned on each sampled
-        tree containing the passed node. However, if unbiased sampling from the conditional distribution is
-        important, this should be tested."""
+        Sampling is likely unbiased from the distribution of trees in
+        the DAG, conditioned on each sampled tree containing the passed
+        node. However, if unbiased sampling from the conditional
+        distribution is important, this should be tested.
+        """
 
         mask_true = self.nodes_above_node(node)
 
@@ -523,11 +526,14 @@ class HistoryDag:
         return self.sample(edge_selector=edge_selector)
 
     def sample_with_edge(self, edge) -> "HistoryDag":
-        """Samples a history which contains ``edge`` (a tuple of HistoryDagNodes) from the history DAG.
+        """Samples a history which contains ``edge`` (a tuple of
+        HistoryDagNodes) from the history DAG.
 
-        Sampling is likely unbiased from the distribution of trees in the DAG, conditioned on each sampled
-        tree containing the passed edge. However, if unbiased sampling from the conditional distribution is
-        important, this should be tested."""
+        Sampling is likely unbiased from the distribution of trees in
+        the DAG, conditioned on each sampled tree containing the passed
+        edge. However, if unbiased sampling from the conditional
+        distribution is important, this should be tested.
+        """
         mask_true = self.nodes_above_node(edge[0])
 
         def edge_selector(inedge):
@@ -535,12 +541,15 @@ class HistoryDag:
 
         return self.sample(edge_selector=edge_selector)
 
-    def iter_covering_histories(self) -> Generator["Historydag", None, None]:
-        """Samples a sequence of histories which together contain all nodes in the history DAG.
+    def iter_covering_histories(self) -> Generator["HistoryDag", None, None]:
+        """Samples a sequence of histories which together contain all nodes in
+        the history DAG.
 
-        Histories are sampled using :meth:`sample_with_node`, starting with the nodes which are contained
-        in the fewest of the DAG's histories. The sequence of trees is therefore non-deterministic unless
-        ``random.seed`` is set."""
+        Histories are sampled using :meth:`sample_with_node`, starting
+        with the nodes which are contained in the fewest of the DAG's
+        histories. The sequence of trees is therefore non-deterministic
+        unless ``random.seed`` is set.
+        """
         node_counts = self.count_nodes()
         node_list = sorted(node_counts.keys(), key=lambda n: node_counts[n])
 
@@ -574,8 +583,12 @@ class HistoryDag:
         return ret
 
     def relabel(self, relabel_func: Callable[[HistoryDagNode], Label]) -> "HistoryDag":
-        """Return a new HistoryDag with labels modified according to a provided function.
-        `relabel_func` should take a node and return the new label appropriate for that node."""
+        """Return a new HistoryDag with labels modified according to a provided
+        function.
+
+        `relabel_func` should take a node and return the new label
+        appropriate for that node.
+        """
 
         leaf_label_dict = {leaf.label: relabel_func(leaf) for leaf in self.get_leaves()}
         if len(leaf_label_dict) != len(set(leaf_label_dict.keys())):
@@ -1727,9 +1740,11 @@ class EdgeSet:
             self._targetset = set(self.targets)
 
     def sample(self, mask=None) -> Tuple[HistoryDagNode, float]:
-        """Returns a randomly sampled child edge, and its corresponding
-        weight. When possible, only edges pointing to child nodes on which ``selection_function`` evaluates to True
-        will be sampled."""
+        """Returns a randomly sampled child edge, and its corresponding weight.
+
+        When possible, only edges pointing to child nodes on which
+        ``selection_function`` evaluates to True will be sampled.
+        """
         if sum(mask) == 0:
             weights = self.probs
         else:

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -463,7 +463,8 @@ class HistoryDag:
         self.attr = serial_dict["attr"]
 
     def _check_valid(self) -> bool:
-        """Check that this HistoryDag complies with all the conditions of the definition."""
+        """Check that this HistoryDag complies with all the conditions of the
+        definition."""
         # Traversal checks if a node has been visited by its id, which makes it
         # suitable for these checks.
         po = list(self.postorder())
@@ -1788,8 +1789,11 @@ class EdgeSet:
         )
 
     def set_targets(self, targets, weights=None, probs=None):
-        """Set the target nodes of this node. If no weights or probabilities
-        are provided, then these will be set to 0 and 1/n, respectively."""
+        """Set the target nodes of this node.
+
+        If no weights or probabilities are provided, then these will be
+        set to 0 and 1/n, respectively.
+        """
         n = len(targets)
         if len(set(targets)) != n:
             raise ValueError(

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1770,6 +1770,10 @@ class EdgeSet:
         self.set_targets(targets, weights, probs)
 
     def __iter__(self):
+        print('group')
+        print(len(self.targets))
+        print(len(self.probs))
+        print(len(self.weights))
         return (
             (self.targets[i], self.weights[i], self.probs[i])
             for i in range(len(self.targets))

--- a/historydag/parsimony.py
+++ b/historydag/parsimony.py
@@ -6,7 +6,7 @@ import numpy as np
 import Bio.Data.IUPACData
 from historydag.utils import access_nodefield_default
 from itertools import product
-from historydag.dag import history_dag_from_clade_trees, history_dag_from_etes
+from historydag.dag import history_dag_from_clade_trees, history_dag_from_etes, HistoryDag
 
 bases = "AGCT-"
 ambiguous_dna_values = Bio.Data.IUPACData.ambiguous_dna_values.copy()
@@ -148,7 +148,7 @@ def sankoff_upward(
                 )
         return np.sum(np.min(tree.cost_vector, axis=1))
 
-    elif isinstance(tree, hdag.HistoryDag):
+    elif isinstance(tree, HistoryDag):
         tree.recompute_parents()
         adj_arr = _get_adj_array(
             len(next(tree.postorder()).label.sequence),

--- a/historydag/parsimony.py
+++ b/historydag/parsimony.py
@@ -1,10 +1,12 @@
+"""A module implementing Sankoff Algorithm"""
+
 import random
 import ete3
-import historydag as hdag
 import numpy as np
 import Bio.Data.IUPACData
 from historydag.utils import access_nodefield_default
 from itertools import product
+from historydag.dag import history_dag_from_clade_trees, history_dag_from_etes
 
 bases = "AGCT-"
 ambiguous_dna_values = Bio.Data.IUPACData.ambiguous_dna_values.copy()
@@ -609,7 +611,7 @@ def build_dag_from_trees(trees):
         if len(tree.children) == 1:
             newchild = tree.add_child()
             newchild.add_feature("sequence", tree.sequence)
-    return hdag.history_dag_from_etes(
+    return history_dag_from_etes(
         trees,
         ["sequence"],
     )
@@ -635,14 +637,14 @@ def disambiguate_history(history):
         }
     )
     disambiguate(etetree, min_ambiguities=True)
-    rhistory = hdag.history_dag_from_etes([etetree], ["sequence"])
+    rhistory = history_dag_from_etes([etetree], ["sequence"])
     return rhistory
 
 
-def treewise_sankoff_in_dag(dag):
+def treewise_sankoff_in_dag(dag, cover_edges=False):
     """Perform tree-wise sankoff to compute labels for all nodes in the DAG."""
-    newdag = hdag.dag.history_dag_from_clade_trees(
-        disambiguate_history(history) for history in dag.iter_covering_histories()
+    newdag = history_dag_from_clade_trees(
+        disambiguate_history(history) for history in dag.iter_covering_histories(cover_edges=cover_edges)
     )
     newdag.explode_nodes()
     newdag.add_all_allowed_edges()

--- a/historydag/parsimony.py
+++ b/historydag/parsimony.py
@@ -299,7 +299,7 @@ def sankoff_downward(
         ]
         return list(zip(new_sequence, adj_vec, [min_cost] * len(new_sequence)))
 
-    dag_nodes = {node: node for node in dag.postorder()}
+    dag_nodes = {}
     # downward pass of Sankoff: find and assign sequence labels to each internal node
     for node in reversed(list(dag.postorder())):
         if not (node.is_leaf() or node.is_root()):

--- a/historydag/parsimony.py
+++ b/historydag/parsimony.py
@@ -1,0 +1,395 @@
+import random
+import ete3
+import historydag as hdag
+import numpy as np
+import Bio.Data.IUPACData
+
+bases = "AGCT-"
+ambiguous_dna_values = Bio.Data.IUPACData.ambiguous_dna_values.copy()
+ambiguous_dna_values.update({"?": "GATC-", "-": "-"})
+
+
+def hamming_distance(seq1: str, seq2: str) -> int:
+    r"""Hamming distance between two sequences of equal length.
+
+    Args:
+        seq1: sequence 1
+        seq2: sequence 2
+    """
+    if len(seq1) != len(seq2):
+        raise ValueError("sequence lengths do not match!")
+    return sum(x != y for x, y in zip(seq1, seq2))
+
+
+_yey = np.array(
+    [
+        [0, 1, 1, 1, 1],
+        [1, 0, 1, 1, 1],
+        [1, 1, 0, 1, 1],
+        [1, 1, 1, 0, 1],
+        [1, 1, 1, 1, 0],
+    ]
+)
+
+# This is applicable even when diagonal entries in transition rate matrix are
+# nonzero, since it is only a mask on allowable sites based on each base.
+code_vectors = {
+    code: np.array(
+        [0 if base in ambiguous_dna_values[code] else float("inf") for base in bases]
+    )
+    for code in ambiguous_dna_values
+}
+
+ambiguous_codes_from_vecs = {
+    tuple(0 if base in base_set else 1 for base in bases): code
+    for code, base_set in ambiguous_dna_values.items()
+}
+
+
+def _get_adj_array(seq_len, transition_weights=None):
+    if transition_weights is None:
+        transition_weights = _yey
+    else:
+        transition_weights = np.array(transition_weights)
+
+    if transition_weights.shape == (5, 5):
+        adj_arr = np.array([transition_weights] * seq_len)
+    elif transition_weights.shape == (seq_len, 5, 5):
+        adj_arr = transition_weights
+    else:
+        raise RuntimeError(
+            "Transition weight matrix must have shape (5, 5) or (sequence_length, 5, 5)."
+        )
+    return adj_arr
+
+
+def sankoff_upward(tree, gap_as_char=False, transition_weights=None):
+    """Compute Sankoff cost vectors at nodes in a postorder traversal, and
+    return best possible parsimony score of the tree.
+
+    Args:
+        gap_as_char: if True, the gap character ``-`` will be treated as a fifth character. Otherwise,
+            it will be treated the same as an ``N``.
+        transition_weights: A 5x5 transition weight matrix, with base order `AGCT-`.
+            Rows contain targeting weights. That is, the first row contains the transition weights
+            from `A` to each possible target base. Alternatively, a sequence-length array of these
+            transition weight matrices, if transition weights vary by-site. By default, a constant
+            weight matrix will be used containing 1 in all off-diagonal positions, equivalent
+            to Hamming parsimony.
+    """
+    if gap_as_char:
+
+        def translate_base(char):
+            return char
+
+    else:
+
+        def translate_base(char):
+            if char == "-":
+                return "N"
+            else:
+                return char
+
+    adj_arr = _get_adj_array(len(tree.sequence), transition_weights=transition_weights)
+
+    # First pass of Sankoff: compute cost vectors
+    for node in tree.traverse(strategy="postorder"):
+        node.add_feature(
+            "cv",
+            np.array(
+                [code_vectors[translate_base(base)].copy() for base in node.sequence]
+            ),
+        )
+        if not node.is_leaf():
+            child_costs = []
+            for child in node.children:
+                stacked_child_cv = np.stack((child.cv,) * 5, axis=1)
+                total_cost = adj_arr + stacked_child_cv
+                child_costs.append(np.min(total_cost, axis=2))
+            child_cost = np.sum(child_costs, axis=0)
+            node.cv = (
+                np.array([code_vectors[translate_base(base)] for base in node.sequence])
+                + child_cost
+            )
+    return np.sum(np.min(tree.cv, axis=1))
+
+
+def disambiguate(
+    tree,
+    compute_cvs=True,
+    random_state=None,
+    remove_cvs=False,
+    adj_dist=False,
+    gap_as_char=False,
+    transition_weights=None,
+    min_ambiguities=False,
+):
+    """Randomly resolve ambiguous bases using a two-pass Sankoff Algorithm on
+    subtrees of consecutive ambiguity codes.
+
+    Args:
+        compute_cvs: If true, compute upward sankoff cost vectors. If ``sankoff_upward`` was
+            already run on the tree, this may be skipped.
+        random_state: A ``random`` module random state, returned by ``random.getstate()``. Output
+            from this function is otherwise deterministic.
+        remove_cvs: Remove sankoff cost vectors from tree nodes after disambiguation.
+        adj_dist: Recompute hamming parsimony distances on tree after disambiguation, and store them
+            in ``dist`` node attributes.
+        gap_as_char: if True, the gap character ``-`` will be treated as a fifth character. Otherwise,
+            it will be treated the same as an ``N``.
+        transition_weights: A 5x5 transition weight matrix, with base order `AGCT-`.
+            Rows contain targeting weights. That is, the first row contains the transition weights
+            from `A` to each possible target base. Alternatively, a sequence-length array of these
+            transition weight matrices, if transition weights vary by-site. By default, a constant
+            weight matrix will be used containing 1 in all off-diagonal positions, equivalent
+            to Hamming parsimony.
+        min_ambiguities: If True, leaves ambiguities in reconstructed sequences, expressing which
+            bases are possible at each site in a maximally parsimonious disambiguation of the given
+            topology. In the history DAG paper, this is known as a strictly min-weight ambiguous labeling.
+            Otherwise, sequences are resolved in one possible way, and include no ambiguities.
+    """
+    if random_state is None:
+        random.seed(tree.write(format=1))
+    else:
+        random.setstate(random_state)
+
+    seq_len = len(tree.sequence)
+    adj_arr = _get_adj_array(len(tree.sequence), transition_weights=transition_weights)
+    if compute_cvs:
+        sankoff_upward(tree, gap_as_char=gap_as_char)
+    # Second pass of Sankoff: choose bases
+    preorder = list(tree.traverse(strategy="preorder"))
+    for node in preorder:
+        if min_ambiguities:
+            adj_vec = node.cv != np.stack((node.cv.min(axis=1),) * 5, axis=1)
+            new_seq = [
+                ambiguous_codes_from_vecs[tuple(map(float, row))] for row in adj_vec
+            ]
+        else:
+            base_indices = []
+            for idx in range(seq_len):
+                min_cost = min(node.cv[idx])
+                base_index = random.choice(
+                    [i for i, val in enumerate(node.cv[idx]) if val == min_cost]
+                )
+                base_indices.append(base_index)
+
+            adj_vec = adj_arr[np.arange(seq_len), base_indices]
+            new_seq = [bases[base_index] for base_index in base_indices]
+
+        # Adjust child cost vectors
+        for child in node.children:
+            child.cv += adj_vec
+        node.sequence = "".join(new_seq)
+
+    if remove_cvs:
+        for node in tree.traverse():
+            try:
+                node.del_feature("cv")
+            except (AttributeError, KeyError):
+                pass
+    if adj_dist:
+        tree.dist = 0
+        for node in tree.iter_descendants():
+            node.dist = hamming_distance(node.up.sequence, node.sequence)
+    return tree
+
+
+def load_fasta(fastapath):
+    """Load a fasta file as a dictionary, with sequence ids as keys and
+    sequences as values."""
+    fasta_map = {}
+    with open(fastapath, "r") as fh:
+        seqid = None
+        for line in fh:
+            if line[0] == ">":
+                seqid = line[1:].strip()
+                if seqid in fasta_map:
+                    raise ValueError(
+                        "Duplicate records with matching identifier in fasta file"
+                    )
+                else:
+                    fasta_map[seqid] = ""
+            else:
+                if seqid is None and line.strip():
+                    raise ValueError(
+                        "First non-blank line in fasta does not contain identifier"
+                    )
+                else:
+                    fasta_map[seqid] += line.strip().upper()
+    return fasta_map
+
+
+def build_tree(
+    newickstring,
+    fasta_map,
+    newickformat=1,
+    reference_id=None,
+    reference_sequence=None,
+    ignore_internal_sequences=False,
+):
+    """Load an ete tree from a newick string, and add 'sequence' attributes
+    from fasta.
+
+    If internal node sequences aren't specified in the newick string and fasta data,
+    internal node sequences will be fully ambiguous (contain repeated N's).
+
+    Arguments:
+        newickstring: a newick string
+        fasta_map: a dictionary with sequence id keys matching node names in `newickstring`, and sequence values.
+        newickformat: the ete format identifier for the passed newick string. See ete docs
+        reference_id: key in `fasta_map` corresponding to the root sequence of the tree, if root sequence is fixed.
+        reference_sequence: fixed root sequence of the tree, if root sequence is fixed
+        ignore_internal_sequences: if True, sequences at non-leaf nodes specified in fasta_map
+        and newickstring will be ignored, and all internal sequences will be fully ambiguous.
+    """
+    tree = ete3.Tree(newickstring, format=newickformat)
+    # all fasta entries should be same length
+    seq_len = len(next(iter(fasta_map.values())))
+    ambig_seq = "?" * seq_len
+    for node in tree.traverse():
+        if node.is_root() and reference_sequence is not None:
+            node.add_feature("sequence", reference_sequence)
+        elif node.is_root() and reference_id is not None:
+            node.add_feature("sequence", fasta_map[reference_id])
+        elif (not node.is_leaf()) and ignore_internal_sequences:
+            node.add_feature("sequence", ambig_seq)
+        elif node.name in fasta_map:
+            node.add_feature("sequence", fasta_map[node.name])
+        else:
+            node.add_feature("sequence", ambig_seq)
+    return tree
+
+
+def build_trees_from_files(newickfiles, fastafile, **kwargs):
+    """Same as `build_tree`, but takes a list of filenames containing newick
+    strings, and a filename for a fasta file, and returns a generator on
+    trees."""
+    fasta_map = load_fasta(fastafile)
+    for newick in newickfiles:
+        with open(newick, "r") as fh:
+            newick = fh.read()
+        yield build_tree(newick, fasta_map, **kwargs)
+
+
+def parsimony_score(tree):
+    """returns the parsimony score of a (disambiguated) ete tree.
+
+    Tree must have 'sequence' attributes on all nodes.
+    """
+    return sum(
+        hamming_distance(node.up.sequence, node.sequence)
+        for node in tree.iter_descendants()
+    )
+
+
+def remove_invariant_sites(fasta_map):
+    """Eliminate invariant characters in a fasta alignment and record the
+    0-based indices of those variant sites."""
+    # eliminate characters for which there's no diversity:
+    informative_sites = [
+        idx for idx, chars in enumerate(zip(*fasta_map.values())) if len(set(chars)) > 1
+    ]
+    newfasta = {
+        key: "".join(oldseq[idx] for idx in informative_sites)
+        for key, oldseq in fasta_map.items()
+    }
+    return newfasta, informative_sites
+
+
+def parsimony_scores_from_topologies(
+    newicks, fasta_map, gap_as_char=False, remove_invariants=False, **kwargs
+):
+    """returns a generator on parsimony scores of trees specified by newick
+    strings and fasta. additional keyword arguments are passed to `build_tree`.
+
+    Args:
+        newicks: newick strings of trees whose parsimony scores will be computed
+        fasta_map: fasta data as a dictionary, as output by ``load_fasta``
+        gap_as_char: if True, gap characters `-` will be treated as a fifth character.
+            Otherwise, they will be synonymous with `N`'s.
+        remove_invariants: if True, removes invariant sites from the provided fasta_map
+    """
+    if remove_invariants:
+        print("removing invariant sites...")
+        newfasta = remove_invariant_sites(fasta_map)
+        print("...finished removing invariant sites")
+    else:
+        newfasta = fasta_map
+    yield from (
+        sankoff_upward(build_tree(newick, newfasta, **kwargs), gap_as_char=gap_as_char)
+        for newick in newicks
+    )
+
+
+def parsimony_scores_from_files(treefiles, fastafile, **kwargs):
+    """returns the parsimony scores of trees specified by newick files and a
+    fasta file.
+
+    Arguments match `build_trees_from_files`. Additional keyword
+    arguments are passed to ``parsimony_scores_from_topologies``.
+    """
+
+    def load_newick(npath):
+        with open(npath, "r") as fh:
+            return fh.read()
+
+    return parsimony_scores_from_topologies(
+        (load_newick(path) for path in treefiles), load_fasta(fastafile), **kwargs
+    )
+
+
+def build_dag_from_trees(trees):
+    """Build a history DAG from trees containing a `sequence` attribute on all
+    nodes.
+
+    unifurcations in the provided trees will be deleted.
+    """
+    trees = [tree.copy() for tree in trees]
+    for tree in trees:
+        for node in tree.iter_descendants():
+            if len(node.children) == 1:
+                node.delete(prevent_nondicotomic=False)
+        if len(tree.children) == 1:
+            newchild = tree.add_child()
+            newchild.add_feature("sequence", tree.sequence)
+    return hdag.history_dag_from_etes(
+        trees,
+        ["sequence"],
+    )
+
+
+def summarize_dag(dag):
+    """print summary information about the provided history DAG."""
+    print("DAG contains")
+    print("trees: ", dag.count_trees())
+    print("nodes: ", len(list(dag.preorder())))
+    print("edges: ", sum(len(list(node.children())) for node in dag.preorder()))
+    print("parsimony scores: ", dag.weight_count())
+
+
+def disambiguate_history(history):
+    """A rather ugly way to disambiguate a history, by converting to ete, using
+    the disambiguate method, then converting back to HistoryDag."""
+    seq_len = len(next(history.get_leaves()).label.sequence)
+    ambig_seq = "N" * seq_len
+    etetree = history.to_ete(
+        feature_funcs={
+            "sequence": (lambda n: n.label.sequence if n.is_leaf() else ambig_seq)
+        }
+    )
+    disambiguate(etetree, min_ambiguities=True)
+    rhistory = hdag.history_dag_from_etes([etetree], ["sequence"])
+    return rhistory
+
+
+def treewise_sankoff_in_dag(dag):
+    """Perform tree-wise sankoff to compute labels for all nodes in the DAG."""
+    newdag = hdag.dag.history_dag_from_clade_trees(
+        disambiguate_history(history) for history in dag.iter_covering_histories()
+    )
+    newdag.explode_nodes()
+    newdag.add_all_allowed_edges()
+    newdag.trim_optimal_weight()
+    newdag.convert_to_collapsed()
+    return newdag

--- a/historydag/sankoff_cli.py
+++ b/historydag/sankoff_cli.py
@@ -1,0 +1,208 @@
+import parsimony as pars
+import click
+import pickle
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+def _cli():
+    """A collection of tools for calculating parsimony scores of newick trees,
+    and using them to create a history DAG."""
+    pass
+
+
+@_cli.command("remove-invariants")
+@click.argument("in_fasta")
+@click.argument("out_fasta")
+@click.argument("out_variant_sites")
+def _cli_remove_invariant_sites(in_fasta, out_fasta, out_variant_sites):
+    fasta_map = pars.load_fasta(in_fasta)
+    newfasta, variant_sites = pars.remove_invariant_sites(fasta_map)
+    with open(out_fasta, "w") as fh:
+        for seqid, seq in newfasta.items():
+            print(">" + seqid, file=fh)
+            print(seq, file=fh)
+    with open(out_variant_sites, "w") as fh:
+        print(",".join([str(site) for site in variant_sites]), file=fh)
+
+
+@_cli.command("build-trees")
+@click.argument("treefiles", nargs=-1)
+@click.option(
+    "-f",
+    "--fasta-file",
+    required=True,
+    help="Filename of a fasta file containing sequences appearing on nodes of newick tree",
+)
+@click.option(
+    "-r",
+    "--root-id",
+    default=None,
+    help="The fasta identifier of the fixed root of provided trees. May be omitted if there is no fixed root sequence.",
+)
+@click.option(
+    "-F",
+    "--newick-format",
+    default=1,
+    help=("Newick format of the provided newick file. See "
+          "http://etetoolkit.org/docs/latest/reference/reference_tree.html#ete3.TreeNode"),
+)
+@click.option(
+    "-i",
+    "--include-internal-sequences",
+    is_flag=True,
+    help="include non-leaf node labels, and associated sequences in the fasta file.",
+)
+@click.option(
+    "-g",
+    "--gap-as-char",
+    is_flag=True,
+    help="Treat gap character `-` as a fifth character. Otherwise treated as ambiguous `N`.",
+)
+@click.option(
+    "-a",
+    "--preserve-ambiguities",
+    is_flag=True,
+    help=("Do not disambiguate fully, but rather preserve ambiguities to express "
+          "all maximally parsimonious assignments at each site."),
+)
+@click.option(
+    "-o", "--outdir", default=".", help="Directory in which to write pickled trees."
+)
+@click.option(
+    "-c",
+    "--clean-trees",
+    is_flag=True,
+    help="remove cost vectors from tree, resulting in smaller pickled tree files",
+)
+def _cli_build_trees(
+    treefiles,
+    fasta_file,
+    root_id,
+    newick_format,
+    include_internal_sequences,
+    gap_as_char,
+    preserve_ambiguities,
+    outdir,
+    clean_trees,
+):
+    trees = pars.build_trees_from_files(
+        treefiles,
+        fasta_file,
+        reference_id=root_id,
+        ignore_internal_sequences=(not include_internal_sequences),
+    )
+    trees = (
+        pars.disambiguate(
+            tree,
+            gap_as_char=gap_as_char,
+            min_ambiguities=preserve_ambiguities,
+            remove_cvs=clean_trees,
+        )
+        for tree in trees
+    )
+    for treefile, tree in zip(treefiles, trees):
+        print("saving tree")
+        with open(outdir + f"tree_{treefile.split('/')[-1]}.p", "wb") as fh:
+            fh.write(pickle.dumps(tree))
+        print("saved tree")
+
+
+@_cli.command("parsimony_scores")
+@click.argument("treefiles", nargs=-1)
+@click.option(
+    "-f",
+    "--fasta-file",
+    required=True,
+    help="Filename of a fasta file containing sequences appearing on nodes of newick tree",
+)
+@click.option(
+    "-r",
+    "--root-id",
+    default=None,
+    help="The fasta identifier of the fixed root of provided trees. May be omitted if there is no fixed root sequence.",
+)
+@click.option(
+    "-F",
+    "--newick-format",
+    default=1,
+    help=("Newick format of the provided newick file. See "
+          "http://etetoolkit.org/docs/latest/reference/reference_tree.html#ete3.TreeNode"),
+)
+@click.option(
+    "-i",
+    "--include-internal-sequences",
+    is_flag=True,
+    help="include non-leaf node labels, and associated sequences in the fasta file.",
+)
+@click.option(
+    "-d",
+    "--save-to-dag",
+    default=None,
+    help="Combine loaded and disambiguated trees into a history DAG, and save pickled DAG to provided path.",
+)
+@click.option(
+    "-g",
+    "--gap-as-char",
+    is_flag=True,
+    help="Treat gap character `-` as a fifth character. Otherwise treated as ambiguous `N`.",
+)
+@click.option(
+    "-a",
+    "--preserve-ambiguities",
+    is_flag=True,
+    help=("Do not disambiguate fully, but rather preserve ambiguities to express "
+          "all maximally parsimonious assignments at each site."),
+)
+def _cli_parsimony_score_from_files(
+    treefiles,
+    fasta_file,
+    root_id,
+    newick_format,
+    include_internal_sequences,
+    save_to_dag,
+    gap_as_char,
+    preserve_ambiguities,
+):
+    """Print the parsimony score of one or more newick files."""
+    pscore_gen = pars.parsimony_scores_from_files(
+        treefiles,
+        fasta_file,
+        reference_id=root_id,
+        gap_as_char=gap_as_char,
+        ignore_internal_sequences=(not include_internal_sequences),
+        remove_invariants=True,
+    )
+
+    for score, treepath in zip(pscore_gen, treefiles):
+        print(treepath)
+        print(score)
+
+    if save_to_dag is not None:
+        trees = pars.build_trees_from_files(
+            treefiles,
+            fasta_file,
+            reference_id=root_id,
+            ignore_internal_sequences=(not include_internal_sequences),
+        )
+        trees = (
+            pars.disambiguate(
+                tree, gap_as_char=gap_as_char, min_ambiguities=preserve_ambiguities
+            )
+            for tree in trees
+        )
+        dag = pars.build_dag_from_trees(trees)
+        with open(save_to_dag, "wb") as fh:
+            fh.write(pickle.dumps(dag))
+
+
+@_cli.command("summarize-dag")
+@click.argument("dagpath")
+def _cli_summarize_dag(dagpath):
+    """print summary information about the provided history DAG."""
+    with open(dagpath, "rb") as fh:
+        dag = pickle.load(fh)
+    pars.summarize_dag(dag)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/historydag/sankoff_cli.py
+++ b/historydag/sankoff_cli.py
@@ -43,8 +43,10 @@ def _cli_remove_invariant_sites(in_fasta, out_fasta, out_variant_sites):
     "-F",
     "--newick-format",
     default=1,
-    help=("Newick format of the provided newick file. See "
-          "http://etetoolkit.org/docs/latest/reference/reference_tree.html#ete3.TreeNode"),
+    help=(
+        "Newick format of the provided newick file. See "
+        "http://etetoolkit.org/docs/latest/reference/reference_tree.html#ete3.TreeNode"
+    ),
 )
 @click.option(
     "-i",
@@ -62,8 +64,10 @@ def _cli_remove_invariant_sites(in_fasta, out_fasta, out_variant_sites):
     "-a",
     "--preserve-ambiguities",
     is_flag=True,
-    help=("Do not disambiguate fully, but rather preserve ambiguities to express "
-          "all maximally parsimonious assignments at each site."),
+    help=(
+        "Do not disambiguate fully, but rather preserve ambiguities to express "
+        "all maximally parsimonious assignments at each site."
+    ),
 )
 @click.option(
     "-o", "--outdir", default=".", help="Directory in which to write pickled trees."
@@ -125,8 +129,10 @@ def _cli_build_trees(
     "-F",
     "--newick-format",
     default=1,
-    help=("Newick format of the provided newick file. See "
-          "http://etetoolkit.org/docs/latest/reference/reference_tree.html#ete3.TreeNode"),
+    help=(
+        "Newick format of the provided newick file. See "
+        "http://etetoolkit.org/docs/latest/reference/reference_tree.html#ete3.TreeNode"
+    ),
 )
 @click.option(
     "-i",
@@ -150,8 +156,10 @@ def _cli_build_trees(
     "-a",
     "--preserve-ambiguities",
     is_flag=True,
-    help=("Do not disambiguate fully, but rather preserve ambiguities to express "
-          "all maximally parsimonious assignments at each site."),
+    help=(
+        "Do not disambiguate fully, but rather preserve ambiguities to express "
+        "all maximally parsimonious assignments at each site."
+    ),
 )
 def _cli_parsimony_score_from_files(
     treefiles,

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -171,6 +171,22 @@ def wrapped_hamming_distance(s1, s2) -> int:
     return hamming_distance(s1, s2)
 
 
+def hamming_distance_leaf_ambiguous(n1, n2):
+    """Same as wrapped_hamming_distance, but correctly calculates parsimony scores
+    if leaf nodes have ambiguous sequences."""
+    if n2.is_leaf():
+        # Then its sequence may be ambiguous
+        s1 = n1.label.sequence
+        s2 = n2.label.sequence
+        if len(s1) != len(s2):
+            raise ValueError("Sequences must have the same length!")
+        return sum(
+            pbase not in ambiguous_dna_values[cbase] for pbase, cbase in zip(s1, s2)
+        )
+    else:
+        return wrapped_hamming_distance(n1, n2)
+
+
 def is_ambiguous(sequence: str) -> bool:
     """Returns whether the provided sequence contains IUPAC nucleotide
     ambiguity codes."""
@@ -392,6 +408,17 @@ hamming_distance_countfuncs = AddFuncDict(
 """Provides functions to count hamming distance parsimony.
 For use with :meth:`historydag.HistoryDag.weight_count`."""
 
+node_countfuncs = AddFuncDict(
+    {
+        "start_func": lambda n: 0,
+        "edge_weight_func": lambda n1, n2: 1,
+        "accum_func": sum,
+    },
+    name="NodeCount",
+)
+"""Provides functions to count the number of nodes in trees.
+For use with :meth:`historydag.HistoryDag.weight_count`."""
+
 
 def make_newickcountfuncs(
     name_func=lambda n: "unnamed",
@@ -591,3 +618,15 @@ class StrState(str):
 
     def __setstate__(self, statedict):
         self.state = statedict["state"]
+
+
+def load_fasta(fastapath):
+    fasta_records = []
+    current_seq = ""
+    with open(fastapath, "r") as fh:
+        for line in fh:
+            if line[0] == ">":
+                fasta_records.append([line[1:].strip(), ""])
+            else:
+                fasta_records[-1][-1] += line.strip()
+    return dict(fasta_records)

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -172,8 +172,8 @@ def wrapped_hamming_distance(s1, s2) -> int:
 
 
 def hamming_distance_leaf_ambiguous(n1, n2):
-    """Same as wrapped_hamming_distance, but correctly calculates parsimony scores
-    if leaf nodes have ambiguous sequences."""
+    """Same as wrapped_hamming_distance, but correctly calculates parsimony
+    scores if leaf nodes have ambiguous sequences."""
     if n2.is_leaf():
         # Then its sequence may be ambiguous
         s1 = n1.label.sequence
@@ -622,7 +622,6 @@ class StrState(str):
 
 def load_fasta(fastapath):
     fasta_records = []
-    current_seq = ""
     with open(fastapath, "r") as fh:
         for line in fh:
             if line[0] == ">":

--- a/scripts/agg_mut.py
+++ b/scripts/agg_mut.py
@@ -888,7 +888,10 @@ def make_testcase(pickled_forest, outdir, num_trees, random_seed):
     outdir.mkdir(exist_ok=True)
     with open(pickled_forest, 'rb') as fh:
         forest = pickle.load(fh)
-    dag = forest._forest
+    try:
+        dag = forest._forest
+    except AttributeError:
+        dag = forest
     trees = [dag.sample() for _ in range(int(num_trees))]
     refseqs = [next(tree.preorder(skip_root=True)).label.sequence for tree in trees]
     assert len(set(refseqs)) == 1

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -55,6 +55,7 @@ for tree in trees:
 def test_fulltree():
     dag = hdag.history_dag_from_etes([etetree], ["sequence"])
     dag.convert_to_collapsed()
+    dag._check_valid()
     assert set(deterministic_newick(tree.to_ete()) for tree in dag.get_trees()) == set(
         {deterministic_newick(etetree2)}
     )
@@ -63,6 +64,7 @@ def test_fulltree():
 def test_twotrees():
     dag = hdag.history_dag_from_etes([etetree, etetree2], ["sequence"])
     dag.convert_to_collapsed()
+    dag._check_valid()
     assert dag.count_trees() == 1
     assert {deterministic_newick(tree.to_ete()) for tree in dag.get_trees()} == {
         deterministic_newick(etetree2)
@@ -75,10 +77,12 @@ def test_collapse():
     uncollapsed_dag.convert_to_collapsed()
     allcollapsedtrees = [utils.collapse_adjacent_sequences(tree) for tree in trees]
     collapsed_dag = hdag.history_dag_from_etes(allcollapsedtrees, ["sequence"])
+    collapsed_dag._check_valid()
     maybecollapsedtrees = [tree.to_ete() for tree in uncollapsed_dag.get_trees()]
     assert all(utils.is_collapsed(tree) for tree in maybecollapsedtrees)
     n_before = uncollapsed_dag.count_trees()
     uncollapsed_dag.merge(collapsed_dag)
+    uncollapsed_dag._check_valid()
     assert n_before == uncollapsed_dag.count_trees()
 
 
@@ -86,14 +90,18 @@ def test_add_allowed_edges():
     # See that adding only edges that preserve parent labels preserves parsimony
     dag = hdag.history_dag_from_etes(trees, ["sequence"])
     dag.add_all_allowed_edges(preserve_parent_labels=True)
+    dag._check_valid()
     c = dag.weight_count()
     assert min(c) == max(c)
 
     # See that adding only edges between nodes with different labels preserves collapse
     allcollapsedtrees = [collapse_adjacent_sequences(tree) for tree in trees]
     collapsed_dag = hdag.history_dag_from_etes(allcollapsedtrees, ["sequence"])
+    collapsed_dag._check_valid()
     collapsed_dag.convert_to_collapsed()
+    collapsed_dag._check_valid()
     collapsed_dag.add_all_allowed_edges(adjacent_labels=False)
+    collapsed_dag._check_valid()
     assert all(
         parent.label != target.label
         for parent in collapsed_dag.postorder()

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -1,0 +1,123 @@
+import pickle
+import numpy as np
+import historydag as hdag
+import historydag.parsimony as dag_parsimony
+
+
+def compare_dag_and_tree_parsimonies(
+    dag, transition_weights=None, filter_min_score=True
+):
+    dag.recompute_parents()
+    # extract sample tree
+    s = dag.sample()
+    # convert to ete3.Tree format
+    s_ete = s.to_ete()
+
+    # compute cost vectors for sample tree in dag and in ete3.Tree format to compare
+    a = dag_parsimony.sankoff_upward(
+        s, transition_weights=transition_weights, filter_min_score=filter_min_score
+    )
+    b = dag_parsimony.sankoff_upward(s_ete, transition_weights=transition_weights)
+    assert (
+        a == b
+    ), "Upward Sankoff on ete_Tree vs on the dag version of the tree produced different results"
+
+    # calculate sequences for internal nodes using Sankoff for both formats of sample tree
+    s_weight = dag_parsimony.sankoff_downward(
+        s,
+        compute_cvs=False,
+        transition_weights=transition_weights,
+        filter_min_score=filter_min_score,
+    )
+    s_ete = dag_parsimony.disambiguate(
+        s_ete, compute_cvs=False, transition_weights=transition_weights
+    )
+    # convert ete3.Tree back to a HistoryDag object so as to compare, but keeping the data calculated using ete3 structure
+    s_ete_as_dag = hdag.history_dag_from_etes([s_ete], label_features=["sequence"])
+
+    # parsimony score depends on the choice of `transition_weights` arg
+    if transition_weights is not None:
+        s_ete_weight = s_ete_as_dag.optimal_weight_annotate(
+            edge_weight_func=dag_parsimony.edge_weight_func_from_weight_matrix(
+                s_ete_as_dag, transition_weights, dag_parsimony.bases
+            )
+        )
+    else:
+        s_ete_weight = s_ete_as_dag.optimal_weight_annotate()
+    assert (
+        s_weight == s_ete_weight
+    ), "Downward sankoff on ete_Tree vs on the dag version of the tree produced different results"
+
+    s_labels = set(n.label.sequence for n in s.postorder() if not n.is_root())
+    s_ete_labels = set(
+        n.label.sequence for n in s_ete_as_dag.postorder() if not n.is_root()
+    )
+    assert (
+        len(s_ete_labels - s_labels) < 1
+    ), "DAG Sankoff missed a label that occurs in the tree Sankoff."
+
+
+def check_sankoff_on_dag(
+    dag, expected_score, transition_weights=None, filter_min_score=True
+):
+    # perform upward sweep of sankoff to calculate overall parsimony score and assign cost vectors to internal nodes
+    upward_pass_min_cost = dag_parsimony.sankoff_upward(
+        dag, transition_weights=transition_weights, filter_min_score=filter_min_score
+    )
+    assert np.isclose(
+        [upward_pass_min_cost], [expected_score]
+    ), "Upward pass of Sankoff on dag did not yield expected score"
+
+    # perform downward sweep of sankoff to calculate all possible internal node sequences.
+    downward_pass_min_cost = dag_parsimony.sankoff_downward(
+        dag,
+        transition_weights=transition_weights,
+        filter_min_score=filter_min_score,
+        compute_cvs=False,
+    )
+    assert np.isclose(
+        [downward_pass_min_cost], [expected_score]
+    ), "Downward pass of Sankoff on dag did not yield expected score"
+
+
+with open("sample_data/toy_trees.p", "rb") as f:
+    ete_trees = pickle.load(f)
+dg = hdag.history_dag_from_etes(ete_trees, ["sequence"])
+
+tw_options = [
+    (75, None),
+    (
+        93,
+        np.array(
+            [
+                [0, 1, 2.5, 1, 1],
+                [1, 0, 1, 2.5, 1],
+                [2.5, 1, 0, 1, 1],
+                [1, 2.5, 1, 0, 1],
+                [1, 1, 1, 1, 0],
+            ]
+        ),
+    ),
+    (
+        104,
+        np.array(
+            [
+                [0, 1, 5, 1, 1],
+                [1, 0, 1, 5, 1],
+                [5, 1, 0, 1, 1],
+                [1, 5, 1, 0, 1],
+                [1, 1, 1, 1, 0],
+            ]
+        ),
+    ),
+]
+
+for (w, tw) in tw_options:
+    check_sankoff_on_dag(dg.copy(), w, transition_weights=tw, filter_min_score=False)
+    check_sankoff_on_dag(dg.copy(), w, transition_weights=tw, filter_min_score=True)
+    compare_dag_and_tree_parsimonies(
+        dg.copy(), transition_weights=tw, filter_min_score=False
+    )
+    compare_dag_and_tree_parsimonies(
+        dg.copy(), transition_weights=tw, filter_min_score=True
+    )

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -81,6 +81,7 @@ def check_sankoff_on_dag(
         filter_min_score=filter_min_score,
         compute_cvs=False,
     )
+    dag._check_valid()
     assert np.isclose(
         [downward_pass_min_cost], [expected_score]
     ), "Downward pass of Sankoff on dag did not yield expected score"
@@ -90,44 +91,47 @@ def check_sankoff_on_dag(
     ), "Resulting DAG had invalid internal node assignments"
 
 
-with open("sample_data/toy_trees.p", "rb") as f:
-    ete_trees = pickle.load(f)
-dg = hdag.history_dag_from_etes(ete_trees, ["sequence"])
+def test_sankoff_on_dag():
+    with open("sample_data/toy_trees.p", "rb") as f:
+        ete_trees = pickle.load(f)
+    dg = hdag.history_dag_from_etes(ete_trees, ["sequence"])
 
-tw_options = [
-    (75, None),
-    (
-        93,
-        np.array(
-            [
-                [0, 1, 2.5, 1, 1],
-                [1, 0, 1, 2.5, 1],
-                [2.5, 1, 0, 1, 1],
-                [1, 2.5, 1, 0, 1],
-                [1, 1, 1, 1, 0],
-            ]
+    tw_options = [
+        (75, None),
+        (
+            93,
+            np.array(
+                [
+                    [0, 1, 2.5, 1, 1],
+                    [1, 0, 1, 2.5, 1],
+                    [2.5, 1, 0, 1, 1],
+                    [1, 2.5, 1, 0, 1],
+                    [1, 1, 1, 1, 0],
+                ]
+            ),
         ),
-    ),
-    (
-        106,
-        np.array(
-            [
-                [0, 1, 5, 1, 1],
-                [1, 0, 1, 5, 1],
-                [5, 1, 0, 1, 1],
-                [1, 5, 1, 0, 1],
-                [1, 1, 1, 1, 0],
-            ]
+        (
+            106,
+            np.array(
+                [
+                    [0, 1, 5, 1, 1],
+                    [1, 0, 1, 5, 1],
+                    [5, 1, 0, 1, 1],
+                    [1, 5, 1, 0, 1],
+                    [1, 1, 1, 1, 0],
+                ]
+            ),
         ),
-    ),
-]
+    ]
 
-for (w, tw) in tw_options:
-    check_sankoff_on_dag(dg.copy(), w, transition_weights=tw, filter_min_score=False)
-    check_sankoff_on_dag(dg.copy(), w, transition_weights=tw, filter_min_score=True)
-    compare_dag_and_tree_parsimonies(
-        dg.copy(), transition_weights=tw, filter_min_score=False
-    )
-    compare_dag_and_tree_parsimonies(
-        dg.copy(), transition_weights=tw, filter_min_score=True
-    )
+    for (w, tw) in tw_options:
+        check_sankoff_on_dag(
+            dg.copy(), w, transition_weights=tw, filter_min_score=False
+        )
+        check_sankoff_on_dag(dg.copy(), w, transition_weights=tw, filter_min_score=True)
+        compare_dag_and_tree_parsimonies(
+            dg.copy(), transition_weights=tw, filter_min_score=False
+        )
+        compare_dag_and_tree_parsimonies(
+            dg.copy(), transition_weights=tw, filter_min_score=True
+        )

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -8,6 +8,8 @@ def compare_dag_and_tree_parsimonies(
     dag, transition_weights=None, filter_min_score=True
 ):
     dag.recompute_parents()
+    dag.convert_to_collapsed()
+
     # extract sample tree
     s = dag.sample()
     # convert to ete3.Tree format
@@ -79,6 +81,10 @@ def check_sankoff_on_dag(
         [downward_pass_min_cost], [expected_score]
     ), "Downward pass of Sankoff on dag did not yield expected score"
 
+    assert (
+        dag.count_trees() == dag.copy().count_trees()
+    ), "Resulting DAG had invalid internal node assignments"
+
 
 with open("sample_data/toy_trees.p", "rb") as f:
     ete_trees = pickle.load(f)
@@ -99,7 +105,7 @@ tw_options = [
         ),
     ),
     (
-        104,
+        106,
         np.array(
             [
                 [0, 1, 5, 1, 1],

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -39,10 +39,14 @@ def compare_dag_and_tree_parsimonies(
 
     # parsimony score depends on the choice of `transition_weights` arg
     if transition_weights is not None:
-        s_ete_weight = s_ete_as_dag.optimal_weight_annotate(
-            edge_weight_func=dag_parsimony.edge_weight_func_from_weight_matrix(
-                s_ete_as_dag, transition_weights, dag_parsimony.bases
+
+        def weight_func(x, y):
+            return dag_parsimony.edge_weight_func_from_weight_matrix(
+                x, y, transition_weights, dag_parsimony.bases
             )
+
+        s_ete_weight = s_ete_as_dag.optimal_weight_annotate(
+            edge_weight_func=weight_func
         )
     else:
         s_ete_weight = s_ete_as_dag.optimal_weight_annotate()

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -197,6 +197,7 @@ def test_expand_ambiguities():
         cdag.explode_nodes()
         print(cdag.count_trees())
         cdag.trim_optimal_weight()
+        cdag._check_valid()
         print(cdag.count_trees())
         print(cdag.weight_count())
         checkset = {

--- a/tests/test_edgeset.py
+++ b/tests/test_edgeset.py
@@ -11,12 +11,14 @@ def test_init():
     tree1 = ete3.Tree(newickstring2, format=1)
     dag1 = from_tree(tree1, ["sequence"])
     EdgeSet()
-    EdgeSet([dag.dagroot])
+    e = EdgeSet([dag.dagroot])
+    for edge in e:
+        print(e)
     EdgeSet([dag.dagroot], probs=[0.5])
     try:
         EdgeSet([dag.dagroot, dag1.dagroot])
         raise TypeError("EdgeSet init is allowing identical dags to be added")
-    except TypeError:
+    except (TypeError, ValueError):
         pass
     try:
         EdgeSet([dag.dagroot], [dag1.dagroot])
@@ -33,6 +35,9 @@ def test_iter():
     e2 = EdgeSet([next(dag.dagroot.children()), next(dag1.dagroot.children())])
     for target, weight, prob in e2:
         pass
+    for node in (dag | dag1).preorder():
+        for clade, eset in node.clades.items():
+            assert len(eset.targets) == len(eset.probs) and len(eset.probs) == len(eset.weights)
 
 
 def test_copy():

--- a/tests/test_edgeset.py
+++ b/tests/test_edgeset.py
@@ -37,7 +37,9 @@ def test_iter():
         pass
     for node in (dag | dag1).preorder():
         for clade, eset in node.clades.items():
-            assert len(eset.targets) == len(eset.probs) and len(eset.probs) == len(eset.weights)
+            assert len(eset.targets) == len(eset.probs) and len(eset.probs) == len(
+                eset.weights
+            )
 
 
 def test_copy():

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -424,5 +424,5 @@ def test_relabel():
     Label = namedtuple("Label", ["sequence", "newthing"])
     ndag = dag.relabel(lambda n: Label(n.label.sequence, len(list(n.children()))))
     Label = namedtuple("Label", ["sequence"])
-    odag = dag.relabel(lambda n: Label(n.label.sequence))
+    odag = ndag.relabel(lambda n: Label(n.label.sequence))
     assert dag.weight_count() == odag.weight_count()

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -106,6 +106,8 @@ def _testfactory(resultfunc, verify_func, collapse_invariant=False, accum_func=C
 
 def test_valid_dags():
     for dag in dags + cdags:
+        dag._check_valid()
+        dag.copy()._check_valid()
         # each edge is allowed:
         for node in dag.postorder():
             for clade in node.clades:
@@ -348,14 +350,30 @@ def test_indexing_comprehensive():
         )
 
 
+def test_trim():
+    for dag in dags + cdags:
+        dag = dag.copy()
+        dag.add_all_allowed_edges()
+        dag._check_valid()
+        dag.recompute_parents()
+        dag._check_valid()
+        dag.trim_optimal_weight()
+        dag._check_valid()
+        dag.convert_to_collapsed()
+        dag._check_valid()
+
+
 def test_from_nodes():
     for dag in dags + cdags:
         cdag = dag.copy()
         cdag.add_all_allowed_edges()
         cdag.trim_optimal_weight()
+        cdag._check_valid()
         wc = cdag.weight_count()
         ndag = hdag.history_dag_from_nodes(cdag.preorder())
+        ndag._check_valid()
         ndag.trim_optimal_weight()
+        ndag._check_valid()
         print(ndag.to_graphviz())
         assert wc == ndag.weight_count()
 
@@ -371,6 +389,7 @@ def test_sample_with_node():
     ]
     for node in least_supported_nodes:
         tree_samples = [dag.sample_with_node(node) for _ in range(min_count * 5)]
+        tree_samples[0]._check_valid()
         tree_newicks = {tree.to_newick() for tree in tree_samples}
         # We sampled all trees possible containing the node
         assert len(tree_newicks) == min_count
@@ -404,6 +423,7 @@ def test_sample_with_edge():
     for parent in node.parents:
         edge = (parent, node)
         tree_samples = [dag.sample_with_edge(edge) for _ in range(min_count * 5)]
+        tree_samples[0]._check_valid()
         # We sampled all trees possible containing the node
         # All trees sampled contained the node
         assert all(edge in edges(tree) for tree in tree_samples)
@@ -433,4 +453,5 @@ def test_relabel():
     ndag = dag.relabel(lambda n: Label(n.label.sequence, len(list(n.children()))))
     Label = namedtuple("Label", ["sequence"])
     odag = ndag.relabel(lambda n: Label(n.label.sequence))
+    odag._check_valid()
     assert dag.weight_count() == odag.weight_count()

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -419,6 +419,14 @@ def test_iter_covering_histories():
         assert tdag.weight_count() == codag.weight_count()
 
 
+def test_iter_covering_histories_edges():
+    for dag in dags + cdags:
+        trees = list(dag.iter_covering_histories(cover_edges=True))
+        tdag = trees[0] | trees
+        assert tdag.weight_count() == dag.weight_count()
+        assert set(tdag.to_newicks()) == set(dag.to_newicks())
+
+
 def test_relabel():
     dag = dags[-1]
     Label = namedtuple("Label", ["sequence", "newthing"])

--- a/tests/test_historydag.py
+++ b/tests/test_historydag.py
@@ -90,6 +90,7 @@ def test_from_tree():
     tree = ete3.Tree(newickstring2, format=1)
     print(tree.sequence)
     dag = from_tree(tree, ["sequence"])
+    dag._check_valid()
     G = dag.to_graphviz(namedict=namedict)
     return G
 
@@ -98,6 +99,7 @@ def test_is_clade_tree():
     tree = ete3.Tree(newickstring2, format=1)
     print(tree.sequence)
     dag = from_tree(tree, ["sequence"])
+    dag._check_valid()
     assert dag.is_clade_tree()
 
 
@@ -110,6 +112,7 @@ def test_from_tree_label():
         ["sequence", "abundance"],
         label_functions={"abundance2x": lambda n: 2 * n.abundance},
     )
+    dag._check_valid()
 
 
 def test_preserve_attr():
@@ -119,6 +122,7 @@ def test_preserve_attr():
         ["sequence"],
         attr_func=lambda n: n.name,
     )
+    dag._check_valid()
     assert all(n.attr for n in dag.preorder(skip_root=True))
 
     @utils.explode_label("sequence")
@@ -131,8 +135,10 @@ def test_preserve_attr():
             yield seq
 
     dag.explode_nodes(expand_func=expand_func)
+    dag._check_valid()
     assert all(n.attr for n in dag.preorder(skip_root=True))
     dag.convert_to_collapsed()
+    dag._check_valid()
     assert all(n.attr for n in dag.preorder(skip_root=True))
 
 
@@ -232,6 +238,7 @@ def test_sample():
     for i in range(10):
         assert dag.sample().is_clade_tree()
     sample = dag.sample()
+    sample._check_valid()
     return sample.to_graphviz(namedict=namedict)
 
 
@@ -332,6 +339,7 @@ def test_make_uniform():
     )
     take1 = Counter([dag.sample().to_newick() for _ in range(1000)])
     dag.make_uniform()
+    dag._check_valid()
     take2 = Counter([dag.sample().to_newick() for _ in range(1000)])
 
     take1norms, avg1 = normalize_counts(take1)


### PR DESCRIPTION
Adds lots of new features, especially history sampling conditional on inclusion of an edge or node, and the ability to iterate through a list of histories which cover all the nodes or edges in the history DAG.

Also adds the ability to build a complete history DAG from a collection of nodes, and to change the labels on all nodes of the DAG according to an arbitrary function, as long as that function is injective on leaf nodes.

In `utils.py`, a simple function to load a fasta file, and a version of `wrapped_hamming_distance` which allows leaf node sequences to contain ambiguities.

In `parsimony.py`, utilities (subject to change) for performing sankoff on a tree and doing tree-wise disambiguation of the DAG.