### PR TITLE
Various bug fixes

### DIFF
--- a/historydag/compact_genome.py
+++ b/historydag/compact_genome.py
@@ -24,6 +24,24 @@ class CompactGenome:
     def __eq__(self, other):
         return (self.mutations, self.reference) == (other.mutations, other.reference)
 
+    def __le__(self, other: object) -> bool:
+        if isinstance(other, CompactGenome):
+            return sorted(self.mutations.items()) <= sorted(other.mutations.items())
+        else:
+            raise NotImplementedError
+
+    def __lt__(self, other: object) -> bool:
+        if isinstance(other, CompactGenome):
+            return sorted(self.mutations.items()) < sorted(other.mutations.items())
+        else:
+            raise NotImplementedError
+
+    def __gt__(self, other: object) -> bool:
+        return not self.__le__(other)
+
+    def __ge__(self, other: object) -> bool:
+        return not self.__lt__(other)
+
     def __repr__(self):
         return f"CompactGenome({self.mutations}, '{self.reference}')"
 

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -463,7 +463,6 @@ class HistoryDag:
         precursor_fields = set()
 
         def find_conversion_func(fieldname: str):
-            print(fieldname, set(dag.label_fields))
             if fieldname in dag.label_fields:
                 return (fieldname, get_existing_field(fieldname))
             elif fieldname in required_fields_set:
@@ -493,12 +492,9 @@ class HistoryDag:
             for field in label_fields:
                 convert_funcs.append(find_conversion_func(field))
 
-        print(convert_funcs)
         Label = NamedTuple(
             "Label", [(converttuple[0], Any) for converttuple in convert_funcs]
         )
-
-        print(dir(Label))
 
         def relabel_func(node):
             labeldata = [

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -964,6 +964,7 @@ class HistoryDag:
                 appropriate for that node. The relabel_func should return a consistent
                 NamedTuple type with name Label. That is, all returned labels
                 should have matching `_fields` attribute.
+                No two leaf nodes may be mapped to the same new label.
             relax_type: Whether to require the returned HistoryDag to be of the same subclass as self.
                 If True, the returned HistoryDag will be of the abstract type `HistoryDag`
         """
@@ -1296,6 +1297,7 @@ class HistoryDag:
     def explode_nodes(
         self,
         expand_func: Callable[[Label], Iterable[Label]] = utils.sequence_resolutions,
+        expand_node_func: Callable[[HistoryDagNode], Iterable[Label]] = None,
         expandable_func: Callable[[Label], bool] = None,
     ) -> int:
         r"""Explode nodes according to a provided function. Adds copies of each
@@ -1303,10 +1305,13 @@ class HistoryDag:
         children as the original node.
 
         Args:
-            expand_func: A function that takes a node label, and returns an iterable
+            expand_func: (Deprecated) A function that takes a node label, and returns an iterable
                 containing 'exploded' or 'disambiguated' labels corresponding to the original.
                 The wrapper :meth:`utils.explode_label` is provided to make such a function
                 easy to write.
+            expand_node_func: A function that takes a node and returns an iterable
+                containing 'exploded' or 'disambiguated' labels corresponding to the
+                node. If provided, expand_func will be ignored.
             expandable_func: A function that takes a node label, and returns whether the
                 iterable returned by calling expand_func on that label would contain more
                 than one item.
@@ -1315,28 +1320,34 @@ class HistoryDag:
             The number of new nodes added to the history DAG.
         """
 
+        if expand_node_func is None:
+
+            def expand_node_func(node):
+                return expand_func(node.label)
+
         if expandable_func is None:
 
-            def is_ambiguous(label):
+            def is_ambiguous(node):
                 # Check if expand_func(label) has at least two items, without
                 # exhausting the (arbitrarily expensive) generator
-                return len(list(zip([1, 2], expand_func(label)))) > 1
+                return len(list(zip([1, 2], expand_node_func(node)))) > 1
 
         else:
-            is_ambiguous = expandable_func
+            is_ambiguous = lambda node: expandable_func(node.label)
 
         self.recompute_parents()
         nodedict = {node: node for node in self.postorder()}
         nodeorder = list(self.postorder())
         new_nodes = set()
         for node in nodeorder:
-            if not node.is_ua_node() and is_ambiguous(node.label):
+            if not node.is_ua_node() and is_ambiguous(node):
                 if node.is_leaf():
                     raise ValueError(
-                        "Passed expand_func would explode a leaf node. "
+                        "Passed expand_func or expand_node_func would"
+                        " explode a leaf node. "
                         "Leaf nodes may not be exploded."
                     )
-                for resolution in expand_func(node.label):
+                for resolution in expand_node_func(node):
                     newnodetemp = node.empty_copy()
                     newnodetemp.label = resolution
                     if newnodetemp in nodedict:

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1329,7 +1329,9 @@ class HistoryDag:
                 return len(list(zip([1, 2], expand_node_func(node)))) > 1
 
         else:
-            is_ambiguous = lambda node: expandable_func(node.label)
+
+            def is_ambiguous(node):
+                return expandable_func(node.label)
 
         self.recompute_parents()
         nodedict = {node: node for node in self.postorder()}

--- a/historydag/parsimony.py
+++ b/historydag/parsimony.py
@@ -489,9 +489,9 @@ def build_tree(
     seq_len = len(next(iter(fasta_map.values())))
     ambig_seq = "?" * seq_len
     for node in tree.traverse():
-        if node.is_ua_node() and reference_sequence is not None:
+        if node.is_root() and reference_sequence is not None:
             node.add_feature("sequence", reference_sequence)
-        elif node.is_ua_node() and reference_id is not None:
+        elif node.is_root() and reference_id is not None:
             node.add_feature("sequence", fasta_map[reference_id])
         elif (not node.is_leaf()) and ignore_internal_sequences:
             node.add_feature("sequence", ambig_seq)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,5 +1,6 @@
 import ete3
 import pickle
+import historydag
 import historydag.dag as hdag
 import historydag.utils as dagutils
 from collections import Counter, namedtuple
@@ -271,9 +272,10 @@ def test_count_histories_expanded():
 
 def test_count_weights_expanded():
     for dag in dags + cdags:
-        ndag = dag.copy()
+        ndag = historydag.sequence_dag.SequenceHistoryDag.from_history_dag(dag.copy())
+        odag = ndag.copy()
         ndag.explode_nodes()
-        assert dag.hamming_parsimony_count() == ndag.weight_counts_with_ambiguities()
+        assert odag.hamming_parsimony_count() == ndag.weight_counts_with_ambiguities()
 
 
 def test_topology_decompose():

--- a/tests/test_mutation_annotated_dag.py
+++ b/tests/test_mutation_annotated_dag.py
@@ -14,6 +14,7 @@ def test_load_protobuf():
     dag.to_protobuf_file(test_filename)
     ndag = load_MAD_protobuf_file(test_filename)
     ndag._check_valid()
+    ndag.convert_to_collapsed()
     assert dag.weight_count() == ndag.weight_count()
 
 


### PR DESCRIPTION
* add a more general argument to `explode_nodes` method, which has access to the entire node in question
* change `is_ua_node` to `is_root` call on ete tree in `parsimony.build_tree`