### PR TITLE
squashed commits from node-utils branch

### DIFF
--- a/historydag/__init__.py
+++ b/historydag/__init__.py
@@ -11,4 +11,6 @@ from .dag import (  # noqa
 
 from . import _version
 
+from . import parsimony  # noqa
+
 __version__ = _version.get_versions()["version"]

--- a/historydag/parsimony.py
+++ b/historydag/parsimony.py
@@ -1,0 +1,657 @@
+"""A module implementing Sankoff Algorithm."""
+
+import random
+import ete3
+import numpy as np
+import Bio.Data.IUPACData
+from itertools import product
+from historydag.dag import (
+    history_dag_from_clade_trees,
+    history_dag_from_etes,
+    HistoryDag,
+)
+from copy import deepcopy
+
+bases = "AGCT-"
+ambiguous_dna_values = Bio.Data.IUPACData.ambiguous_dna_values.copy()
+ambiguous_dna_values.update({"?": "GATC-", "-": "-"})
+
+
+def hamming_distance(seq1: str, seq2: str) -> int:
+    r"""Hamming distance between two sequences of equal length.
+
+    Args:
+        seq1: sequence 1
+        seq2: sequence 2
+    """
+    if len(seq1) != len(seq2):
+        raise ValueError("sequence lengths do not match!")
+    return sum(x != y for x, y in zip(seq1, seq2))
+
+
+_yey = np.array(
+    [
+        [0, 1, 1, 1, 1],
+        [1, 0, 1, 1, 1],
+        [1, 1, 0, 1, 1],
+        [1, 1, 1, 0, 1],
+        [1, 1, 1, 1, 0],
+    ]
+)
+
+# This is applicable even when diagonal entries in transition rate matrix are
+# nonzero, since it is only a mask on allowable sites based on each base.
+code_vectors = {
+    code: np.array(
+        [0 if base in ambiguous_dna_values[code] else float("inf") for base in bases]
+    )
+    for code in ambiguous_dna_values
+}
+
+ambiguous_codes_from_vecs = {
+    tuple(0 if base in base_set else 1 for base in bases): code
+    for code, base_set in ambiguous_dna_values.items()
+}
+
+
+def _get_adj_array(seq_len, transition_weights=None):
+    if transition_weights is None:
+        transition_weights = _yey
+    else:
+        transition_weights = np.array(transition_weights)
+
+    if transition_weights.shape == (5, 5):
+        adj_arr = np.array([transition_weights] * seq_len)
+    elif transition_weights.shape == (seq_len, 5, 5):
+        adj_arr = transition_weights
+    else:
+        raise RuntimeError(
+            "Transition weight matrix must have shape (5, 5) or (sequence_length, 5, 5)."
+        )
+    return adj_arr
+
+
+def edge_weight_func_from_weight_matrix(n1, n2, weight_mat=None, bases=None):
+    if n1.is_root() or n2.is_root():
+        return 0
+    if len(n1.label.sequence) != len(n2.label.sequence):
+        raise ValueError("Sequences must have the same length!")
+    if weight_mat is not None and bases is not None:
+        base_indices = {k: v for v, k in enumerate(bases)}
+        return sum(
+            weight_mat[base_indices[x], base_indices[y]]
+            for x, y in zip(n1.label.sequence, n2.label.sequence)
+        )
+    return sum(x != y for x, y in zip(n1.label.sequence, n2.label.sequence))
+
+
+def sankoff_upward(
+    tree,
+    gap_as_char=False,
+    transition_weights=None,
+    filter_min_score=True,
+    use_internal_node_sequences=False,
+):
+    """Compute Sankoff cost vectors at nodes in a postorder traversal, and
+    return best possible parsimony score of the tree.
+
+    Args:
+        gap_as_char: if True, the gap character ``-`` will be treated as a fifth character. Otherwise,
+            it will be treated the same as an ``N``.
+        transition_weights: A 5x5 transition weight matrix, with base order `AGCT-`.
+            Rows contain targeting weights. That is, the first row contains the transition weights
+            from `A` to each possible target base. Alternatively, a sequence-length array of these
+            transition weight matrices, if transition weights vary by-site. By default, a constant
+            weight matrix will be used containing 1 in all off-diagonal positions, equivalent
+            to Hamming parsimony.
+        filter_min_score: (used when tree is of type ``HistoryDag``) if True, then discard any cost
+            vectors that do not minimize subtree cost. Otherwise, keep all possible cost vectors at all
+            nodes. This is an optimization that *seems* to be valid, but is yet to be proven to be valid.
+        use_internal_node_sequences: (used when tree is of type ``ete3.TreeNode``) If True, then compute
+            the transition cost for sequences assigned to internal nodes. This assumes that internal
+            nodes have a field with name ``sequence``.
+    """
+    if gap_as_char:
+
+        def translate_base(char):
+            return char
+
+    else:
+
+        def translate_base(char):
+            if char == "-":
+                return "N"
+            else:
+                return char
+
+    if isinstance(tree, ete3.TreeNode):
+        adj_arr = _get_adj_array(
+            len(tree.sequence), transition_weights=transition_weights
+        )
+
+        # First pass of Sankoff: compute cost vectors
+        for node in tree.traverse(strategy="postorder"):
+            node.add_feature(
+                "cost_vector",
+                np.array(
+                    [
+                        code_vectors[translate_base(base)].copy()
+                        for base in node.sequence
+                    ]
+                ),
+            )
+            if not node.is_leaf():
+                child_costs = []
+                for child in node.children:
+                    stacked_child_cv = np.stack((child.cost_vector,) * 5, axis=1)
+                    total_cost = adj_arr + stacked_child_cv
+                    child_costs.append(np.min(total_cost, axis=2))
+                child_cost = np.sum(child_costs, axis=0)
+                node.cost_vector = child_cost
+            if use_internal_node_sequences:
+                node.cost_vector += np.array(
+                    [code_vectors[translate_base(base)] for base in node.sequence]
+                )
+        return np.sum(np.min(tree.cost_vector, axis=1))
+
+    elif isinstance(tree, HistoryDag):
+        # squash all duplicated nodes in the unlabeled historydag, since they will get expanded out with new labels.
+        tree.convert_to_collapsed()
+        adj_arr = _get_adj_array(
+            len(next(tree.postorder()).label.sequence),
+            transition_weights=transition_weights,
+        )
+
+        def children_cost(child_cost_vectors):
+            costs = []
+            for c in child_cost_vectors:
+                cost = adj_arr + np.stack((c,) * 5, axis=1)
+                costs.append(np.min(cost, axis=2))
+            return np.sum(costs, axis=0)
+
+        def leaf_func(n):
+            return {
+                "cost_vectors": [
+                    np.array(
+                        [
+                            code_vectors[translate_base(base)].copy()
+                            for base in n.label.sequence
+                        ]
+                    )
+                ],
+                "subtree_cost": 0,
+            }
+
+        def accum_between_clade(clade_data):
+            cost_vectors = []
+            min_cost = float("inf")
+            # iterate over each possible combination of edge choice across clades
+            for choice in product(*clade_data):
+                # compute every possible combination of cost vectors for the given edge choice
+                # (each child node has possibly multiple cost vectors that are all optimal)
+                for cost_vector_combination in product(
+                    *[c._dp_data["cost_vectors"] for c in choice]
+                ):
+                    cv = children_cost(cost_vector_combination)
+                    min_cost = min(min_cost, np.sum(np.min(cv, axis=1)))
+                    if not any([np.array_equal(cv, cv2) for cv2 in cost_vectors]):
+                        cost_vectors.append(cv)
+            return {"cost_vectors": cost_vectors, "subtree_cost": min_cost}
+
+        def accum_between_clade_with_filtering(clade_data):
+            cost_vectors = []
+            min_cost = float("inf")
+            # iterate over each possible combination of edge choice across clades
+            for choice in product(*clade_data):
+                # compute every possible combination of cost vectors for the given edge choice
+                # (each child node has possibly multiple cost vectors that are all optimal)
+                for cost_vector_combination in product(
+                    *[c._dp_data["cost_vectors"] for c in choice]
+                ):
+                    cv = children_cost(cost_vector_combination)
+                    cost = np.sum(np.min(cv, axis=1))
+                    if cost < min_cost:
+                        min_cost = cost
+                        cost_vectors = [cv]
+                    elif cost <= min_cost and not any(
+                        [np.array_equal(cv, other_cv) for other_cv in cost_vectors]
+                    ):
+                        cost_vectors.append(cv)
+            return {"cost_vectors": cost_vectors, "subtree_cost": min_cost}
+
+        if filter_min_score:
+            clade_func = accum_between_clade_with_filtering
+        else:
+            clade_func = accum_between_clade
+
+        tree.postorder_cladetree_accum(
+            leaf_func=leaf_func,
+            edge_func=lambda x, y: y,
+            accum_within_clade=lambda x: x,
+            accum_between_clade=clade_func,
+            accum_above_edge=lambda x, y: y,
+        )
+        return next(tree.preorder(skip_root=True))._dp_data["subtree_cost"]
+    else:
+        return 0
+
+
+def sankoff_downward(
+    dag,
+    compute_cvs=True,
+    gap_as_char=False,
+    transition_weights=None,
+    filter_min_score=True,
+):
+    """Assign sequences to internal nodes of dag using a weighted Sankoff
+    algorithm by exploding all possible labelings associated to each internal
+    node based on its subtrees.
+
+    Args:
+        compute_cvs: If true, compute upward sankoff cost vectors. If ``sankoff_upward`` was
+            already run on the tree/dag, this may be skipped.
+        gap_as_char: if True, the gap character ``-`` will be treated as a fifth character. Otherwise,
+            it will be treated the same as an ``N``.
+        transition_weights: A 5x5 transition weight matrix, with base order `AGCT-`.
+            Rows contain targeting weights. That is, the first row contains the transition weights
+            from `A` to each possible target base. Alternatively, a sequence-length array of these
+            transition weight matrices, if transition weights vary by-site. By default, a constant
+            weight matrix will be used containing 1 in all off-diagonal positions, equivalent
+            to Hamming parsimony.
+        filter_min_score: potentially valid optimization(See :meth:`sankoff_upward`).
+    """
+    # this computes cost vectors for each node in an upward sweep of Sankoff
+    if compute_cvs:
+        sankoff_upward(
+            dag,
+            gap_as_char=gap_as_char,
+            transition_weights=transition_weights,
+            filter_min_score=filter_min_score,
+        )
+
+    # save the field names/types of the label datatype for this dag
+    seq_len = len(next(dag.postorder()).label.sequence)
+    adj_arr = _get_adj_array(seq_len, transition_weights=transition_weights)
+
+    def compute_sequence_data(cost_vector):
+        """Compute all possible sequences that minimize transition costs as given by cost_vector.
+        Returns: a list of tuples, each tuple containing:
+                  - a sequence
+                  - an adjacency array of costs for that sequence, and
+                  - the minimum cost associated to the cost vector
+        """
+        all_base_indices = [[]]
+        min_cost = sum(np.min(cost_vector, axis=1))
+        for idx in range(seq_len):
+            min_cost_indices = np.where(cost_vector[idx] == cost_vector[idx].min())[0]
+            all_base_indices = [
+                base_idx + [i]
+                for base_idx in all_base_indices
+                for i in min_cost_indices
+            ]
+        adj_vec = [
+            adj_arr[np.arange(seq_len), base_indices]
+            for base_indices in all_base_indices
+        ]
+        new_sequence = [
+            "".join([bases[base_index] for base_index in base_indices])
+            for base_indices in all_base_indices
+        ]
+        return list(zip(new_sequence, adj_vec, [min_cost] * len(new_sequence)))
+
+    dag_nodes = {}
+    # downward pass of Sankoff: find and assign sequence labels to each internal node
+    for node in reversed(list(dag.postorder())):
+        if not (node.is_leaf() or node.is_root()):
+            node_data = {k: v for k, v in node._dp_data.items()}
+            node_copies = {}
+            node_children = set(node.children())
+            node_parents = set(node.parents)
+            for p in node_parents:
+                if p.is_root():
+                    new_seq_data = [
+                        y
+                        for cv in node._dp_data["cost_vectors"]
+                        for y in compute_sequence_data(cv)
+                    ]
+                else:
+                    new_seq_data = [
+                        y
+                        for cv in node._dp_data["cost_vectors"]
+                        for y in compute_sequence_data(
+                            cv + p._dp_data["transition_cost"]
+                        )
+                    ]
+
+                # only keep those node/parent/cost_vector choices that
+                # achieve a minimal cost for the node/parent choice
+                min_val = new_seq_data[0][-1]
+                if len(new_seq_data) > 1:
+                    min_val = min(*list(zip(*new_seq_data))[-1])
+
+                for nsd in new_seq_data:
+                    if (nsd[-1] <= min_val) and (nsd[0] not in node_copies):
+                        new_node = node.node_self()
+                        new_node.label = node.label._replace(sequence=nsd[0])
+                        new_node._dp_data = deepcopy(node_data)
+                        new_node._dp_data["transition_cost"] = nsd[1]
+                        node_copies[nsd[0]] = new_node
+
+            for c in node_children:
+                c.parents.remove(node)
+            for p in node_parents:
+                p.remove_edge_by_clade_and_id(node, node.under_clade())
+            # add all new copies of current node(with alt sequence labels) into the dag
+            for new_sequence, new_node in node_copies.items():
+                if new_node in dag_nodes:
+                    tc = new_node._dp_data["transition_cost"]
+                    new_node = dag_nodes[new_node]
+                    new_node._dp_data["transition_cost"] = tc
+                for c in node_children:
+                    new_node.add_edge(c)
+                    c.parents.add(new_node)
+                for parent in node_parents:
+                    parent.add_edge(new_node)
+                new_node.parents.update(node_parents)
+                dag_nodes[new_node] = new_node
+
+    dag.recompute_parents()
+    # still need to trim the dag since the final addition of all
+    # parents/children to new nodes can yield suboptimal choices
+    if transition_weights is not None:
+
+        def weight_func(x, y):
+            return edge_weight_func_from_weight_matrix(x, y, adj_arr[0], bases)
+
+        optimal_weight = dag.trim_optimal_weight(edge_weight_func=weight_func)
+    else:
+        optimal_weight = dag.trim_optimal_weight()
+    return optimal_weight
+
+
+def disambiguate(
+    tree,
+    compute_cvs=True,
+    random_state=None,
+    remove_cvs=False,
+    adj_dist=False,
+    gap_as_char=False,
+    transition_weights=None,
+    min_ambiguities=False,
+):
+    """Randomly resolve ambiguous bases using a two-pass Sankoff Algorithm on
+    subtrees of consecutive ambiguity codes.
+
+    Args:
+        compute_cvs: If true, compute upward sankoff cost vectors. If ``sankoff_upward`` was
+            already run on the tree, this may be skipped.
+        random_state: A ``random`` module random state, returned by ``random.getstate()``. Output
+            from this function is otherwise deterministic.
+        remove_cvs: Remove sankoff cost vectors from tree nodes after disambiguation.
+        adj_dist: Recompute hamming parsimony distances on tree after disambiguation, and store them
+            in ``dist`` node attributes.
+        gap_as_char: if True, the gap character ``-`` will be treated as a fifth character. Otherwise,
+            it will be treated the same as an ``N``.
+        transition_weights: A 5x5 transition weight matrix, with base order `AGCT-`.
+            Rows contain targeting weights. That is, the first row contains the transition weights
+            from `A` to each possible target base. Alternatively, a sequence-length array of these
+            transition weight matrices, if transition weights vary by-site. By default, a constant
+            weight matrix will be used containing 1 in all off-diagonal positions, equivalent
+            to Hamming parsimony.
+        min_ambiguities: If True, leaves ambiguities in reconstructed sequences, expressing which
+            bases are possible at each site in a maximally parsimonious disambiguation of the given
+            topology. In the history DAG paper, this is known as a strictly min-weight ambiguous labeling.
+            Otherwise, sequences are resolved in one possible way, and include no ambiguities.
+    """
+    if random_state is None:
+        random.seed(tree.write(format=1))
+    else:
+        random.setstate(random_state)
+
+    seq_len = len(tree.sequence)
+    adj_arr = _get_adj_array(len(tree.sequence), transition_weights=transition_weights)
+    if compute_cvs:
+        sankoff_upward(tree, gap_as_char=gap_as_char)
+    # Second pass of Sankoff: choose bases
+    preorder = list(tree.traverse(strategy="preorder"))
+    for node in preorder:
+        if min_ambiguities:
+            adj_vec = node.cost_vector != np.stack(
+                (node.cost_vector.min(axis=1),) * 5, axis=1
+            )
+            new_seq = [
+                ambiguous_codes_from_vecs[tuple(map(float, row))] for row in adj_vec
+            ]
+        else:
+            base_indices = []
+            for idx in range(seq_len):
+                min_cost = min(node.cost_vector[idx])
+                base_index = random.choice(
+                    [
+                        i
+                        for i, val in enumerate(node.cost_vector[idx])
+                        if val == min_cost
+                    ]
+                )
+                base_indices.append(base_index)
+
+            adj_vec = adj_arr[np.arange(seq_len), base_indices]
+            new_seq = [bases[base_index] for base_index in base_indices]
+
+        # Adjust child cost vectors
+        for child in node.children:
+            child.cost_vector += adj_vec
+        node.sequence = "".join(new_seq)
+
+    if remove_cvs:
+        for node in tree.traverse():
+            try:
+                node.del_feature("cost_vector")
+            except (AttributeError, KeyError):
+                pass
+    if adj_dist:
+        tree.dist = 0
+        for node in tree.iter_descendants():
+            node.dist = hamming_distance(node.up.sequence, node.sequence)
+    return tree
+
+
+def load_fasta(fastapath):
+    """Load a fasta file as a dictionary, with sequence ids as keys and
+    sequences as values."""
+    fasta_map = {}
+    with open(fastapath, "r") as fh:
+        seqid = None
+        for line in fh:
+            if line[0] == ">":
+                seqid = line[1:].strip()
+                if seqid in fasta_map:
+                    raise ValueError(
+                        "Duplicate records with matching identifier in fasta file"
+                    )
+                else:
+                    fasta_map[seqid] = ""
+            else:
+                if seqid is None and line.strip():
+                    raise ValueError(
+                        "First non-blank line in fasta does not contain identifier"
+                    )
+                else:
+                    fasta_map[seqid] += line.strip().upper()
+    return fasta_map
+
+
+def build_tree(
+    newickstring,
+    fasta_map,
+    newickformat=1,
+    reference_id=None,
+    reference_sequence=None,
+    ignore_internal_sequences=False,
+):
+    """Load an ete tree from a newick string, and add 'sequence' attributes
+    from fasta.
+
+    If internal node sequences aren't specified in the newick string and fasta data,
+    internal node sequences will be fully ambiguous (contain repeated N's).
+
+    Arguments:
+        newickstring: a newick string
+        fasta_map: a dictionary with sequence id keys matching node names in `newickstring`, and sequence values.
+        newickformat: the ete format identifier for the passed newick string. See ete docs
+        reference_id: key in `fasta_map` corresponding to the root sequence of the tree, if root sequence is fixed.
+        reference_sequence: fixed root sequence of the tree, if root sequence is fixed
+        ignore_internal_sequences: if True, sequences at non-leaf nodes specified in fasta_map
+        and newickstring will be ignored, and all internal sequences will be fully ambiguous.
+    """
+    tree = ete3.Tree(newickstring, format=newickformat)
+    # all fasta entries should be same length
+    seq_len = len(next(iter(fasta_map.values())))
+    ambig_seq = "?" * seq_len
+    for node in tree.traverse():
+        if node.is_root() and reference_sequence is not None:
+            node.add_feature("sequence", reference_sequence)
+        elif node.is_root() and reference_id is not None:
+            node.add_feature("sequence", fasta_map[reference_id])
+        elif (not node.is_leaf()) and ignore_internal_sequences:
+            node.add_feature("sequence", ambig_seq)
+        elif node.name in fasta_map:
+            node.add_feature("sequence", fasta_map[node.name])
+        else:
+            node.add_feature("sequence", ambig_seq)
+    return tree
+
+
+def build_trees_from_files(newickfiles, fastafile, **kwargs):
+    """Same as `build_tree`, but takes a list of filenames containing newick
+    strings, and a filename for a fasta file, and returns a generator on
+    trees."""
+    fasta_map = load_fasta(fastafile)
+    for newick in newickfiles:
+        with open(newick, "r") as fh:
+            newick = fh.read()
+        yield build_tree(newick, fasta_map, **kwargs)
+
+
+def parsimony_score(tree):
+    """returns the parsimony score of a (disambiguated) ete tree.
+
+    Tree must have 'sequence' attributes on all nodes.
+    """
+    return sum(
+        hamming_distance(node.up.sequence, node.sequence)
+        for node in tree.iter_descendants()
+    )
+
+
+def remove_invariant_sites(fasta_map):
+    """Eliminate invariant characters in a fasta alignment and record the
+    0-based indices of those variant sites."""
+    # eliminate characters for which there's no diversity:
+    informative_sites = [
+        idx for idx, chars in enumerate(zip(*fasta_map.values())) if len(set(chars)) > 1
+    ]
+    newfasta = {
+        key: "".join(oldseq[idx] for idx in informative_sites)
+        for key, oldseq in fasta_map.items()
+    }
+    return newfasta, informative_sites
+
+
+def parsimony_scores_from_topologies(
+    newicks, fasta_map, gap_as_char=False, remove_invariants=False, **kwargs
+):
+    """returns a generator on parsimony scores of trees specified by newick
+    strings and fasta. additional keyword arguments are passed to `build_tree`.
+
+    Args:
+        newicks: newick strings of trees whose parsimony scores will be computed
+        fasta_map: fasta data as a dictionary, as output by ``load_fasta``
+        gap_as_char: if True, gap characters `-` will be treated as a fifth character.
+            Otherwise, they will be synonymous with `N`'s.
+        remove_invariants: if True, removes invariant sites from the provided fasta_map
+    """
+    if remove_invariants:
+        print("removing invariant sites...")
+        newfasta = remove_invariant_sites(fasta_map)
+        print("...finished removing invariant sites")
+    else:
+        newfasta = fasta_map
+    yield from (
+        sankoff_upward(build_tree(newick, newfasta, **kwargs), gap_as_char=gap_as_char)
+        for newick in newicks
+    )
+
+
+def parsimony_scores_from_files(treefiles, fastafile, **kwargs):
+    """returns the parsimony scores of trees specified by newick files and a
+    fasta file.
+
+    Arguments match `build_trees_from_files`. Additional keyword
+    arguments are passed to ``parsimony_scores_from_topologies``.
+    """
+
+    def load_newick(npath):
+        with open(npath, "r") as fh:
+            return fh.read()
+
+    return parsimony_scores_from_topologies(
+        (load_newick(path) for path in treefiles), load_fasta(fastafile), **kwargs
+    )
+
+
+def build_dag_from_trees(trees):
+    """Build a history DAG from trees containing a `sequence` attribute on all
+    nodes.
+
+    unifurcations in the provided trees will be deleted.
+    """
+    trees = [tree.copy() for tree in trees]
+    for tree in trees:
+        for node in tree.iter_descendants():
+            if len(node.children) == 1:
+                node.delete(prevent_nondicotomic=False)
+        if len(tree.children) == 1:
+            newchild = tree.add_child()
+            newchild.add_feature("sequence", tree.sequence)
+    return history_dag_from_etes(
+        trees,
+        ["sequence"],
+    )
+
+
+def summarize_dag(dag):
+    """print summary information about the provided history DAG."""
+    print("DAG contains")
+    print("trees: ", dag.count_trees())
+    print("nodes: ", len(list(dag.preorder())))
+    print("edges: ", sum(len(list(node.children())) for node in dag.preorder()))
+    print("parsimony scores: ", dag.weight_count())
+
+
+def disambiguate_history(history):
+    """A rather ugly way to disambiguate a history, by converting to ete, using
+    the disambiguate method, then converting back to HistoryDag."""
+    seq_len = len(next(history.get_leaves()).label.sequence)
+    ambig_seq = "N" * seq_len
+    etetree = history.to_ete(
+        feature_funcs={
+            "sequence": (lambda n: n.label.sequence if n.is_leaf() else ambig_seq)
+        }
+    )
+    disambiguate(etetree, min_ambiguities=True)
+    rhistory = history_dag_from_etes([etetree], ["sequence"])
+    return rhistory
+
+
+def treewise_sankoff_in_dag(dag, cover_edges=False):
+    """Perform tree-wise sankoff to compute labels for all nodes in the DAG."""
+    newdag = history_dag_from_clade_trees(
+        disambiguate_history(history)
+        for history in dag.iter_covering_histories(cover_edges=cover_edges)
+    )
+    newdag.explode_nodes()
+    newdag.add_all_allowed_edges()
+    newdag.trim_optimal_weight()
+    newdag.convert_to_collapsed()
+    return newdag

--- a/historydag/sankoff_cli.py
+++ b/historydag/sankoff_cli.py
@@ -1,0 +1,216 @@
+import parsimony as pars
+import click
+import pickle
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+def _cli():
+    """A collection of tools for calculating parsimony scores of newick trees,
+    and using them to create a history DAG."""
+    pass
+
+
+@_cli.command("remove-invariants")
+@click.argument("in_fasta")
+@click.argument("out_fasta")
+@click.argument("out_variant_sites")
+def _cli_remove_invariant_sites(in_fasta, out_fasta, out_variant_sites):
+    fasta_map = pars.load_fasta(in_fasta)
+    newfasta, variant_sites = pars.remove_invariant_sites(fasta_map)
+    with open(out_fasta, "w") as fh:
+        for seqid, seq in newfasta.items():
+            print(">" + seqid, file=fh)
+            print(seq, file=fh)
+    with open(out_variant_sites, "w") as fh:
+        print(",".join([str(site) for site in variant_sites]), file=fh)
+
+
+@_cli.command("build-trees")
+@click.argument("treefiles", nargs=-1)
+@click.option(
+    "-f",
+    "--fasta-file",
+    required=True,
+    help="Filename of a fasta file containing sequences appearing on nodes of newick tree",
+)
+@click.option(
+    "-r",
+    "--root-id",
+    default=None,
+    help="The fasta identifier of the fixed root of provided trees. May be omitted if there is no fixed root sequence.",
+)
+@click.option(
+    "-F",
+    "--newick-format",
+    default=1,
+    help=(
+        "Newick format of the provided newick file. See "
+        "http://etetoolkit.org/docs/latest/reference/reference_tree.html#ete3.TreeNode"
+    ),
+)
+@click.option(
+    "-i",
+    "--include-internal-sequences",
+    is_flag=True,
+    help="include non-leaf node labels, and associated sequences in the fasta file.",
+)
+@click.option(
+    "-g",
+    "--gap-as-char",
+    is_flag=True,
+    help="Treat gap character `-` as a fifth character. Otherwise treated as ambiguous `N`.",
+)
+@click.option(
+    "-a",
+    "--preserve-ambiguities",
+    is_flag=True,
+    help=(
+        "Do not disambiguate fully, but rather preserve ambiguities to express "
+        "all maximally parsimonious assignments at each site."
+    ),
+)
+@click.option(
+    "-o", "--outdir", default=".", help="Directory in which to write pickled trees."
+)
+@click.option(
+    "-c",
+    "--clean-trees",
+    is_flag=True,
+    help="remove cost vectors from tree, resulting in smaller pickled tree files",
+)
+def _cli_build_trees(
+    treefiles,
+    fasta_file,
+    root_id,
+    newick_format,
+    include_internal_sequences,
+    gap_as_char,
+    preserve_ambiguities,
+    outdir,
+    clean_trees,
+):
+    trees = pars.build_trees_from_files(
+        treefiles,
+        fasta_file,
+        reference_id=root_id,
+        ignore_internal_sequences=(not include_internal_sequences),
+    )
+    trees = (
+        pars.disambiguate(
+            tree,
+            gap_as_char=gap_as_char,
+            min_ambiguities=preserve_ambiguities,
+            remove_cvs=clean_trees,
+        )
+        for tree in trees
+    )
+    for treefile, tree in zip(treefiles, trees):
+        print("saving tree")
+        with open(outdir + f"tree_{treefile.split('/')[-1]}.p", "wb") as fh:
+            fh.write(pickle.dumps(tree))
+        print("saved tree")
+
+
+@_cli.command("parsimony_scores")
+@click.argument("treefiles", nargs=-1)
+@click.option(
+    "-f",
+    "--fasta-file",
+    required=True,
+    help="Filename of a fasta file containing sequences appearing on nodes of newick tree",
+)
+@click.option(
+    "-r",
+    "--root-id",
+    default=None,
+    help="The fasta identifier of the fixed root of provided trees. May be omitted if there is no fixed root sequence.",
+)
+@click.option(
+    "-F",
+    "--newick-format",
+    default=1,
+    help=(
+        "Newick format of the provided newick file. See "
+        "http://etetoolkit.org/docs/latest/reference/reference_tree.html#ete3.TreeNode"
+    ),
+)
+@click.option(
+    "-i",
+    "--include-internal-sequences",
+    is_flag=True,
+    help="include non-leaf node labels, and associated sequences in the fasta file.",
+)
+@click.option(
+    "-d",
+    "--save-to-dag",
+    default=None,
+    help="Combine loaded and disambiguated trees into a history DAG, and save pickled DAG to provided path.",
+)
+@click.option(
+    "-g",
+    "--gap-as-char",
+    is_flag=True,
+    help="Treat gap character `-` as a fifth character. Otherwise treated as ambiguous `N`.",
+)
+@click.option(
+    "-a",
+    "--preserve-ambiguities",
+    is_flag=True,
+    help=(
+        "Do not disambiguate fully, but rather preserve ambiguities to express "
+        "all maximally parsimonious assignments at each site."
+    ),
+)
+def _cli_parsimony_score_from_files(
+    treefiles,
+    fasta_file,
+    root_id,
+    newick_format,
+    include_internal_sequences,
+    save_to_dag,
+    gap_as_char,
+    preserve_ambiguities,
+):
+    """Print the parsimony score of one or more newick files."""
+    pscore_gen = pars.parsimony_scores_from_files(
+        treefiles,
+        fasta_file,
+        reference_id=root_id,
+        gap_as_char=gap_as_char,
+        ignore_internal_sequences=(not include_internal_sequences),
+        remove_invariants=True,
+    )
+
+    for score, treepath in zip(pscore_gen, treefiles):
+        print(treepath)
+        print(score)
+
+    if save_to_dag is not None:
+        trees = pars.build_trees_from_files(
+            treefiles,
+            fasta_file,
+            reference_id=root_id,
+            ignore_internal_sequences=(not include_internal_sequences),
+        )
+        trees = (
+            pars.disambiguate(
+                tree, gap_as_char=gap_as_char, min_ambiguities=preserve_ambiguities
+            )
+            for tree in trees
+        )
+        dag = pars.build_dag_from_trees(trees)
+        with open(save_to_dag, "wb") as fh:
+            fh.write(pickle.dumps(dag))
+
+
+@_cli.command("summarize-dag")
+@click.argument("dagpath")
+def _cli_summarize_dag(dagpath):
+    """print summary information about the provided history DAG."""
+    with open(dagpath, "rb") as fh:
+        dag = pickle.load(fh)
+    pars.summarize_dag(dag)
+
+
+if __name__ == "__main__":
+    _cli()

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -55,6 +55,7 @@ for tree in trees:
 def test_fulltree():
     dag = hdag.history_dag_from_etes([etetree], ["sequence"])
     dag.convert_to_collapsed()
+    dag._check_valid()
     assert set(deterministic_newick(tree.to_ete()) for tree in dag.get_trees()) == set(
         {deterministic_newick(etetree2)}
     )
@@ -63,6 +64,7 @@ def test_fulltree():
 def test_twotrees():
     dag = hdag.history_dag_from_etes([etetree, etetree2], ["sequence"])
     dag.convert_to_collapsed()
+    dag._check_valid()
     assert dag.count_trees() == 1
     assert {deterministic_newick(tree.to_ete()) for tree in dag.get_trees()} == {
         deterministic_newick(etetree2)
@@ -75,10 +77,12 @@ def test_collapse():
     uncollapsed_dag.convert_to_collapsed()
     allcollapsedtrees = [utils.collapse_adjacent_sequences(tree) for tree in trees]
     collapsed_dag = hdag.history_dag_from_etes(allcollapsedtrees, ["sequence"])
+    collapsed_dag._check_valid()
     maybecollapsedtrees = [tree.to_ete() for tree in uncollapsed_dag.get_trees()]
     assert all(utils.is_collapsed(tree) for tree in maybecollapsedtrees)
     n_before = uncollapsed_dag.count_trees()
     uncollapsed_dag.merge(collapsed_dag)
+    uncollapsed_dag._check_valid()
     assert n_before == uncollapsed_dag.count_trees()
 
 
@@ -86,14 +90,18 @@ def test_add_allowed_edges():
     # See that adding only edges that preserve parent labels preserves parsimony
     dag = hdag.history_dag_from_etes(trees, ["sequence"])
     dag.add_all_allowed_edges(preserve_parent_labels=True)
+    dag._check_valid()
     c = dag.weight_count()
     assert min(c) == max(c)
 
     # See that adding only edges between nodes with different labels preserves collapse
     allcollapsedtrees = [collapse_adjacent_sequences(tree) for tree in trees]
     collapsed_dag = hdag.history_dag_from_etes(allcollapsedtrees, ["sequence"])
+    collapsed_dag._check_valid()
     collapsed_dag.convert_to_collapsed()
+    collapsed_dag._check_valid()
     collapsed_dag.add_all_allowed_edges(adjacent_labels=False)
+    collapsed_dag._check_valid()
     assert all(
         parent.label != target.label
         for parent in collapsed_dag.postorder()

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -1,0 +1,137 @@
+import pickle
+import numpy as np
+import historydag as hdag
+import historydag.parsimony as dag_parsimony
+
+
+def compare_dag_and_tree_parsimonies(
+    dag, transition_weights=None, filter_min_score=True
+):
+    dag.recompute_parents()
+    dag.convert_to_collapsed()
+
+    # extract sample tree
+    s = dag.sample()
+    # convert to ete3.Tree format
+    s_ete = s.to_ete()
+
+    # compute cost vectors for sample tree in dag and in ete3.Tree format to compare
+    a = dag_parsimony.sankoff_upward(
+        s, transition_weights=transition_weights, filter_min_score=filter_min_score
+    )
+    b = dag_parsimony.sankoff_upward(s_ete, transition_weights=transition_weights)
+    assert (
+        a == b
+    ), "Upward Sankoff on ete_Tree vs on the dag version of the tree produced different results"
+
+    # calculate sequences for internal nodes using Sankoff for both formats of sample tree
+    s_weight = dag_parsimony.sankoff_downward(
+        s,
+        compute_cvs=False,
+        transition_weights=transition_weights,
+        filter_min_score=filter_min_score,
+    )
+    s_ete = dag_parsimony.disambiguate(
+        s_ete, compute_cvs=False, transition_weights=transition_weights
+    )
+    # convert ete3.Tree back to a HistoryDag object so as to compare, but keeping the data calculated using ete3 structure
+    s_ete_as_dag = hdag.history_dag_from_etes([s_ete], label_features=["sequence"])
+
+    # parsimony score depends on the choice of `transition_weights` arg
+    if transition_weights is not None:
+
+        def weight_func(x, y):
+            return dag_parsimony.edge_weight_func_from_weight_matrix(
+                x, y, transition_weights, dag_parsimony.bases
+            )
+
+        s_ete_weight = s_ete_as_dag.optimal_weight_annotate(
+            edge_weight_func=weight_func
+        )
+    else:
+        s_ete_weight = s_ete_as_dag.optimal_weight_annotate()
+    assert (
+        s_weight == s_ete_weight
+    ), "Downward sankoff on ete_Tree vs on the dag version of the tree produced different results"
+
+    s_labels = set(n.label.sequence for n in s.postorder() if not n.is_root())
+    s_ete_labels = set(
+        n.label.sequence for n in s_ete_as_dag.postorder() if not n.is_root()
+    )
+    assert (
+        len(s_ete_labels - s_labels) < 1
+    ), "DAG Sankoff missed a label that occurs in the tree Sankoff."
+
+
+def check_sankoff_on_dag(
+    dag, expected_score, transition_weights=None, filter_min_score=True
+):
+    # perform upward sweep of sankoff to calculate overall parsimony score and assign cost vectors to internal nodes
+    upward_pass_min_cost = dag_parsimony.sankoff_upward(
+        dag, transition_weights=transition_weights, filter_min_score=filter_min_score
+    )
+    assert np.isclose(
+        [upward_pass_min_cost], [expected_score]
+    ), "Upward pass of Sankoff on dag did not yield expected score"
+
+    # perform downward sweep of sankoff to calculate all possible internal node sequences.
+    downward_pass_min_cost = dag_parsimony.sankoff_downward(
+        dag,
+        transition_weights=transition_weights,
+        filter_min_score=filter_min_score,
+        compute_cvs=False,
+    )
+    dag._check_valid()
+    assert np.isclose(
+        [downward_pass_min_cost], [expected_score]
+    ), "Downward pass of Sankoff on dag did not yield expected score"
+
+    assert (
+        dag.count_trees() == dag.copy().count_trees()
+    ), "Resulting DAG had invalid internal node assignments"
+
+
+def test_sankoff_on_dag():
+    with open("sample_data/toy_trees.p", "rb") as f:
+        ete_trees = pickle.load(f)
+    dg = hdag.history_dag_from_etes(ete_trees, ["sequence"])
+
+    tw_options = [
+        (75, None),
+        (
+            93,
+            np.array(
+                [
+                    [0, 1, 2.5, 1, 1],
+                    [1, 0, 1, 2.5, 1],
+                    [2.5, 1, 0, 1, 1],
+                    [1, 2.5, 1, 0, 1],
+                    [1, 1, 1, 1, 0],
+                ]
+            ),
+        ),
+        (
+            106,
+            np.array(
+                [
+                    [0, 1, 5, 1, 1],
+                    [1, 0, 1, 5, 1],
+                    [5, 1, 0, 1, 1],
+                    [1, 5, 1, 0, 1],
+                    [1, 1, 1, 1, 0],
+                ]
+            ),
+        ),
+    ]
+
+    for (w, tw) in tw_options:
+        check_sankoff_on_dag(
+            dg.copy(), w, transition_weights=tw, filter_min_score=False
+        )
+        check_sankoff_on_dag(dg.copy(), w, transition_weights=tw, filter_min_score=True)
+        compare_dag_and_tree_parsimonies(
+            dg.copy(), transition_weights=tw, filter_min_score=False
+        )
+        compare_dag_and_tree_parsimonies(
+            dg.copy(), transition_weights=tw, filter_min_score=True
+        )

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -197,6 +197,7 @@ def test_expand_ambiguities():
         cdag.explode_nodes()
         print(cdag.count_trees())
         cdag.trim_optimal_weight()
+        cdag._check_valid()
         print(cdag.count_trees())
         print(cdag.weight_count())
         checkset = {

--- a/tests/test_edgeset.py
+++ b/tests/test_edgeset.py
@@ -11,12 +11,14 @@ def test_init():
     tree1 = ete3.Tree(newickstring2, format=1)
     dag1 = from_tree(tree1, ["sequence"])
     EdgeSet()
-    EdgeSet([dag.dagroot])
+    e = EdgeSet([dag.dagroot])
+    for edge in e:
+        print(e)
     EdgeSet([dag.dagroot], probs=[0.5])
     try:
         EdgeSet([dag.dagroot, dag1.dagroot])
         raise TypeError("EdgeSet init is allowing identical dags to be added")
-    except TypeError:
+    except (TypeError, ValueError):
         pass
     try:
         EdgeSet([dag.dagroot], [dag1.dagroot])
@@ -33,6 +35,11 @@ def test_iter():
     e2 = EdgeSet([next(dag.dagroot.children()), next(dag1.dagroot.children())])
     for target, weight, prob in e2:
         pass
+    for node in (dag | dag1).preorder():
+        for clade, eset in node.clades.items():
+            assert len(eset.targets) == len(eset.probs) and len(eset.probs) == len(
+                eset.weights
+            )
 
 
 def test_copy():

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -2,8 +2,18 @@ import ete3
 import pickle
 import historydag.dag as hdag
 import historydag.utils as dagutils
-from collections import Counter
+from collections import Counter, namedtuple
 import pytest
+import random
+
+
+def normalize_counts(counter):
+    n = len(list(counter.elements()))
+    return ([num / n for _, num in counter.items()], (n / len(counter)) / n)
+
+
+def is_close(f1, f2, tol=0.03):
+    return abs(f1 - f2) < tol
 
 
 def deterministic_newick(tree: ete3.TreeNode) -> str:
@@ -96,6 +106,8 @@ def _testfactory(resultfunc, verify_func, collapse_invariant=False, accum_func=C
 
 def test_valid_dags():
     for dag in dags + cdags:
+        dag._check_valid()
+        dag.copy()._check_valid()
         # each edge is allowed:
         for node in dag.postorder():
             for clade in node.clades:
@@ -336,3 +348,110 @@ def test_indexing_comprehensive():
         assert set(history_dag.to_newicks()) == set(
             {tree.to_newick() for tree in history_dag}
         )
+
+
+def test_trim():
+    for dag in dags + cdags:
+        dag = dag.copy()
+        dag.add_all_allowed_edges()
+        dag._check_valid()
+        dag.recompute_parents()
+        dag._check_valid()
+        dag.trim_optimal_weight()
+        dag._check_valid()
+        dag.convert_to_collapsed()
+        dag._check_valid()
+
+
+def test_from_nodes():
+    for dag in dags + cdags:
+        cdag = dag.copy()
+        cdag.add_all_allowed_edges()
+        cdag.trim_optimal_weight()
+        cdag._check_valid()
+        wc = cdag.weight_count()
+        ndag = hdag.history_dag_from_nodes(cdag.preorder())
+        ndag._check_valid()
+        ndag.trim_optimal_weight()
+        ndag._check_valid()
+        print(ndag.to_graphviz())
+        assert wc == ndag.weight_count()
+
+
+def test_sample_with_node():
+    random.seed(1)
+    dag = dags[-1]
+    dag.make_uniform()
+    node_to_count = dag.count_nodes()
+    min_count = min(node_to_count.values())
+    least_supported_nodes = [
+        node for node, val in node_to_count.items() if val == min_count
+    ]
+    for node in least_supported_nodes:
+        tree_samples = [dag.sample_with_node(node) for _ in range(min_count * 5)]
+        tree_samples[0]._check_valid()
+        tree_newicks = {tree.to_newick() for tree in tree_samples}
+        # We sampled all trees possible containing the node
+        assert len(tree_newicks) == min_count
+        # All trees sampled contained the node
+        assert all(node in set(tree.preorder()) for tree in tree_samples)
+        # # trees containing the node were sampled uniformly
+        # # (This is slow but seems to work)
+        # norms, avg = normalize_counts(Counter(tree.to_newick() for tree in tree_samples))
+        # print(norms)
+        # assert all(is_close(norm, avg) for norm in norms)
+
+
+def test_sample_with_edge():
+    random.seed(1)
+    dag = dags[-1]
+    dag.recompute_parents()
+    node_to_count = dag.count_nodes()
+    min_count = min(node_to_count.values())
+    least_supported_nodes = [
+        node for node, val in node_to_count.items() if val == min_count
+    ]
+    node = least_supported_nodes[0]
+
+    def edges(dag):
+        eset = set()
+        for node in dag.preorder():
+            for child in node.children():
+                eset.add((node, child))
+        return eset
+
+    for parent in node.parents:
+        edge = (parent, node)
+        tree_samples = [dag.sample_with_edge(edge) for _ in range(min_count * 5)]
+        tree_samples[0]._check_valid()
+        # We sampled all trees possible containing the node
+        # All trees sampled contained the node
+        assert all(edge in edges(tree) for tree in tree_samples)
+
+
+def test_iter_covering_histories():
+    for dag in dags + cdags:
+        codag = dag.copy()
+        codag.add_all_allowed_edges()
+        trees = list(dag.iter_covering_histories())
+        tdag = trees[0] | trees
+        tdag.add_all_allowed_edges()
+        assert tdag.weight_count() == codag.weight_count()
+
+
+def test_iter_covering_histories_edges():
+    for dag in dags + cdags:
+        trees = list(dag.iter_covering_histories(cover_edges=True))
+        tdag = trees[0] | trees
+        assert tdag.weight_count() == dag.weight_count()
+        assert set(tdag.to_newicks()) == set(dag.to_newicks())
+
+
+def test_relabel():
+    dag = dags[-1]
+    Label = namedtuple("Label", ["sequence", "newthing"])
+    ndag = dag.relabel(lambda n: Label(n.label.sequence, len(list(n.children()))))
+    Label = namedtuple("Label", ["sequence"])
+    odag = ndag.relabel(lambda n: Label(n.label.sequence))
+    odag._check_valid()
+    assert dag.weight_count() == odag.weight_count()

--- a/tests/test_historydag.py
+++ b/tests/test_historydag.py
@@ -90,6 +90,7 @@ def test_from_tree():
     tree = ete3.Tree(newickstring2, format=1)
     print(tree.sequence)
     dag = from_tree(tree, ["sequence"])
+    dag._check_valid()
     G = dag.to_graphviz(namedict=namedict)
     return G
 
@@ -98,6 +99,7 @@ def test_is_clade_tree():
     tree = ete3.Tree(newickstring2, format=1)
     print(tree.sequence)
     dag = from_tree(tree, ["sequence"])
+    dag._check_valid()
     assert dag.is_clade_tree()
 
 
@@ -110,6 +112,7 @@ def test_from_tree_label():
         ["sequence", "abundance"],
         label_functions={"abundance2x": lambda n: 2 * n.abundance},
     )
+    dag._check_valid()
 
 
 def test_preserve_attr():
@@ -119,6 +122,7 @@ def test_preserve_attr():
         ["sequence"],
         attr_func=lambda n: n.name,
     )
+    dag._check_valid()
     assert all(n.attr for n in dag.preorder(skip_root=True))
 
     @utils.explode_label("sequence")
@@ -131,8 +135,10 @@ def test_preserve_attr():
             yield seq
 
     dag.explode_nodes(expand_func=expand_func)
+    dag._check_valid()
     assert all(n.attr for n in dag.preorder(skip_root=True))
     dag.convert_to_collapsed()
+    dag._check_valid()
     assert all(n.attr for n in dag.preorder(skip_root=True))
 
 
@@ -232,6 +238,7 @@ def test_sample():
     for i in range(10):
         assert dag.sample().is_clade_tree()
     sample = dag.sample()
+    sample._check_valid()
     return sample.to_graphviz(namedict=namedict)
 
 
@@ -332,6 +339,7 @@ def test_make_uniform():
     )
     take1 = Counter([dag.sample().to_newick() for _ in range(1000)])
     dag.make_uniform()
+    dag._check_valid()
     take2 = Counter([dag.sample().to_newick() for _ in range(1000)])
 
     take1norms, avg1 = normalize_counts(take1)


### PR DESCRIPTION
Includes all work from `node-utils` branch:

Adds lots of new features, especially history sampling conditional on inclusion of an edge or node, and the ability to iterate through a list of histories which cover all the nodes or edges in the history DAG.

Also adds the ability to build a complete history DAG from a collection of nodes, and to change the labels on all nodes of the DAG according to an arbitrary function, as long as that function is injective on leaf nodes.

In utils.py, a simple function to load a fasta file, and a version of wrapped_hamming_distance which allows leaf node sequences to contain ambiguities.

In parsimony.py, utilities (subject to change) for performing sankoff on a tree and doing tree-wise disambiguation of the DAG, as well as Sankoff directly on the DAG (from @marybarker)