### PR TITLE
working tests and implementation

### DIFF
--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1767,7 +1767,7 @@ class HistoryDag:
         instead of making multiple calls to this method with the same reference
         history.
         """
-        kwargs = utils.make_rfdistance_countfuncs(history, unrooted=(not rooted))
+        kwargs = utils.make_rfdistance_countfuncs(history, rooted=rooted)
         return self.optimal_weight_annotate(**kwargs, optimal_func=optimal_func)
 
     def count_rf_distances(self, history, rooted=False):
@@ -1780,7 +1780,7 @@ class HistoryDag:
         instead of making multiple calls to this method with the same reference
         history.
         """
-        kwargs = utils.make_rfdistance_countfuncs(history, unrooted=(not rooted))
+        kwargs = utils.make_rfdistance_countfuncs(history, rooted=rooted)
         return self.weight_count(**kwargs)
 
     # ######## End Abstract DP method derivatives ########

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1758,7 +1758,12 @@ class HistoryDag:
             ).values()
         )[0]
 
-    def optimal_rf_distance(self, history, rooted=False, optimal_func=min):
+    def optimal_rf_distance(
+        self,
+        history: "HistoryDag",
+        rooted: bool = False,
+        optimal_func: Callable[[List[Weight]], Weight] = min,
+    ):
         """Returns the optimal (min or max) RF distance to a given history.
 
         The given history must be on the same taxa as all trees in the DAG.
@@ -1770,7 +1775,7 @@ class HistoryDag:
         kwargs = utils.make_rfdistance_countfuncs(history, rooted=rooted)
         return self.optimal_weight_annotate(**kwargs, optimal_func=optimal_func)
 
-    def count_rf_distances(self, history, rooted=False):
+    def count_rf_distances(self, history: "HistoryDag", rooted: bool = False):
         """Returns a Counter containing all RF distances to a given history.
 
         The given history must be on the same taxa as all trees in the DAG.

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1,6 +1,7 @@
 """A module providing the class HistoryDag, and supporting functions."""
 
 import pickle
+from math import log
 import graphviz as gv
 import ete3
 import random
@@ -138,6 +139,10 @@ class HistoryDagNode:
     def is_root(self) -> bool:
         """Deprecated name for :meth:`is_ua_node`"""
         return self.is_ua_node()
+
+    def is_history_root(self) -> bool:
+        """Return whether node is a root of any histories in the DAG."""
+        return any(n.is_ua_node() for n in self.parents)
 
     def child_clades(self) -> frozenset:
         """Returns the node's child clades, or a frozenset containing a
@@ -1625,8 +1630,6 @@ class HistoryDag:
                 clade2support[node.clade_union()] = 0
             clade2support[node.clade_union()] += count / total_trees
 
-        from math import log
-
         self.trim_optimal_weight(
             start_func=lambda n: 0,
             edge_weight_func=lambda n1, n2: log(clade2support[n2.clade_union()]),
@@ -1754,6 +1757,31 @@ class HistoryDag:
                 accum_above_edge=lambda n, e: e,
             ).values()
         )[0]
+
+    def optimal_rf_distance(self, history, rooted=False, optimal_func=min):
+        """Returns the optimal (min or max) RF distance to a given history.
+
+        The given history must be on the same taxa as all trees in the DAG.
+        Since computing reference splits is expensive, it is better to use
+        :meth:``optimal_weight_annotate`` and :meth:``utils.make_rfdistance_countfuncs``
+        instead of making multiple calls to this method with the same reference
+        history.
+        """
+        kwargs = utils.make_rfdistance_countfuncs(history, unrooted=(not rooted))
+        return self.optimal_weight_annotate(**kwargs, optimal_func=optimal_func)
+
+    def count_rf_distances(self, history, rooted=False):
+        """Returns a Counter containing all RF distances to a given history.
+
+        The given history must be on the same taxa as all trees in the DAG.
+
+        Since computing reference splits is expensive, it is better to use
+        :meth:``weight_count`` and :meth:``utils.make_rfdistance_countfuncs``
+        instead of making multiple calls to this method with the same reference
+        history.
+        """
+        kwargs = utils.make_rfdistance_countfuncs(history, unrooted=(not rooted))
+        return self.weight_count(**kwargs)
 
     # ######## End Abstract DP method derivatives ########
 

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -420,6 +420,121 @@ node_countfuncs = AddFuncDict(
 For use with :meth:`historydag.HistoryDag.weight_count`."""
 
 
+def make_rfdistance_countfuncs(ref_tree, unrooted=True):
+    """Provides functions to compute RF distances of trees in a DAG, relative
+    to a fixed reference tree.
+
+    The reference tree must have the same taxa as all the trees in the DAG.
+
+    This calculation relies on the observation that the symmetric distance between
+    the splits A in a tree in the DAG, and the splits B in the reference tree, can
+    be computed as:
+    |A ^ B| = |A U B| - |A n B| = |A - B| + |B| - |A n B|
+
+    As long as tree edges are in bijection with splits, this can be computed without
+    constructing the set A by considering each edge's split independently.
+
+    In order to accommodate multiple edges with the same split in a tree with root
+    bifurcation, we keep track of the contribution of such edges separately.
+
+    The weight type is a tuple wrapped in an IntState object. The first tuple value `a` is the
+    contribution of edges which are not part of a root bifurcation, where edges whose splits are in B
+    contribute `-1`, and edges whose splits are not in B contribute `-1`, and the second tuple
+    value `b` is the contribution of the edges which are part of a root bifurcation. The value
+    of the IntState is computed as `a + sign(b) + |B|`, which on the UA node of the hDAG gives RF distance.
+    """
+    taxa = frozenset(n.label for n in ref_tree.get_leaves())
+
+    if unrooted:
+
+        def split(node):
+            cu = node.clade_union()
+            return frozenset({cu, taxa - cu})
+
+        ref_splits = frozenset(split(node) for node in ref_tree.preorder())
+        # Remove above-root split, which doesn't map to any tree edge:
+        ref_splits = ref_splits - {
+            frozenset({taxa, frozenset()}),
+        }
+        shift = len(ref_splits)
+
+        n_taxa = len(taxa)
+
+        def is_history_root(n):
+            return len(list(n.clade_union())) == n_taxa
+
+        def sign(n):
+            return (-1) * (n < 0) + (n > 0)
+
+        def summer(tupseq):
+            a, b = 0, 0
+            for ia, ib in tupseq:
+                a += ia
+                b += ib
+            return (a, b)
+
+        def make_intstate(tup):
+            return IntState(tup[0] + shift + sign(tup[1]), state=tup)
+
+        def edge_func(n1, n2):
+            spl = split(n2)
+            if n1.is_ua_node():
+                return make_intstate((0, 0))
+            if len(n1.clades) == 2 and is_history_root(n1):
+                if spl in ref_splits:
+                    return make_intstate((0, -1))
+                else:
+                    return make_intstate((0, 1))
+            else:
+                if spl in ref_splits:
+                    return make_intstate((-1, 0))
+                else:
+                    return make_intstate((1, 0))
+
+        kwargs = AddFuncDict(
+            {
+                "start_func": lambda n: make_intstate((0, 0)),
+                "edge_weight_func": edge_func,
+                "accum_func": lambda wlist: make_intstate(
+                    summer(w.state for w in wlist)
+                ),
+            },
+            name="RF_unrooted_distance",
+        )
+    else:
+        ref_cus = frozenset(
+            node.clade_union() for node in ref_tree.preorder(skip_ua_node=True)
+        )
+        ref_cus = ref_cus - {
+            taxa,
+        }
+        shift = len(ref_cus)
+        print(ref_cus)
+        print(shift)
+
+        def make_intstate(n):
+            return IntState(n + shift, state=n)
+
+        def edge_func(n1, n2):
+            if n1.is_ua_node():
+                return make_intstate(0)
+            if n2.clade_union() in ref_cus:
+                return make_intstate(-1)
+            else:
+                return make_intstate(1)
+
+        kwargs = AddFuncDict(
+            {
+                "start_func": lambda n: make_intstate(0),
+                "edge_weight_func": edge_func,
+                "accum_func": lambda wlist: make_intstate(sum(w.state for w in wlist)),
+            },
+            name="RF_rooted_distance",
+        )
+
+    return kwargs
+
+
 def make_newickcountfuncs(
     name_func=lambda n: "unnamed",
     features=None,

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -21,7 +21,7 @@ from typing import (
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from historydag.dag import HistoryDagNode
+    from historydag.dag import HistoryDagNode, HistoryDag
 
 Weight = Any
 Label = Union[NamedTuple, "UALabel"]
@@ -420,9 +420,14 @@ node_countfuncs = AddFuncDict(
 For use with :meth:`historydag.HistoryDag.weight_count`."""
 
 
-def make_rfdistance_countfuncs(ref_tree, rooted=False):
+def make_rfdistance_countfuncs(ref_tree: "HistoryDag", rooted: bool = False):
     """Provides functions to compute RF distances of trees in a DAG, relative
     to a fixed reference tree.
+
+    Args:
+        ref_tree: A tree with respect to which Robinson-Foulds distance will be computed.
+        rooted: If False, use edges' splits for RF distance computation. Otherwise, use
+            the clade below each edge.
 
     The reference tree must have the same taxa as all the trees in the DAG.
 

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -420,7 +420,7 @@ node_countfuncs = AddFuncDict(
 For use with :meth:`historydag.HistoryDag.weight_count`."""
 
 
-def make_rfdistance_countfuncs(ref_tree, unrooted=True):
+def make_rfdistance_countfuncs(ref_tree, rooted=False):
     """Provides functions to compute RF distances of trees in a DAG, relative
     to a fixed reference tree.
 
@@ -445,7 +445,7 @@ def make_rfdistance_countfuncs(ref_tree, unrooted=True):
     """
     taxa = frozenset(n.label for n in ref_tree.get_leaves())
 
-    if unrooted:
+    if not rooted:
 
         def split(node):
             cu = node.clade_union()

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -276,10 +276,6 @@ def test_count_weights_expanded():
         assert dag.hamming_parsimony_count() == ndag.weight_counts_with_ambiguities()
 
 
-def test_cm_counter():
-    pass
-
-
 def test_topology_decompose():
     # make sure that trimming to a topology results in a DAG expressing exactly
     # the trees which have that topology.
@@ -352,17 +348,45 @@ def test_indexing_comprehensive():
         )
 
 
-def test_trim():
+def test_trim_fixedleaves():
     for dag in dags + cdags:
-        dag = dag.copy()
-        dag.make_complete()
-        dag._check_valid()
-        dag.recompute_parents()
-        dag._check_valid()
-        dag.trim_optimal_weight()
-        dag._check_valid()
-        dag.convert_to_collapsed()
-        dag._check_valid()
+        reftree = dag.sample()
+        kwarglist = [
+            (dagutils.make_rfdistance_countfuncs(reftree, unrooted=True), min),
+            (dagutils.make_rfdistance_countfuncs(reftree, unrooted=False), min),
+        ]
+        for kwargs, opt_func in kwarglist:
+            dag = dag.copy()
+            dag.make_complete()
+            dag._check_valid()
+            dag.recompute_parents()
+            dag._check_valid()
+            all_weights = dag.weight_count(**kwargs)
+            optimal_weight = dag.trim_optimal_weight(**kwargs, optimal_func=opt_func)
+            assert all_weights[optimal_weight] == dag.count_trees()
+            dag._check_valid()
+            dag.convert_to_collapsed()
+            dag._check_valid()
+
+
+def test_trim():
+    kwarglist = [
+        (dagutils.hamming_distance_countfuncs, min),
+        (dagutils.node_countfuncs, min),
+    ]
+    for dag in dags + cdags:
+        for kwargs, opt_func in kwarglist:
+            dag = dag.copy()
+            dag.make_complete()
+            dag._check_valid()
+            dag.recompute_parents()
+            dag._check_valid()
+            all_weights = dag.weight_count(**kwargs)
+            optimal_weight = dag.trim_optimal_weight(**kwargs, optimal_func=opt_func)
+            assert all_weights[optimal_weight] == dag.count_trees()
+            dag._check_valid()
+            dag.convert_to_collapsed()
+            dag._check_valid()
 
 
 def test_from_nodes():
@@ -457,3 +481,108 @@ def test_relabel():
     odag = ndag.relabel(lambda n: Label(n.label.sequence))
     odag._check_valid()
     assert dag.weight_count() == odag.weight_count()
+
+
+def test_rf_rooted_distances():
+    for dag in dags:
+        ref_tree = dag.sample()
+        weight_kwargs = dagutils.make_rfdistance_countfuncs(ref_tree, unrooted=False)
+        ref_tree_ete = ref_tree.to_ete(features=["sequence"])
+
+        def add_root(tree):
+            newroot = ete3.TreeNode()
+            newroot.add_feature("sequence", "")
+            newroot.add_child(tree)
+            return newroot
+
+        ref_tree_ete = add_root(ref_tree_ete)
+
+        for node in ref_tree_ete.traverse():
+            node.name = node.sequence
+        ref_taxa = {n.sequence for n in ref_tree_ete.get_leaves()}
+        weight_to_self = ref_tree.optimal_weight_annotate(**weight_kwargs)
+        if not (weight_to_self == 0):
+            print(ref_tree_ete)
+            print("nonzero distance to self in this tree ^^: ", weight_to_self)
+            assert False
+
+        def rf_distance(intree):
+            intreeete = intree.to_ete(features=["sequence"])
+            intreeete = add_root(intreeete)
+            return ref_tree_ete.robinson_foulds(
+                intreeete, attr_t1="sequence", attr_t2="sequence", unrooted_trees=False
+            )[0]
+
+        if Counter(rf_distance(tree) for tree in dag) != dag.weight_count(
+            **weight_kwargs
+        ):
+            print("label format ", next(dag.postorder()).label)
+            for tree in dag:
+                thistree = tree.to_ete(features=["sequence"])
+                tree_taxa = {n.sequence for n in thistree.get_leaves()}
+                if tree_taxa != ref_taxa:
+                    continue
+                ref_dist = rf_distance(tree)
+                comp_dist = tree.optimal_weight_annotate(**weight_kwargs)
+                if ref_dist != comp_dist:
+                    for node in thistree.get_leaves():
+                        node.name = node.sequence
+                        # node.name = str(namedict[node.sequence])
+                    for node in ref_tree_ete.get_leaves():
+                        node.name = node.sequence
+                        # node.name = str(namedict[node.sequence])
+                    print("reference tree:")
+                    print(ref_tree_ete)
+                    print("this tree:")
+                    print(thistree)
+                    print("correct RF: ", ref_dist)
+                    print("computed RF: ", comp_dist)
+                    assert False
+
+
+def test_rf_distances():
+    for dag in reversed(dags):
+        ref_tree = dag.sample()
+        weight_kwargs = dagutils.make_rfdistance_countfuncs(ref_tree)
+        ref_tree_ete = ref_tree.to_ete(features=["sequence"])
+        for node in ref_tree_ete.traverse():
+            node.name = node.sequence
+        ref_taxa = {n.sequence for n in ref_tree_ete.get_leaves()}
+        weight_to_self = ref_tree.optimal_weight_annotate(**weight_kwargs)
+        if not (weight_to_self == 0):
+            print(ref_tree_ete)
+            print("nonzero distance to self in this tree ^^: ", weight_to_self)
+            assert False
+
+        def rf_distance(intree):
+            intreeete = intree.to_ete(features=["sequence"])
+            assert len(intreeete.children) != 1
+            return ref_tree_ete.robinson_foulds(
+                intreeete, attr_t1="sequence", attr_t2="sequence", unrooted_trees=True
+            )[0]
+
+        if Counter(rf_distance(tree) for tree in dag) != dag.weight_count(
+            **weight_kwargs
+        ):
+            print("label format ", next(dag.postorder()).label)
+            for tree in dag:
+                thistree = tree.to_ete(features=["sequence"])
+                tree_taxa = {n.sequence for n in thistree.get_leaves()}
+                if tree_taxa != ref_taxa:
+                    continue
+                ref_dist = rf_distance(tree)
+                comp_dist = tree.optimal_weight_annotate(**weight_kwargs)
+                if ref_dist != comp_dist:
+                    for node in thistree.get_leaves():
+                        node.name = node.sequence
+                        # node.name = str(namedict[node.sequence])
+                    for node in ref_tree_ete.get_leaves():
+                        node.name = node.sequence
+                        # node.name = str(namedict[node.sequence])
+                    print("reference tree:")
+                    print(ref_tree_ete)
+                    print("this tree:")
+                    print(thistree)
+                    print("correct RF: ", ref_dist)
+                    print("computed RF: ", comp_dist)
+                    assert False

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -352,8 +352,8 @@ def test_trim_fixedleaves():
     for dag in dags + cdags:
         reftree = dag.sample()
         kwarglist = [
-            (dagutils.make_rfdistance_countfuncs(reftree, unrooted=True), min),
-            (dagutils.make_rfdistance_countfuncs(reftree, unrooted=False), min),
+            (dagutils.make_rfdistance_countfuncs(reftree, rooted=True), min),
+            (dagutils.make_rfdistance_countfuncs(reftree, rooted=False), min),
         ]
         for kwargs, opt_func in kwarglist:
             dag = dag.copy()
@@ -486,7 +486,7 @@ def test_relabel():
 def test_rf_rooted_distances():
     for dag in dags:
         ref_tree = dag.sample()
-        weight_kwargs = dagutils.make_rfdistance_countfuncs(ref_tree, unrooted=False)
+        weight_kwargs = dagutils.make_rfdistance_countfuncs(ref_tree, rooted=True)
         ref_tree_ete = ref_tree.to_ete(features=["sequence"])
 
         def add_root(tree):
@@ -540,10 +540,10 @@ def test_rf_rooted_distances():
                     assert False
 
 
-def test_rf_distances():
+def test_rf_unrooted_distances():
     for dag in reversed(dags):
         ref_tree = dag.sample()
-        weight_kwargs = dagutils.make_rfdistance_countfuncs(ref_tree)
+        weight_kwargs = dagutils.make_rfdistance_countfuncs(ref_tree, rooted=False)
         ref_tree_ete = ref_tree.to_ete(features=["sequence"])
         for node in ref_tree_ete.traverse():
             node.name = node.sequence


### PR DESCRIPTION
This PR adds a utility method for creating an `AddFuncDict` which allows computation of RF distance between trees in the history DAG and a fixed reference tree. Both rooted and unrooted RF distance are provided, and trimming with respect to these distances is supported.

The attached notes describe the method for computing unrooted RF distance. The rooted case is simpler, since sets of clades (clade unions) are used instead of sets of splits, and there is no need to adjust for root bifurcation.


[Notebook 7.pdf](https://github.com/matsengrp/historydag/files/9687914/Notebook.7.pdf)

Extensive tests are included.