### PR TITLE
Wd general leaf path dag

### DIFF
--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1367,195 +1367,81 @@ class HistoryDag:
                 node.remove_node(nodedict=nodedict)
         return len(new_nodes)
 
-    def leaf_path_uncertainty_dag(self, leaf_label, format_as_nodes=False):
-        """Compute the DAG of possible paths leading to `leaf_label`.
-
-        Args:
-            leaf_label: The node label of the leaf of interest
-            format_as_nodes: bool
-                If True, then return dict with keys/values containing HistoryDagNodes.
-                If False, then return dict with keys/values containing node labels
-        Returns:
-            parent_dictionary: A dictionary keyed by node labels (alt. nodes), with sets
-                of possible parent node labels (alt. possible parent nodes).
-        """
-        if format_as_nodes:
-            parent_dictionary = {
-                node: set()
-                for node in self.dagroot.children()
-                if leaf_label in node.clade_union()
-            }
-            for node in self.preorder(skip_ua_node=True):
-                for clade, eset in node.clades.items():
-                    if leaf_label in clade:
-                        for cnode in eset.targets:
-                            if cnode not in parent_dictionary:
-                                parent_dictionary[cnode] = set()
-                            parent_dictionary[cnode].add(node)
-        else:
-            parent_dictionary = {
-                node.label: set()
-                for node in self.dagroot.children()
-                if leaf_label in node.clade_union()
-            }
-            for node in self.preorder(skip_ua_node=True):
-                for clade, eset in node.clades.items():
-                    if leaf_label in clade:
-                        for cnode in eset.targets:
-                            if cnode.label not in parent_dictionary:
-                                parent_dictionary[cnode.label] = set()
-                            # exclude self loops in label space
-                            if node.label != cnode.label:
-                                parent_dictionary[cnode.label].add(node.label)
-        return parent_dictionary
-
-    def leaf_path_uncertainty_graphviz_collapse(
-        self, leaf_label, edge2count, total_trees
+    def leaf_path_uncertainty_dag_general(
+        self, terminal_node, node_data_func=lambda n: n
     ):
-        """send output of leaf_path_uncertainty_dag to graphviz for rendering.
+        """Create a DAG of possible paths leading to `terminal_node`
 
         Args:
-            leaf_label: The node label of the leaf of interest
-            edge2count: A map of edges in the form of node pairs (parent, child) to their count
-                in the history DAG
-            total_trees: The total number of trees contained in the history DAG
-
+            terminal_node: The returned path DAG will contain all paths from the
+                UA node ending at this node.
+            node_data_func: A function accepting a HistoryDagNode and returning
+                data for the corresponding node in the path dag. Return type must
+                be a valid dictionary key.
         Returns:
-            The graphviz DAG object, and a dictionary mapping node names to labels
+            child_dictionary: A dictionary keyed by return values of
+            `node_data_func`, with each value a dictionary keyed by child nodes,
+            with edge supports as values.
         """
+        self.recompute_parents()
+        edge_counts = self.count_edges()
+        child_dictionary = {node_data_func(terminal_node): dict()}
+
+        for node in self.postorder_above(terminal_node):
+            # Traversal has not visited node, or any of its children yet!
+            node_key = node_data_func(node)
+            child_dictionary[node_key] = dict()
+            for parent in node.parents:
+                if not parent.is_ua_node():
+                    parent_key = node_data_func(parent)
+                    parent_entry = child_dictionary[parent_key]
+                    if node_key not in parent_entry:
+                        parent_entry[node_key] = edge_counts[(parent, node)]
+                    else:
+                        parent_entry[node_key] += edge_counts[(parent, node)]
+
+        return child_dictionary
+
+    def leaf_path_uncertainty_graphviz_general(
+        self,
+        terminal_node,
+        node_data_func=lambda n: n,
+        node_label_func=lambda n: str(n.label),
+    ):
+        total_trees = self.count_histories()
         G = gv.Digraph("Path DAG to leaf", node_attr={})
-        parent_d = self.leaf_path_uncertainty_dag(leaf_label)
-        label_ids = {key: str(idnum) for idnum, key in enumerate(parent_d)}
+        child_d = self.leaf_path_uncertainty_dag_general(
+            terminal_node, node_data_func=node_data_func
+        )
 
-        for key in parent_d:
-            if key == leaf_label:
-                G.node(label_ids[key], shape="octagon")
-            elif len(parent_d[key]) == 0:
-                G.node(label_ids[key], shape="invtriangle")
+        label_ids = {key: str(idnum) for idnum, key in enumerate(child_d)}
+        source_nodes = {node_data_func(child) for child in self.dagroot.children()}
+
+        for node in child_d:
+            if node in source_nodes:
+                G.node(
+                    label_ids[node], label=node_label_func(node), shape="invtriangle"
+                )
+            elif len(child_d[node]) == 0:
+                G.node(label_ids[node], label=node_label_func(node), shape="octagon")
             else:
-                G.node(label_ids[key])
+                G.node(label_ids[node], label=node_label_func(node))
 
-        for child_label, parentset in parent_d.items():
-            for parent_label in parentset:
-                if child_label == parent_label:  # skip self-edges
+        for parent, child_edge_d in child_d.items():
+            for child, support in child_edge_d.items():
+                if parent == child:  # skip self-edges
                     continue
-                support = 0
-                for parent, child in edge2count.keys():
-                    if (
-                        parent.label == parent_label
-                        and child.label == child_label
-                        and (
-                            leaf_label in child.clade_union()
-                            or (child.label == leaf_label and child.is_leaf())
-                        )
-                    ):
-                        support += edge2count[(parent, child)]
                 # Shifts color pallete to less extreme lower bouund
                 color = f"0.0000 {support/total_trees * 0.9 + 0.1} 1.000"
-                G.edge(
-                    label_ids[parent_label],
-                    label_ids[child_label],
-                    penwidth="5",
-                    color=color,
-                    label=f"{support/total_trees:.2}",
-                    weight=f"{support/total_trees}",
-                )
-        return G, {idnum: child_label for child_label, idnum in label_ids.items()}
-
-    def leaf_path_uncertainty_graphviz(self, leaf_label):
-        """send output of leaf_path_uncertainty_dag to graphviz for rendering.
-
-        Returns:
-            The graphviz DAG object, and a dictionary mapping node names to labels
-        """
-        G = gv.Digraph("Path DAG to leaf", node_attr={})
-        parent_d = self.leaf_path_uncertainty_dag(leaf_label)
-        label_ids = {key: str(idnum) for idnum, key in enumerate(parent_d)}
-        for key in parent_d:
-            if key == leaf_label:
-                G.node(label_ids[key], shape="octagon")
-            elif len(parent_d[key]) == 0:
-                G.node(label_ids[key], shape="invtriangle")
-            else:
-                G.node(label_ids[key])
-        for key, parentset in parent_d.items():
-            for parent in parentset:
                 G.edge(
                     label_ids[parent],
-                    label_ids[key],
-                    label="",
-                )
-        return G, {idnum: key for key, idnum in label_ids.items()}
-
-    def leaf_path_uncertainty_dag_no_collapse(self, leaf_label):
-        """Compute the DAG of possible paths leading to `leaf_label`.
-
-        Args:
-            leaf_label: The node label of the leaf of interest
-
-        Returns:
-            parent_dictionary: A dictionary keyed by hDAG nodes, with sets
-                of possible parent nodes.
-        """
-        parent_dictionary = {
-            node: set()
-            for node in self.dagroot.children()
-            if leaf_label in node.clade_union()
-            or (node.is_leaf() and node.label == leaf_label)
-        }
-
-        for node in self.preorder(skip_ua_node=True):
-            for clade, eset in node.clades.items():
-                if leaf_label in clade:
-                    for cnode in eset.targets:
-                        if cnode not in parent_dictionary:
-                            parent_dictionary[cnode] = set()
-                        if node != cnode:
-                            parent_dictionary[cnode].add(node)
-
-        return parent_dictionary
-
-    def leaf_path_uncertainty_graphviz_no_collapse(
-        self, leaf_label, edge2count, total_trees
-    ):
-        """sends output of leaf_path_uncertainty_dag_no_collapse to graphviz
-        for rendering.
-
-        Args:
-            leaf_label: The node label of the leaf of interest
-            edge2count: A map of edges in the form of node pairs (parent, child) to their count
-                in the history DAG
-            total_trees: The total number of trees contained in the history DAG
-
-        Returns:
-            The graphviz DAG object, and a dictionary mapping node names to labels
-        """
-        G = gv.Digraph("Path DAG to leaf", node_attr={})
-        parent_d = self.leaf_path_uncertainty_dag_no_collapse(leaf_label)
-        node_ids = {key: str(idnum) for idnum, key in enumerate(parent_d)}
-
-        for node in parent_d:
-            if node.is_leaf():
-                G.node(node_ids[node], shape="octagon")
-            elif len(parent_d[node]) == 0:
-                G.node(node_ids[node], shape="invtriangle")
-            else:
-                G.node(node_ids[node])
-
-        for child, parentset in parent_d.items():
-            for parent in parentset:
-                support = edge2count[(parent, child)]
-                # Shifts color pallete to less extreme lower bouund
-                color = f"0.0000 {support/total_trees * 0.9 + 0.1} 1.000"
-                G.edge(
-                    node_ids[parent],
-                    node_ids[child],
+                    label_ids[child],
                     penwidth="5",
                     color=color,
                     label=f"{support/total_trees:.2}",
                     weight=f"{support/total_trees}",
                 )
-        return G, {idnum: child_label for child_label, idnum in node_ids.items()}
+        return G
 
     def summary(self):
         """Print nicely formatted summary about the history DAG."""
@@ -2491,24 +2377,41 @@ class HistoryDag:
 
     # ######## DAG Traversal Methods ########
 
-    def postorder_above(self, node_as_leaf):
-        """Recursive postorder traversal of the history DAG, starting at a
-        (possiblly internal) node.
+    def postorder_above(
+        self, terminal_node, skip_ua_node=False, recompute_parents=True
+    ):
+        """Recursive postorder traversal of all ancestors of a (possibly
+        internal) node. This traversal is postorder with respect to reversed
+        edge directions. With respect to standard edge directions (pointing
+        towards leaves), the traversal order guarantees that all of a node's
+        parents will be visited before the node itself.
+
+        Warning: This method requires nodes' parent sets to be correct,
+        but does not enforce this. A call to `HistoryDag.recompute_parents`
+
+        Args:
+            terminal_node: The node whose ancestors should be included in the
+                traversal. This must actually be a node in `self`, not simply
+                compare equal to a node in `self`.
+            skip_ua_node: If True, the UA node will not be included in the traversal
+            recompute_parents: If False, node parent sets will not be recomputed.
+                This makes many repeated calls to postorder_above much faster.
 
         Returns:
             Generator on nodes that lie on any path between node_as_leaf and UA node
         """
-        ancestor_set = self.nodes_above_node(node_as_leaf)
+        if recompute_parents:
+            self.recompute_parents()
         visited = set()
 
         def traverse(node: HistoryDagNode):
             visited.add(id(node))
-            for child in node.children():
-                if (not id(child) in visited) and (child in ancestor_set):
-                    yield from traverse(child)
+            for parent in node.parents():
+                if not id(parent) in visited:
+                    yield from traverse(parent)
             yield node
 
-        yield from traverse(self.dagroot)
+        yield from traverse(terminal_node)
 
     def postorder(
         self, include_root: bool = True

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -538,6 +538,10 @@ class HistoryDag:
         self.count_histories()
         return self.__class__(self.dagroot._get_subhistory_by_subid(key))
 
+    def get_label_type(self) -> type:
+        """Return the type for labels on this dag's nodes."""
+        return type(next(self.dagroot.children()).label)
+
     def trim_within_range(
         self,
         min_weight=None,

--- a/historydag/sequence_dag.py
+++ b/historydag/sequence_dag.py
@@ -1,5 +1,52 @@
 from historydag import HistoryDag
+from functools import lru_cache
 import historydag.utils
+from historydag.utils import Weight
+
+
+def nonleaf_sequence_resolutions(node):
+    if node.is_leaf():
+        yield node.label
+    else:
+        yield from historydag.utils.sequence_resolutions(node.label)
+
+
+@lru_cache(maxsize=20000)
+def _ambiguous_hamming_distance(node1, node2):
+    return sum(
+        pbase not in historydag.utils.ambiguous_dna_values[cbase]
+        for pbase, cbase in zip(node1.label.sequence, node2.label.sequence)
+    )
+
+
+def ambiguous_hamming_distance(node1, node2):
+    """Returns the hamming distance between node1.label.sequence and
+    node2.label.sequence.
+
+    If node2 is a leaf node, then its sequence may be ambiguous, and the
+    minimum possible distance will be returned.
+    """
+    if node1.is_ua_node():
+        return 0
+    if node2.is_leaf():
+        return _ambiguous_hamming_distance(node1, node2)
+    else:
+        return historydag.utils.hamming_distance(
+            node1.label.sequence, node2.label.sequence
+        )
+
+
+leaf_ambiguous_hamming_distance_countfuncs = historydag.utils.AddFuncDict(
+    {
+        "start_func": lambda n: 0,
+        "edge_weight_func": ambiguous_hamming_distance,
+        "accum_func": sum,
+    },
+    name="HammingParsimony",
+)
+"""Provides functions to count hamming distance parsimony when leaf sequences
+may be ambiguous.
+For use with :meth:`historydag.AmbiguousLeafSequenceHistoryDag.weight_count`."""
 
 
 class SequenceHistoryDag(HistoryDag):
@@ -27,3 +74,84 @@ class SequenceHistoryDag(HistoryDag):
         Returns a Counter with integer keys.
         """
         return self.weight_count(**historydag.utils.hamming_distance_countfuncs)
+
+
+class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
+    """A HistoryDag subclass with node labels containing full nucleotide
+    sequences.
+
+    The constructor for this class requires that each node label contain a 'sequence'
+    field, which is expected to hold an unambiguous nucleotide sequence if the node
+    is internal. The sequence may be ambiguous for leaf nodes.
+
+    A HistoryDag containing 'compact_genome' node label fields which contain
+    :class:`compact_genome.CompactGenome` objects may be automatically converted to
+    this subclass by calling the class method :meth:`SequenceHistoryDag.from_dag`, providing the
+    HistoryDag object to be converted.
+    """
+
+    # #### Overridden Methods ####
+
+    def weight_count(
+        self,
+        *args,
+        edge_weight_func=ambiguous_hamming_distance,
+        **kwargs,
+    ):
+        """See :meth:`historydag.HistoryDag.weight_count`"""
+        return super().weight_count(*args, edge_weight_func=edge_weight_func, **kwargs)
+
+    def optimal_weight_annotate(
+        self, *args, edge_weight_func=ambiguous_hamming_distance, **kwargs
+    ) -> Weight:
+        """See :meth:`historydag.HistoryDag.optimal_weight_annotate`"""
+        return super().optimal_weight_annotate(
+            *args, edge_weight_func=edge_weight_func, **kwargs
+        )
+
+    def trim_optimal_weight(
+        self,
+        *args,
+        edge_weight_func=ambiguous_hamming_distance,
+        **kwargs,
+    ) -> Weight:
+        """See :meth:`historydag.HistoryDag.trim_optimal_weight`"""
+        return super().trim_optimal_weight(
+            *args, edge_weight_func=edge_weight_func, **kwargs
+        )
+
+    def trim_within_range(
+        self,
+        *args,
+        edge_weight_func=ambiguous_hamming_distance,
+        **kwargs,
+    ):
+        """See :meth:`historydag.HistoryDag.trim_within_range`"""
+        return super().trim_within_range(
+            *args, edge_weight_func=edge_weight_func, **kwargs
+        )
+
+    def trim_below_weight(
+        self,
+        *args,
+        edge_weight_func=ambiguous_hamming_distance,
+        **kwargs,
+    ):
+        """See :meth:`historydag.HistoryDag.trim_below_weight`"""
+        return super().trim_below_weight(
+            *args, edge_weight_func=edge_weight_func, **kwargs
+        )
+
+    def insert_node(
+        self,
+        *args,
+        dist=ambiguous_hamming_distance,
+        **kwargs,
+    ):
+        """See :meth:`historydag.HistoryDag.insert_node`"""
+        return super().insert_node(*args, dist=dist, **kwargs)
+
+    def hamming_parsimony_count(self):
+        """See :meth:`historydag.sequence_dag.SequenceHistoryDag.hamming_parsim
+        ony_count`"""
+        return self.weight_count(**leaf_ambiguous_hamming_distance_countfuncs)

--- a/tests/test_historydag.py
+++ b/tests/test_historydag.py
@@ -91,8 +91,7 @@ def test_from_tree():
     print(tree.sequence)
     dag = from_tree(tree, ["sequence"])
     dag._check_valid()
-    G = dag.to_graphviz(namedict=namedict)
-    return G
+    dag.to_graphviz(namedict=namedict)
 
 
 def test_is_history():
@@ -207,7 +206,7 @@ def test_merge():
     tree2 = ete3.Tree(newickstring3, format=1)
     dag2 = from_tree(tree2, ["sequence"])
     dag1.merge(dag2)
-    return dag1.to_graphviz(namedict=namedict)
+    dag1.to_graphviz(namedict=namedict)
 
 
 def test_weight():
@@ -216,8 +215,8 @@ def test_weight():
     tree2 = ete3.Tree(newickstring3, format=1)
     dag2 = from_tree(tree2, ["sequence"])
     dag1.merge(dag2)
-    return dag1.to_graphviz(namedict=namedict)
-    assert dag1.weight() == 16
+    dag1.to_graphviz(namedict=namedict)
+    assert dag1.optimal_weight_annotate() == 9
 
 
 def test_internal_avg_parents():
@@ -239,7 +238,7 @@ def test_sample():
         assert dag.sample().is_history()
     sample = dag.sample()
     sample._check_valid()
-    return sample.to_graphviz(namedict=namedict)
+    sample.to_graphviz(namedict=namedict)
 
 
 def test_unifurcation():


### PR DESCRIPTION
This PR generalizes @williamhowardsnyder's infrastructure for building leaf path uncertainty DAGs, similar to the plots produced by linearham. In a future PR we can implement filtering, to ignore edges/nodes with too low of support.