### PR TITLE
Add HistoryDagFilter Object

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -458,7 +458,7 @@ However, :class:`utils.HistoryDagFilter` can also be used in history DAG
 filtering syntax, which is equivalent to calling
 :meth:`HistoryDag.trim_optimal_weight` on a copy:
 
->>> filtered_dag = dag & min_nodes
+>>> filtered_dag = dag[min_nodes]
 >>> filtered_dag.weight_count(**min_nodes)
 Counter({35: 17})
 
@@ -523,10 +523,10 @@ The last expression above is faster than, but equivalent to:
 >>> dag.trim_optimal_weight(**max_node_count)
 37
 
-Using filtering syntax, we can do the same thing without modifying the DAG
+Using filtering syntax, we can conveniently do the same thing without modifying the DAG
 in-place:
 
->>> filtered_dag = dag & my_filter
+>>> filtered_dag = dag[my_filter]
 
 The filter object can describe itself:
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -385,8 +385,8 @@ number of nodes:
 ... )
 Counter({37: 173})
 
-The AddFuncDict
----------------
+The AddFuncDict Class
+---------------------
 
 Since the interfaces of these three methods are similar, we provide
 a special subclassed dictionary :class:`utils.AddFuncDict` for storing
@@ -435,11 +435,40 @@ A variety of useful :class:`utils.AddFuncDict` objects are provided:
   although this functionality is conveniently wrapped in
   :meth:`HistoryDag.to_newick` and :meth:`HistoryDag.to_newicks`.
 
+The HistoryDagFilter Class
+---------------------------
+
+In addition to an edge weight function, history DAG methods like
+:meth:`HistoryDag.trim_optimal_weight` require a choice of ``optimal_func``,
+usually specifying whether to minimize or maximize the weight of histories.
+
+The :class:`utils.HistoryDagFilter` class provides a container for
+a :class:`utils.AddFuncDict` and an ``optimal_func``, and provides a similar
+interface as :class:`utils.AddFuncDict`, allowing keyword argument unpacking:
+
+>>> dag.weight_count(**node_count_funcs)
+Counter({35: 17, 36: 325, 37: 173})
+>>> min_nodes = hdag.utils.HistoryDagFilter(node_count_funcs, min)
+>>> print(min_parsimony)
+HistoryDagFilter[minimum NodeCount]
+>>> dag.optimal_weight_annotate(**min_nodes)
+35
+
+However, :class:`utils.HistoryDagFilter` can also be used in history DAG
+filtering syntax, which is equivalent to calling
+:meth:`HistoryDag.trim_optimal_weight` on a copy:
+
+>>> filtered_dag = dag & min_nodes
+>>> filtered_dag.weight_count(**min_nodes)
+Counter({35: 17})
+
+
 Combining Weights
 -----------------
 
-The primary advantage of a :class:`utils.AddFuncDict` object over a plain
-dictionary is its composability via the ``+`` operator.
+The primary advantage of a :class:`utils.AddFuncDict` and
+:class:`utils.HistoryDagFilter` objects over a plain
+dictionary are their composability via the ``+`` operator.
 
 Addition of two ``AddFuncDict`` objects returns a new ``AddFuncDict`` which
 computes the weights implemented by the original two ``AddFuncDict``'s
@@ -467,8 +496,43 @@ order of addition (note that nested tuples are avoided). The names of each
 weight are stored in the ``names`` attribute of the resulting data structure:
 
 >>> kwargs = utils.hamming_distance_countfuncs + utils.node_countfuncs
+>>> print(kwargs)
+AddFuncDict[HammingParsimony, NodeCount]
 >>> kwargs.names
 ('HammingParsimony', 'NodeCount')
+
+
+Similary, addition of two ``HistoryDagFilter`` objects returns a new
+``HistoryDagFilter`` which implements the added ``HistoryDagFilter`` operations
+sequentially. The contained ``AddFuncDict`` is the sum of the original two
+``AddFuncDicts``, so computes the weights implemented by
+the original two ``AddFuncDict``'s simultaneously, storing them in a tuple.
+
+>>> min_parsimony = utils.HistoryDagFilter(utils.hamming_distance_countfuncs, min)
+>>> max_node_count = utils.HistoryDagFilter(utils.node_countfuncs, max)
+>>> my_filter = min_parsimony + max_node_count
+>>> dag.weight_count(**my_filter)
+Counter({(73, 35): 17, (73, 36): 320, (74, 36): 5, (74, 37): 112, (73, 37): 61})
+>>> dag.trim_optimal_weight(**my_filter)
+(73, 37)
+
+The last expression above is faster than, but equivalent to:
+
+>>> dag.trim_optimal_weight(**min_parsimony)
+73
+>>> dag.trim_optimal_weight(**max_node_count)
+37
+
+Using filtering syntax, we can do the same thing without modifying the DAG
+in-place:
+
+>>> filtered_dag = dag & my_filter
+
+The filter object can describe itself:
+
+>>> print(my_filter)
+HistoryDagFilter[minimum HammingParsimony then maximum NodeCount]
+
 
 Exporting Tree Data
 ===================
@@ -493,8 +557,8 @@ History DAGs, including histories, can also be easily visualized using the
 :meth:`HistoryDag.to_graphviz` method.
 
 
-TLDR: A Quick Tour
-==================
+A Quick Tour
+============
 
 In this package, the history DAG is a recursive data structure consisting of
 :class:`historydag.HistoryDagNode` objects storing label, clade, and adjacency

--- a/historydag/__init__.py
+++ b/historydag/__init__.py
@@ -8,6 +8,7 @@ from .dag import (  # noqa
     history_dag_from_newicks,
     history_dag_from_etes,
     history_dag_from_histories,
+    history_dag_from_trees,
 )
 
 from . import _version

--- a/historydag/compact_genome.py
+++ b/historydag/compact_genome.py
@@ -43,7 +43,10 @@ class CompactGenome:
         return not self.__lt__(other)
 
     def __repr__(self):
-        return f"CompactGenome({self.mutations}, '{self.reference}')"
+        return (
+            f"CompactGenome({self.mutations},"
+            f" <reference sequence str with id:{id(self.reference)}>)"
+        )
 
     def __str__(self):
         return f"CompactGenome[{', '.join(self.mutations_as_strings())}]"
@@ -89,6 +92,8 @@ class CompactGenome:
                     self.reference,
                 )
         else:
+            if self.reference[idx - 1] != oldbase:
+                warn("recorded old base in reference sequence doesn't match old base")
             return CompactGenome(
                 self.mutations.set(idx, (oldbase, newbase)), self.reference
             )
@@ -102,15 +107,23 @@ class CompactGenome:
         match the recorded old base in this compact genome.
 
         Args:
-            muts: The mutations to apply
+            muts: The mutations to apply, in the order they should be applied
             reverse: Apply the mutations in reverse, such as when the provided mutations
                 describe how to achieve this CompactGenome from the desired CompactGenome.
+                If True, the mutations in `muts` will also be applied in reversed order.
 
         Returns:
             The new CompactGenome
         """
         newcg = self
-        for mut in muts:
+        if reverse:
+            mod_func = reversed
+        else:
+
+            def mod_func(seq):
+                yield from seq
+
+        for mut in mod_func(muts):
             newcg = newcg.mutate(mut, reverse=reverse)
         return newcg
 

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -526,13 +526,15 @@ class HistoryDag:
         # identical trees return True. TODO
         raise NotImplementedError
 
-    def __iand__(self, other: object) -> 'HistoryDag':
+    def __iand__(self, other: object) -> "HistoryDag":
         if not isinstance(other, utils.HistoryDagFilter):
-            raise TypeError(f"Filtering a HistoryDag object requires a HistoryDagFilter object, not f{type(other)}")
+            raise TypeError(
+                f"Filtering a HistoryDag object requires a HistoryDagFilter object, not f{type(other)}"
+            )
         self.trim_optimal_weight(**other)
         return self
 
-    def __and__(self, other: object) -> 'HistoryDag':
+    def __and__(self, other: object) -> "HistoryDag":
         outdag = self.copy()
         outdag &= other
         return outdag

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -838,6 +838,10 @@ class HistoryDag:
         """Return a generator containing all leaf nodes in the history DAG."""
         return self.find_nodes(HistoryDagNode.is_leaf)
 
+    def num_edges(self) -> int:
+        """Return the number of edges in the DAG, including edges descending from the UA node"""
+        return sum(len(list(n.children())) for n in self.preorder())
+
     def num_nodes(self) -> int:
         """Return the number of nodes in the DAG, not counting the UA node."""
         return sum(1 for _ in self.preorder(skip_ua_node=True))
@@ -1482,9 +1486,14 @@ class HistoryDag:
 
     def summary(self):
         """Print nicely formatted summary about the history DAG."""
-        print(f"Nodes:\t{sum(1 for _ in self.postorder())}")
+        print(type(self))
+        print(f"Nodes:\t{self.num_nodes()}")
+        print(f"Nodes:\t{self.num_edges()}")
         print(f"Trees:\t{self.count_histories()}")
-        utils.hist(self.weight_counts_with_ambiguities())
+        print(f"Leaves:\t{self.num_leaves()}")
+        min_nodes, max_nodes = self.weight_range_annotate(**utils.node_countfuncs)
+        print(f"Smallest tree has {min_nodes} nodes, largest tree has {max_nodes} nodes")
+        print(f"Average number of parents of internal nodes:\t{self.internal_avg_parents()}")
 
     def label_uncertainty_summary(self):
         """Print information about internal nodes which have the same child

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1640,6 +1640,7 @@ class HistoryDag:
         accum_func: Callable[[List[Weight]], Weight] = sum,
         min_func: Callable[[List[Weight]], Weight] = min,
         max_func: Callable[[List[Weight]], Weight] = max,
+        **kwargs,
     ):
         """Computes the minimum and maximum weight of any history in the
         history DAG.

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -526,6 +526,17 @@ class HistoryDag:
         # identical trees return True. TODO
         raise NotImplementedError
 
+    def __iand__(self, other: object) -> 'HistoryDag':
+        if not isinstance(other, utils.HistoryDagFilter):
+            raise TypeError(f"Filtering a HistoryDag object requires a HistoryDagFilter object, not f{type(other)}")
+        self.trim_optimal_weight(**other)
+        return self
+
+    def __and__(self, other: object) -> 'HistoryDag':
+        outdag = self.copy()
+        outdag &= other
+        return outdag
+
     def __getitem__(self, key) -> "HistoryDag":
         r"""Returns the history (tree-shaped sub-history DAG) in the current
         history dag corresponding to the given index."""
@@ -1545,6 +1556,7 @@ class HistoryDag:
         ] = utils.wrapped_hamming_distance,
         accum_func: Callable[[List[Weight]], Weight] = sum,
         optimal_func: Callable[[List[Weight]], Weight] = min,
+        **kwargs,
     ) -> Weight:
         r"""A template method for finding the optimal tree weight in the DAG.
         Dynamically annotates each node in the DAG with the optimal weight of a
@@ -1577,6 +1589,7 @@ class HistoryDag:
             ["HistoryDagNode", "HistoryDagNode"], Weight
         ] = utils.wrapped_hamming_distance,
         accum_func: Callable[[List[Weight]], Weight] = sum,
+        **kwargs,
     ):
         r"""A template method for counting weights of trees expressed in the
         history DAG.

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -839,7 +839,8 @@ class HistoryDag:
         return self.find_nodes(HistoryDagNode.is_leaf)
 
     def num_edges(self) -> int:
-        """Return the number of edges in the DAG, including edges descending from the UA node"""
+        """Return the number of edges in the DAG, including edges descending
+        from the UA node."""
         return sum(len(list(n.children())) for n in self.preorder())
 
     def num_nodes(self) -> int:
@@ -1492,8 +1493,12 @@ class HistoryDag:
         print(f"Trees:\t{self.count_histories()}")
         print(f"Leaves:\t{self.num_leaves()}")
         min_nodes, max_nodes = self.weight_range_annotate(**utils.node_countfuncs)
-        print(f"Smallest tree has {min_nodes} nodes, largest tree has {max_nodes} nodes")
-        print(f"Average number of parents of internal nodes:\t{self.internal_avg_parents()}")
+        print(
+            f"Smallest tree has {min_nodes} nodes, largest tree has {max_nodes} nodes"
+        )
+        print(
+            f"Average number of parents of internal nodes:\t{self.internal_avg_parents()}"
+        )
 
     def label_uncertainty_summary(self):
         """Print information about internal nodes which have the same child

--- a/historydag/mutation_annotated_dag.py
+++ b/historydag/mutation_annotated_dag.py
@@ -70,6 +70,11 @@ class CGHistoryDag(HistoryDag):
 
     # #### Overridden Methods ####
 
+    def summary(self):
+        HistoryDag.summary(self)
+        min_pars, max_pars = self.weight_range_annotate(**compact_genome_hamming_distance_countfuncs)
+        print(f"Parsimony score range {min_pars} to {max_pars}")
+
     def weight_count(
         self,
         *args,

--- a/historydag/mutation_annotated_dag.py
+++ b/historydag/mutation_annotated_dag.py
@@ -72,7 +72,9 @@ class CGHistoryDag(HistoryDag):
 
     def summary(self):
         HistoryDag.summary(self)
-        min_pars, max_pars = self.weight_range_annotate(**compact_genome_hamming_distance_countfuncs)
+        min_pars, max_pars = self.weight_range_annotate(
+            **compact_genome_hamming_distance_countfuncs
+        )
         print(f"Parsimony score range {min_pars} to {max_pars}")
 
     def weight_count(

--- a/historydag/sequence_dag.py
+++ b/historydag/sequence_dag.py
@@ -77,7 +77,9 @@ class SequenceHistoryDag(HistoryDag):
 
     def summary(self):
         HistoryDag.summary(self)
-        min_pars, max_pars = self.weight_range_annotate(**historydag.utils.hamming_distance_countfuncs)
+        min_pars, max_pars = self.weight_range_annotate(
+            **historydag.utils.hamming_distance_countfuncs
+        )
         print(f"Parsimony score range {min_pars} to {max_pars}")
 
 
@@ -163,5 +165,7 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
 
     def summary(self):
         HistoryDag.summary(self)
-        min_pars, max_pars = self.weight_range_annotate(**leaf_ambiguous_hamming_distance_countfuncs)
+        min_pars, max_pars = self.weight_range_annotate(
+            **leaf_ambiguous_hamming_distance_countfuncs
+        )
         print(f"Parsimony score range {min_pars} to {max_pars}")

--- a/historydag/sequence_dag.py
+++ b/historydag/sequence_dag.py
@@ -75,6 +75,11 @@ class SequenceHistoryDag(HistoryDag):
         """
         return self.weight_count(**historydag.utils.hamming_distance_countfuncs)
 
+    def summary(self):
+        HistoryDag.summary(self)
+        min_pars, max_pars = self.weight_range_annotate(**historydag.utils.hamming_distance_countfuncs)
+        print(f"Parsimony score range {min_pars} to {max_pars}")
+
 
 class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     """A HistoryDag subclass with node labels containing full nucleotide
@@ -155,3 +160,8 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
         """See :meth:`historydag.sequence_dag.SequenceHistoryDag.hamming_parsim
         ony_count`"""
         return self.weight_count(**leaf_ambiguous_hamming_distance_countfuncs)
+
+    def summary(self):
+        HistoryDag.summary(self)
+        min_pars, max_pars = self.weight_range_annotate(**leaf_ambiguous_hamming_distance_countfuncs)
+        print(f"Parsimony score range {min_pars} to {max_pars}")

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -330,6 +330,8 @@ class AddFuncDict(UserDict):
             self.name = name
             self.names = (self.name,)
         elif names is not None:
+            if not isinstance(names, tuple):
+                raise ValueError("``names`` keyword argument expects a tuple.")
             self.names = names
             self.name = None
         if not set(initialdata.keys()) == self.requiredkeys:

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -35,10 +35,9 @@ def compare_dag_and_tree_parsimonies(dag, transition_weights=None):
     # parsimony score depends on the choice of `transition_weights` arg
     if transition_weights is not None:
 
-        def weight_func(x, y):
-            return dag_parsimony.edge_weight_func_from_weight_matrix(
-                x, y, transition_weights, dag_parsimony.bases
-            )
+        weight_func = dag_parsimony.make_weighted_hamming_edge_func(
+            transition_weights, bases=dag_parsimony.bases
+        )
 
         s_ete_weight = s_ete_as_dag.optimal_weight_annotate(
             edge_weight_func=weight_func

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -784,3 +784,12 @@ def test_trim_filter():
     print(p_n_f)
     print(pnf_f)
     print(lc_f)
+
+
+def test_weight_range_annotate():
+    kwargs = hdag.utils.hamming_distance_countfuncs
+    for dag in dags:
+        assert dag.weight_range_annotate(**kwargs) == (
+            dag.optimal_weight_annotate(**kwargs, optimal_func=min),
+            dag.optimal_weight_annotate(**kwargs, optimal_func=max),
+        )

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -751,16 +751,16 @@ def test_trim_filter():
     node_f = hdag.utils.HistoryDagFilter(node_d, max)
     p_n_f = pars_f + node_f
 
-    assert ((cdag & pars_f) & node_f).weight_count(**p_n_f) == (
-        cdag & p_n_f
-    ).weight_count(**p_n_f)
+    assert (cdag[pars_f][node_f]).weight_count(**p_n_f) == (cdag[p_n_f]).weight_count(
+        **p_n_f
+    )
     print("sequential trimming is the same as trimming with sum of filters")
     # >>
     rf_d = hdag.utils.make_rfdistance_countfuncs(dag[25])
     rf_f = hdag.utils.HistoryDagFilter(rf_d, min)
 
     pnf_f = p_n_f + rf_f
-    assert ((cdag & p_n_f) & rf_f).weight_count(**pnf_f) == (cdag & pnf_f).weight_count(
+    assert (cdag[p_n_f][rf_f]).weight_count(**pnf_f) == (cdag[pnf_f]).weight_count(
         **pnf_f
     )
     print("sequential addition of Filters works")
@@ -775,7 +775,7 @@ def test_trim_filter():
         for w in weights.elements()
         if sum(c * ww for c, ww in zip([1, 2, 0], w)) == min_weight
     )
-    assert (cdag & lc_f).weight_count(**pnf_f) == min_weights
+    assert (cdag[lc_f]).weight_count(**pnf_f) == min_weights
     print("linear combination trimming works")
 
     # >>


### PR DESCRIPTION
This PR contains lots of improvements for convenient modification of HistoryDag objects

* adds a HistoryDagFilter object, extending AddFuncDict to include a function describing optimality, and implements a filtering syntax using `&`.
* adds the method `HistoryDag.weight_range_annotate` for automatically computing the minimum and maximum history weight in a DAG
* adds the method `HistoryDag.filter_nodes` and `HistoryDag.filter_node` for finding nodes that make a passed function True
* provides a more convenient interface for creating weighted hamming distance edge functions in `historydag.parsimony`
* adds an option to not trim the DAG after calling `parsimony.sankoff_downward`.