### PR TITLE
Sankoff filtering cleanup

### DIFF
--- a/historydag/parsimony.py
+++ b/historydag/parsimony.py
@@ -198,7 +198,7 @@ def sankoff_upward(
 
         def accum_between_clade_with_filtering(clade_data):
             cost_vectors = []
-            min_cost = float("inf") * np.ones((seq_len,))
+            min_cost = float("inf")
             # iterate over each possible combination of edge choice across clades
             for choice in product(*clade_data):
                 # compute every possible combination of cost vectors for the given edge choice
@@ -207,15 +207,15 @@ def sankoff_upward(
                     *[c._dp_data["cost_vectors"] for c in choice]
                 ):
                     cv = children_cost(cost_vector_combination)
-                    cost = np.min(cv, axis=1)
-                    if any(cost < min_cost):
-                        min_cost = np.minimum(cost, min_cost)
+                    cost = np.sum(np.min(cv, axis=1))
+                    if cost < min_cost:
+                        min_cost = cost
                         cost_vectors = [cv]
-                    elif all(cost <= min_cost) and not any(
+                    elif cost <= min_cost and not any(
                         [np.array_equal(cv, other_cv) for other_cv in cost_vectors]
                     ):
                         cost_vectors.append(cv)
-            return {"cost_vectors": cost_vectors, "subtree_cost": np.sum(min_cost)}
+            return {"cost_vectors": cost_vectors, "subtree_cost": min_cost}
 
         compute_val = tree.postorder_history_accum(
             leaf_func=leaf_func,

--- a/historydag/parsimony.py
+++ b/historydag/parsimony.py
@@ -122,9 +122,7 @@ def sankoff_upward(
 
     if isinstance(tree, ete3.TreeNode):
         seq_len = len(next(tree.iter_leaves()).sequence)
-        adj_arr = _get_adj_array(
-            seq_len, transition_weights=transition_weights
-        )
+        adj_arr = _get_adj_array(seq_len, transition_weights=transition_weights)
 
         # First pass of Sankoff: compute cost vectors
         for node in tree.traverse(strategy="postorder"):
@@ -158,7 +156,8 @@ def sankoff_upward(
                 seq_len = len(n.label.sequence)
                 break
         adj_arr = _get_adj_array(
-            seq_len, transition_weights=transition_weights,
+            seq_len,
+            transition_weights=transition_weights,
         )
 
         def children_cost(child_cost_vectors):
@@ -199,7 +198,7 @@ def sankoff_upward(
 
         def accum_between_clade_with_filtering(clade_data):
             cost_vectors = []
-            min_cost = float("inf")*np.ones((seq_len,))
+            min_cost = float("inf") * np.ones((seq_len,))
             # iterate over each possible combination of edge choice across clades
             for choice in product(*clade_data):
                 # compute every possible combination of cost vectors for the given edge choice
@@ -354,6 +353,7 @@ def sankoff_downward(
     # still need to trim the dag since the final addition of all
     # parents/children to new nodes can yield suboptimal choices
     if transition_weights is not None:
+
         def weight_func(x, y):
             return edge_weight_func_from_weight_matrix(x, y, adj_arr[0], bases)
 

--- a/historydag/parsimony.py
+++ b/historydag/parsimony.py
@@ -199,7 +199,7 @@ def sankoff_upward(
 
         def accum_between_clade_with_filtering(clade_data):
             cost_vectors = []
-            min_cost = float("inf")
+            min_cost = float("inf")*np.ones((seq_len,))
             # iterate over each possible combination of edge choice across clades
             for choice in product(*clade_data):
                 # compute every possible combination of cost vectors for the given edge choice
@@ -208,15 +208,15 @@ def sankoff_upward(
                     *[c._dp_data["cost_vectors"] for c in choice]
                 ):
                     cv = children_cost(cost_vector_combination)
-                    cost = np.sum(np.min(cv, axis=1))
-                    if cost < min_cost:
-                        min_cost = cost
+                    cost = np.min(cv, axis=1)
+                    if any(cost < min_cost):
+                        min_cost = np.minimum(cost, min_cost)
                         cost_vectors = [cv]
-                    elif cost <= min_cost and not any(
+                    elif all(cost <= min_cost) and not any(
                         [np.array_equal(cv, other_cv) for other_cv in cost_vectors]
                     ):
                         cost_vectors.append(cv)
-            return {"cost_vectors": cost_vectors, "subtree_cost": min_cost}
+            return {"cost_vectors": cost_vectors, "subtree_cost": np.sum(min_cost)}
 
         compute_val = tree.postorder_history_accum(
             leaf_func=leaf_func,

--- a/historydag/parsimony.py
+++ b/historydag/parsimony.py
@@ -89,7 +89,6 @@ def sankoff_upward(
     tree,
     gap_as_char=False,
     transition_weights=None,
-    filter_min_score=True,
     use_internal_node_sequences=False,
 ):
     """Compute Sankoff cost vectors at nodes in a postorder traversal, and
@@ -104,9 +103,6 @@ def sankoff_upward(
             transition weight matrices, if transition weights vary by-site. By default, a constant
             weight matrix will be used containing 1 in all off-diagonal positions, equivalent
             to Hamming parsimony.
-        filter_min_score: (used when tree is of type ``HistoryDag``) if True, then discard any cost
-            vectors that do not minimize subtree cost. Otherwise, keep all possible cost vectors at all
-            nodes. This is an optimization that *seems* to be valid, but is yet to be proven to be valid.
         use_internal_node_sequences: (used when tree is of type ``ete3.TreeNode``) If True, then compute
             the transition cost for sequences assigned to internal nodes. This assumes that internal
             nodes have a field with name ``sequence``.
@@ -222,19 +218,14 @@ def sankoff_upward(
                         cost_vectors.append(cv)
             return {"cost_vectors": cost_vectors, "subtree_cost": min_cost}
 
-        if filter_min_score:
-            clade_func = accum_between_clade_with_filtering
-        else:
-            clade_func = accum_between_clade
-
-        tree.postorder_history_accum(
+        compute_val = tree.postorder_history_accum(
             leaf_func=leaf_func,
             edge_func=lambda x, y: y,
             accum_within_clade=lambda x: x,
-            accum_between_clade=clade_func,
+            accum_between_clade=accum_between_clade_with_filtering,
             accum_above_edge=lambda x, y: y,
         )
-        return next(tree.preorder(skip_ua_node=True))._dp_data["subtree_cost"]
+        return compute_val["subtree_cost"]
     else:
         return 0
 
@@ -244,7 +235,6 @@ def sankoff_downward(
     compute_cvs=True,
     gap_as_char=False,
     transition_weights=None,
-    filter_min_score=True,
 ):
     """Assign sequences to internal nodes of dag using a weighted Sankoff
     algorithm by exploding all possible labelings associated to each internal
@@ -261,7 +251,6 @@ def sankoff_downward(
             transition weight matrices, if transition weights vary by-site. By default, a constant
             weight matrix will be used containing 1 in all off-diagonal positions, equivalent
             to Hamming parsimony.
-        filter_min_score: potentially valid optimization(See :meth:`sankoff_upward`).
     """
     # this computes cost vectors for each node in an upward sweep of Sankoff
     if compute_cvs:
@@ -269,7 +258,6 @@ def sankoff_downward(
             dag,
             gap_as_char=gap_as_char,
             transition_weights=transition_weights,
-            filter_min_score=filter_min_score,
         )
 
     # save the field names/types of the label datatype for this dag

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -15,9 +15,10 @@ def compare_dag_and_tree_parsimonies(dag, transition_weights=None):
     # compute cost vectors for sample tree in dag and in ete3.Tree format to compare
     a = dag_parsimony.sankoff_upward(s, transition_weights=transition_weights)
     b = dag_parsimony.sankoff_upward(s_ete, transition_weights=transition_weights)
-    assert (
-        a == b
-    ), "Upward Sankoff on ete_Tree vs on the dag version of the tree produced different results: %lf from the dag and %lf from the ete_Tree"%(a, b)
+    assert a == b, (
+        "Upward Sankoff on ete_Tree vs on the dag version of the tree produced different results: "
+        + "%lf from the dag and %lf from the ete_Tree" % (a, b)
+    )
 
     # calculate sequences for internal nodes using Sankoff for both formats of sample tree
     s_weight = dag_parsimony.sankoff_downward(
@@ -44,9 +45,10 @@ def compare_dag_and_tree_parsimonies(dag, transition_weights=None):
         )
     else:
         s_ete_weight = s_ete_as_dag.optimal_weight_annotate()
-    assert (
-        s_weight == s_ete_weight
-    ), "Downward sankoff on ete_Tree vs on the dag version of the tree produced different results: %lf from the dag and %lf from the ete_Tree"%(s_weight, s_ete_weight)
+    assert s_weight == s_ete_weight, (
+        "Downward sankoff on ete_Tree vs on the dag version of the tree produced different results: "
+        + "%lf from the dag and %lf from the ete_Tree" % (s_weight, s_ete_weight)
+    )
 
     s_labels = set(n.label.sequence for n in s.postorder() if not n.is_ua_node())
     s_ete_labels = set(
@@ -62,9 +64,10 @@ def check_sankoff_on_dag(dag, expected_score, transition_weights=None):
     upward_pass_min_cost = dag_parsimony.sankoff_upward(
         dag, transition_weights=transition_weights
     )
-    assert np.isclose(
-        [upward_pass_min_cost], [expected_score]
-    ), "Upward pass of Sankoff on dag did not yield expected score: computed %lf, but expected %lf"%(upward_pass_min_cost, expected_score)
+    assert np.isclose([upward_pass_min_cost], [expected_score]), (
+        "Upward pass of Sankoff on dag did not yield expected score: computed %lf, but expected %lf"
+        % (upward_pass_min_cost, expected_score)
+    )
 
     # perform downward sweep of sankoff to calculate all possible internal node sequences.
     downward_pass_min_cost = dag_parsimony.sankoff_downward(
@@ -73,9 +76,10 @@ def check_sankoff_on_dag(dag, expected_score, transition_weights=None):
         compute_cvs=False,
     )
     dag._check_valid()
-    assert np.isclose(
-        [downward_pass_min_cost], [expected_score]
-    ), "Downward pass of Sankoff on dag did not yield expected score: computed %lf, but expected %lf"%(downward_pass_min_cost, expected_score)
+    assert np.isclose([downward_pass_min_cost], [expected_score]), (
+        "Downward pass of Sankoff on dag did not yield expected score: computed %lf, but expected %lf"
+        % (downward_pass_min_cost, expected_score)
+    )
 
     assert (
         dag.count_histories() == dag.copy().count_histories()

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -57,9 +57,7 @@ def compare_dag_and_tree_parsimonies(dag, transition_weights=None):
     ), "DAG Sankoff missed a label that occurs in the tree Sankoff."
 
 
-def check_sankoff_on_dag(
-    dag, expected_score, transition_weights=None
-):
+def check_sankoff_on_dag(dag, expected_score, transition_weights=None):
     # perform upward sweep of sankoff to calculate overall parsimony score and assign cost vectors to internal nodes
     upward_pass_min_cost = dag_parsimony.sankoff_upward(
         dag, transition_weights=transition_weights

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -4,9 +4,7 @@ import historydag as hdag
 import historydag.parsimony as dag_parsimony
 
 
-def compare_dag_and_tree_parsimonies(
-    dag, transition_weights=None, filter_min_score=True
-):
+def compare_dag_and_tree_parsimonies(dag, transition_weights=None):
 
     # extract sample tree
     s = dag.sample().copy()
@@ -15,9 +13,7 @@ def compare_dag_and_tree_parsimonies(
     s_ete = s.to_ete()
 
     # compute cost vectors for sample tree in dag and in ete3.Tree format to compare
-    a = dag_parsimony.sankoff_upward(
-        s, transition_weights=transition_weights, filter_min_score=filter_min_score
-    )
+    a = dag_parsimony.sankoff_upward(s, transition_weights=transition_weights)
     b = dag_parsimony.sankoff_upward(s_ete, transition_weights=transition_weights)
     assert (
         a == b
@@ -28,7 +24,6 @@ def compare_dag_and_tree_parsimonies(
         s,
         compute_cvs=False,
         transition_weights=transition_weights,
-        filter_min_score=filter_min_score,
     )
     s_ete = dag_parsimony.disambiguate(
         s_ete, compute_cvs=False, transition_weights=transition_weights
@@ -63,11 +58,11 @@ def compare_dag_and_tree_parsimonies(
 
 
 def check_sankoff_on_dag(
-    dag, expected_score, transition_weights=None, filter_min_score=True
+    dag, expected_score, transition_weights=None
 ):
     # perform upward sweep of sankoff to calculate overall parsimony score and assign cost vectors to internal nodes
     upward_pass_min_cost = dag_parsimony.sankoff_upward(
-        dag, transition_weights=transition_weights, filter_min_score=filter_min_score
+        dag, transition_weights=transition_weights
     )
     assert np.isclose(
         [upward_pass_min_cost], [expected_score]
@@ -77,7 +72,6 @@ def check_sankoff_on_dag(
     downward_pass_min_cost = dag_parsimony.sankoff_downward(
         dag,
         transition_weights=transition_weights,
-        filter_min_score=filter_min_score,
         compute_cvs=False,
     )
     dag._check_valid()
@@ -126,13 +120,5 @@ def test_sankoff_on_dag():
     ]
 
     for (w, tw) in tw_options:
-        check_sankoff_on_dag(
-            dg.copy(), w, transition_weights=tw, filter_min_score=False
-        )
-        check_sankoff_on_dag(dg.copy(), w, transition_weights=tw, filter_min_score=True)
-        compare_dag_and_tree_parsimonies(
-            dg.copy(), transition_weights=tw, filter_min_score=False
-        )
-        compare_dag_and_tree_parsimonies(
-            dg.copy(), transition_weights=tw, filter_min_score=True
-        )
+        check_sankoff_on_dag(dg.copy(), w, transition_weights=tw)
+        compare_dag_and_tree_parsimonies(dg.copy(), transition_weights=tw)

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -7,11 +7,10 @@ import historydag.parsimony as dag_parsimony
 def compare_dag_and_tree_parsimonies(
     dag, transition_weights=None, filter_min_score=True
 ):
-    dag.recompute_parents()
-    dag.convert_to_collapsed()
 
     # extract sample tree
-    s = dag.sample()
+    s = dag.sample().copy()
+    s.recompute_parents()
     # convert to ete3.Tree format
     s_ete = s.to_ete()
 
@@ -95,6 +94,8 @@ def test_sankoff_on_dag():
     with open("sample_data/toy_trees.p", "rb") as f:
         ete_trees = pickle.load(f)
     dg = hdag.history_dag_from_etes(ete_trees, ["sequence"])
+    dg.recompute_parents()
+    dg.convert_to_collapsed()
 
     tw_options = [
         (75, None),

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -17,7 +17,7 @@ def compare_dag_and_tree_parsimonies(dag, transition_weights=None):
     b = dag_parsimony.sankoff_upward(s_ete, transition_weights=transition_weights)
     assert (
         a == b
-    ), "Upward Sankoff on ete_Tree vs on the dag version of the tree produced different results"
+    ), "Upward Sankoff on ete_Tree vs on the dag version of the tree produced different results: %lf from the dag and %lf from the ete_Tree"%(a, b)
 
     # calculate sequences for internal nodes using Sankoff for both formats of sample tree
     s_weight = dag_parsimony.sankoff_downward(
@@ -46,7 +46,7 @@ def compare_dag_and_tree_parsimonies(dag, transition_weights=None):
         s_ete_weight = s_ete_as_dag.optimal_weight_annotate()
     assert (
         s_weight == s_ete_weight
-    ), "Downward sankoff on ete_Tree vs on the dag version of the tree produced different results"
+    ), "Downward sankoff on ete_Tree vs on the dag version of the tree produced different results: %lf from the dag and %lf from the ete_Tree"%(s_weight, s_ete_weight)
 
     s_labels = set(n.label.sequence for n in s.postorder() if not n.is_ua_node())
     s_ete_labels = set(
@@ -64,7 +64,7 @@ def check_sankoff_on_dag(dag, expected_score, transition_weights=None):
     )
     assert np.isclose(
         [upward_pass_min_cost], [expected_score]
-    ), "Upward pass of Sankoff on dag did not yield expected score"
+    ), "Upward pass of Sankoff on dag did not yield expected score: computed %lf, but expected %lf"%(upward_pass_min_cost, expected_score)
 
     # perform downward sweep of sankoff to calculate all possible internal node sequences.
     downward_pass_min_cost = dag_parsimony.sankoff_downward(
@@ -75,7 +75,7 @@ def check_sankoff_on_dag(dag, expected_score, transition_weights=None):
     dag._check_valid()
     assert np.isclose(
         [downward_pass_min_cost], [expected_score]
-    ), "Downward pass of Sankoff on dag did not yield expected score"
+    ), "Downward pass of Sankoff on dag did not yield expected score: computed %lf, but expected %lf"%(downward_pass_min_cost, expected_score)
 
     assert (
         dag.count_histories() == dag.copy().count_histories()


### PR DESCRIPTION
updates to the dag Sankoff algoirthm:
- filtering step is now implemented generally, instead of as an optional argument. 
- the criterion for filtering out cost vectors is one that is imposed by the restriction of the Sankoff algorithm to any tree in the dag
- cleaned up code
- small changes to print statements in tests
<img width="920" alt="filter" src="https://user-images.githubusercontent.com/6298398/192891581-e9d0c364-578c-47f8-81b9-dbcf7b64742c.png">
