### PR TITLE
Create subclass for ambiguous samples

### DIFF
--- a/tests/test_historydag.py
+++ b/tests/test_historydag.py
@@ -278,13 +278,10 @@ def test_explode_rejects_leaf_ambiguities():
     dag = from_newick(
         "((A, N)W, T)C;", [], label_functions={"sequence": lambda n: n.name}
     )
-    try:
-        dag.explode_nodes(expandable_func=None)
-        raise RuntimeError(
-            "history DAG explode accepted expand_func that would explode a leaf"
-        )
-    except ValueError:
-        return
+    N = dag.num_leaves()
+    dag.explode_nodes(expandable_func=None)
+    assert dag._check_valid()
+    assert dag.num_leaves() == N
 
 
 def test_print():


### PR DESCRIPTION
This PR creates the new subclass `historydag.sequence_dag.AmbiguousLeafSequenceHistoryDag` which allows leaf sequences to contain ambiguous characters, provides a convenient edge weight function for computing minimum hamming distance on those edges, and provides overridden methods that use that edge weight function.

it also:

* provides generalized interface for loading arbitrary tree data, with `historydag.from_tree` and `historydag.history_dag_from_trees`,
* automatically declines to explode leaves with ambiguous labels in `HistoryDag.explode_nodes`.