### PR TITLE
Implement sum pairwise rf distance

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -250,6 +250,34 @@ These operations may also be achieved using the :meth:`HistoryDag.merge` and
 >>> combined_dag = dag1.copy()
 >>> combined_dag.merge(dag2)
 
+Intersecting
+------------
+:class:`HistoryDag` also supports set-style intersection via ``&`` and ``&=``,
+so that the resulting history DAG contains the histories which were in both the
+intersected DAGs. In the following example, notice that both ``dag1`` and
+``dag2`` contain the history ``dag[0]``:
+
+>>> dag1 = dag[0] | (dag.sample() for _ in range(8))
+>>> dag2 = dag[0] | (dag.sample() for _ in range(8))
+>>> idag = dag1 & dag2
+>>> len(idag) >=1
+True
+>>> len(idag | dag1) == len(dag1)
+True
+>>> len(idag | dag2) == len(dag2)
+
+However, since a history DAG must contain at least a single history, empty
+intersections raise a :class:`dag.IntersectionError`:
+
+>>> dag[0] & dag[-1]
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "/home/user/historydag/historydag/dag.py", line 1086, in history_complement
+    raise IntersectionError("The requested complement contains no histories,"
+historydag.dag.IntersectionError: The requested complement contains no histories, and a history DAG must contain at least one history.
+
+The ``&`` operator is shorthand for :meth:`HistoryDag.history_intersect`.
+
 Completion
 ----------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -458,7 +458,7 @@ However, :class:`utils.HistoryDagFilter` can also be used in history DAG
 filtering syntax, which is equivalent to calling
 :meth:`HistoryDag.trim_optimal_weight` on a copy:
 
->>> filtered_dag = dag & min_nodes
+>>> filtered_dag = dag[min_nodes]
 >>> filtered_dag.weight_count(**min_nodes)
 Counter({35: 17})
 
@@ -523,10 +523,10 @@ The last expression above is faster than, but equivalent to:
 >>> dag.trim_optimal_weight(**max_node_count)
 37
 
-Using filtering syntax, we can do the same thing without modifying the DAG
+Using filtering syntax, we can conveniently do the same thing without modifying the DAG
 in-place:
 
->>> filtered_dag = dag & my_filter
+>>> filtered_dag = dag[my_filter]
 
 The filter object can describe itself:
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -385,8 +385,8 @@ number of nodes:
 ... )
 Counter({37: 173})
 
-The AddFuncDict
----------------
+The AddFuncDict Class
+---------------------
 
 Since the interfaces of these three methods are similar, we provide
 a special subclassed dictionary :class:`utils.AddFuncDict` for storing
@@ -435,11 +435,40 @@ A variety of useful :class:`utils.AddFuncDict` objects are provided:
   although this functionality is conveniently wrapped in
   :meth:`HistoryDag.to_newick` and :meth:`HistoryDag.to_newicks`.
 
+The HistoryDagFilter Class
+---------------------------
+
+In addition to an edge weight function, history DAG methods like
+:meth:`HistoryDag.trim_optimal_weight` require a choice of ``optimal_func``,
+usually specifying whether to minimize or maximize the weight of histories.
+
+The :class:`utils.HistoryDagFilter` class provides a container for
+a :class:`utils.AddFuncDict` and an ``optimal_func``, and provides a similar
+interface as :class:`utils.AddFuncDict`, allowing keyword argument unpacking:
+
+>>> dag.weight_count(**node_count_funcs)
+Counter({35: 17, 36: 325, 37: 173})
+>>> min_nodes = hdag.utils.HistoryDagFilter(node_count_funcs, min)
+>>> print(min_parsimony)
+HistoryDagFilter[minimum NodeCount]
+>>> dag.optimal_weight_annotate(**min_nodes)
+35
+
+However, :class:`utils.HistoryDagFilter` can also be used in history DAG
+filtering syntax, which is equivalent to calling
+:meth:`HistoryDag.trim_optimal_weight` on a copy:
+
+>>> filtered_dag = dag & min_nodes
+>>> filtered_dag.weight_count(**min_nodes)
+Counter({35: 17})
+
+
 Combining Weights
 -----------------
 
-The primary advantage of a :class:`utils.AddFuncDict` object over a plain
-dictionary is its composability via the ``+`` operator.
+The primary advantage of a :class:`utils.AddFuncDict` and
+:class:`utils.HistoryDagFilter` objects over a plain
+dictionary are their composability via the ``+`` operator.
 
 Addition of two ``AddFuncDict`` objects returns a new ``AddFuncDict`` which
 computes the weights implemented by the original two ``AddFuncDict``'s
@@ -467,8 +496,43 @@ order of addition (note that nested tuples are avoided). The names of each
 weight are stored in the ``names`` attribute of the resulting data structure:
 
 >>> kwargs = utils.hamming_distance_countfuncs + utils.node_countfuncs
+>>> print(kwargs)
+AddFuncDict[HammingParsimony, NodeCount]
 >>> kwargs.names
 ('HammingParsimony', 'NodeCount')
+
+
+Similary, addition of two ``HistoryDagFilter`` objects returns a new
+``HistoryDagFilter`` which implements the added ``HistoryDagFilter`` operations
+sequentially. The contained ``AddFuncDict`` is the sum of the original two
+``AddFuncDicts``, so computes the weights implemented by
+the original two ``AddFuncDict``'s simultaneously, storing them in a tuple.
+
+>>> min_parsimony = utils.HistoryDagFilter(utils.hamming_distance_countfuncs, min)
+>>> max_node_count = utils.HistoryDagFilter(utils.node_countfuncs, max)
+>>> my_filter = min_parsimony + max_node_count
+>>> dag.weight_count(**my_filter)
+Counter({(73, 35): 17, (73, 36): 320, (74, 36): 5, (74, 37): 112, (73, 37): 61})
+>>> dag.trim_optimal_weight(**my_filter)
+(73, 37)
+
+The last expression above is faster than, but equivalent to:
+
+>>> dag.trim_optimal_weight(**min_parsimony)
+73
+>>> dag.trim_optimal_weight(**max_node_count)
+37
+
+Using filtering syntax, we can do the same thing without modifying the DAG
+in-place:
+
+>>> filtered_dag = dag & my_filter
+
+The filter object can describe itself:
+
+>>> print(my_filter)
+HistoryDagFilter[minimum HammingParsimony then maximum NodeCount]
+
 
 Exporting Tree Data
 ===================
@@ -493,8 +557,8 @@ History DAGs, including histories, can also be easily visualized using the
 :meth:`HistoryDag.to_graphviz` method.
 
 
-TLDR: A Quick Tour
-==================
+A Quick Tour
+============
 
 In this package, the history DAG is a recursive data structure consisting of
 :class:`historydag.HistoryDagNode` objects storing label, clade, and adjacency

--- a/historydag/__init__.py
+++ b/historydag/__init__.py
@@ -8,6 +8,7 @@ from .dag import (  # noqa
     history_dag_from_newicks,
     history_dag_from_etes,
     history_dag_from_histories,
+    history_dag_from_trees,
 )
 
 from . import _version

--- a/historydag/compact_genome.py
+++ b/historydag/compact_genome.py
@@ -43,7 +43,10 @@ class CompactGenome:
         return not self.__lt__(other)
 
     def __repr__(self):
-        return f"CompactGenome({self.mutations}, '{self.reference}')"
+        return (
+            f"CompactGenome({self.mutations},"
+            f" <reference sequence str with id:{id(self.reference)}>)"
+        )
 
     def __str__(self):
         return f"CompactGenome[{', '.join(self.mutations_as_strings())}]"
@@ -89,6 +92,8 @@ class CompactGenome:
                     self.reference,
                 )
         else:
+            if self.reference[idx - 1] != oldbase:
+                warn("recorded old base in reference sequence doesn't match old base")
             return CompactGenome(
                 self.mutations.set(idx, (oldbase, newbase)), self.reference
             )
@@ -102,15 +107,23 @@ class CompactGenome:
         match the recorded old base in this compact genome.
 
         Args:
-            muts: The mutations to apply
+            muts: The mutations to apply, in the order they should be applied
             reverse: Apply the mutations in reverse, such as when the provided mutations
                 describe how to achieve this CompactGenome from the desired CompactGenome.
+                If True, the mutations in `muts` will also be applied in reversed order.
 
         Returns:
             The new CompactGenome
         """
         newcg = self
-        for mut in muts:
+        if reverse:
+            mod_func = reversed
+        else:
+
+            def mod_func(seq):
+                yield from seq
+
+        for mut in mod_func(muts):
             newcg = newcg.mutate(mut, reverse=reverse)
         return newcg
 

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -526,13 +526,15 @@ class HistoryDag:
         # identical trees return True. TODO
         raise NotImplementedError
 
-    def __iand__(self, other: object) -> 'HistoryDag':
+    def __iand__(self, other: object) -> "HistoryDag":
         if not isinstance(other, utils.HistoryDagFilter):
-            raise TypeError(f"Filtering a HistoryDag object requires a HistoryDagFilter object, not f{type(other)}")
+            raise TypeError(
+                f"Filtering a HistoryDag object requires a HistoryDagFilter object, not f{type(other)}"
+            )
         self.trim_optimal_weight(**other)
         return self
 
-    def __and__(self, other: object) -> 'HistoryDag':
+    def __and__(self, other: object) -> "HistoryDag":
         outdag = self.copy()
         outdag &= other
         return outdag

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -838,6 +838,10 @@ class HistoryDag:
         """Return a generator containing all leaf nodes in the history DAG."""
         return self.find_nodes(HistoryDagNode.is_leaf)
 
+    def num_edges(self) -> int:
+        """Return the number of edges in the DAG, including edges descending from the UA node"""
+        return sum(len(list(n.children())) for n in self.preorder())
+
     def num_nodes(self) -> int:
         """Return the number of nodes in the DAG, not counting the UA node."""
         return sum(1 for _ in self.preorder(skip_ua_node=True))
@@ -1482,9 +1486,14 @@ class HistoryDag:
 
     def summary(self):
         """Print nicely formatted summary about the history DAG."""
-        print(f"Nodes:\t{sum(1 for _ in self.postorder())}")
+        print(type(self))
+        print(f"Nodes:\t{self.num_nodes()}")
+        print(f"Nodes:\t{self.num_edges()}")
         print(f"Trees:\t{self.count_histories()}")
-        utils.hist(self.weight_counts_with_ambiguities())
+        print(f"Leaves:\t{self.num_leaves()}")
+        min_nodes, max_nodes = self.weight_range_annotate(**utils.node_countfuncs)
+        print(f"Smallest tree has {min_nodes} nodes, largest tree has {max_nodes} nodes")
+        print(f"Average number of parents of internal nodes:\t{self.internal_avg_parents()}")
 
     def label_uncertainty_summary(self):
         """Print information about internal nodes which have the same child

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -28,8 +28,10 @@ from historydag import utils
 from historydag.utils import Weight, Label, UALabel, prod
 from historydag.counterops import counter_sum, counter_prod
 
+
 class IntersectionError(ValueError):
     pass
+
 
 def _clade_union_dict(nodeseq: Sequence["HistoryDagNode"]) -> Dict:
     clade_dict: Dict[FrozenSet[Label], List[HistoryDagNode]] = {}
@@ -673,7 +675,9 @@ class HistoryDag:
 
     def __iand__(self, other) -> "HistoryDag":
         if not isinstance(other, HistoryDag):
-            raise TypeError(f"Unsupported operand types for &: 'HistoryDag' and '{type(other)}'")
+            raise TypeError(
+                f"Unsupported operand types for &: 'HistoryDag' and '{type(other)}'"
+            )
         else:
             self.history_intersect(other)
             return self
@@ -1084,7 +1088,6 @@ class HistoryDag:
         """
         return pickle.loads(pickle.dumps(self))
 
-        
     def history_intersect(self, other_dag: "HistoryDag", key=lambda n: n):
         """Modify this HistoryDag to contain only the histories which are also
         contained in ``other_dag``.
@@ -1095,19 +1098,25 @@ class HistoryDag:
             key: A function accepting a node and returning a value which will be used to compare
                 nodes.
         """
-        
-        edge_set = set((key(n), key(c)) for n in other_dag.preorder() for c in n.children())
+
+        edge_set = set(
+            (key(n), key(c)) for n in other_dag.preorder() for c in n.children()
+        )
 
         def edge_weight_func(n1, n2):
             return int((key(n1), key(n2)) not in edge_set)
 
-        min_weight = self.trim_optimal_weight(edge_weight_func=edge_weight_func,
-                                              accum_func=sum,
-                                              optimal_func=min,
-                                              start_func=lambda n: 0)
+        min_weight = self.trim_optimal_weight(
+            edge_weight_func=edge_weight_func,
+            accum_func=sum,
+            optimal_func=min,
+            start_func=lambda n: 0,
+        )
         if min_weight > 0:
-            raise IntersectionError("Provided history DAGs have no histories in common,"
-                                    " and a history DAG must contain at least one history.")
+            raise IntersectionError(
+                "Provided history DAGs have no histories in common,"
+                " and a history DAG must contain at least one history."
+            )
 
     def merge(self, trees: Union["HistoryDag", Sequence["HistoryDag"]]):
         r"""Graph union this history DAG with all those in a list of history
@@ -2148,7 +2157,8 @@ class HistoryDag:
         return self.weight_count(**kwargs)
 
     def count_sum_rf_distances(self, reference_dag: "HistoryDag", rooted: bool = False):
-        """Returns a Counter containing all sum RF distances to a given reference DAG.
+        """Returns a Counter containing all sum RF distances to a given
+        reference DAG.
 
         The given history DAG must be on the same taxa as all trees in the DAG.
 
@@ -2203,7 +2213,11 @@ class HistoryDag:
         n_histories_prime, N_prime, clade_count_sum_prime = get_data(self)
 
         if reference_dag is None:
-            n_histories, N, clade_count_sum = n_histories_prime, N_prime, clade_count_sum_prime
+            n_histories, N, clade_count_sum = (
+                n_histories_prime,
+                N_prime,
+                clade_count_sum_prime,
+            )
         else:
             n_histories, N, clade_count_sum = get_data(reference_dag)
 
@@ -2220,7 +2234,8 @@ class HistoryDag:
         )
 
     def average_pairwise_rf_distance(self, reference_dag: "HistoryDag" = None):
-        """Return the average Robinson-Foulds distance between pairs of histories.
+        """Return the average Robinson-Foulds distance between pairs of
+        histories.
 
         Args:
             reference_dag: A history DAG from which to take the second history in
@@ -2235,7 +2250,8 @@ class HistoryDag:
             between pairs of non-identical histories in ``self``. Since identical pairs are
             excluded in this case, ``dag.average_pairwise_distance()`` will not match
             (and should in general be greater than)
-            ``dag.average_pairwise_distance(reference_dag=dag)``."""
+            ``dag.average_pairwise_distance(reference_dag=dag)``.
+        """
         sum_pairwise_distance = self.sum_rf_distances(reference_dag=reference_dag)
         if reference_dag is None:
             # ignore the diagonal in the distance matrix, since it contains

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1640,6 +1640,7 @@ class HistoryDag:
         accum_func: Callable[[List[Weight]], Weight] = sum,
         min_func: Callable[[List[Weight]], Weight] = min,
         max_func: Callable[[List[Weight]], Weight] = max,
+        **kwargs,
     ):
         """Computes the minimum and maximum weight of any history in the
         history DAG.

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -526,6 +526,17 @@ class HistoryDag:
         # identical trees return True. TODO
         raise NotImplementedError
 
+    def __iand__(self, other: object) -> 'HistoryDag':
+        if not isinstance(other, utils.HistoryDagFilter):
+            raise TypeError(f"Filtering a HistoryDag object requires a HistoryDagFilter object, not f{type(other)}")
+        self.trim_optimal_weight(**other)
+        return self
+
+    def __and__(self, other: object) -> 'HistoryDag':
+        outdag = self.copy()
+        outdag &= other
+        return outdag
+
     def __getitem__(self, key) -> "HistoryDag":
         r"""Returns the history (tree-shaped sub-history DAG) in the current
         history dag corresponding to the given index."""
@@ -1545,6 +1556,7 @@ class HistoryDag:
         ] = utils.wrapped_hamming_distance,
         accum_func: Callable[[List[Weight]], Weight] = sum,
         optimal_func: Callable[[List[Weight]], Weight] = min,
+        **kwargs,
     ) -> Weight:
         r"""A template method for finding the optimal tree weight in the DAG.
         Dynamically annotates each node in the DAG with the optimal weight of a
@@ -1577,6 +1589,7 @@ class HistoryDag:
             ["HistoryDagNode", "HistoryDagNode"], Weight
         ] = utils.wrapped_hamming_distance,
         accum_func: Callable[[List[Weight]], Weight] = sum,
+        **kwargs,
     ):
         r"""A template method for counting weights of trees expressed in the
         history DAG.

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -2110,6 +2110,54 @@ class HistoryDag:
 
     # ######## End Abstract DP method derivatives ########
 
+    def sum_rf_distances(self, reference_dag=None: "HistoryDag"):
+        """Computes the sum of all Robinson-Foulds distances between a history in this DAG
+        and a history in the reference DAG.
+
+        This is rooted RF distance.
+
+        If T is the set of histories in the reference DAG, and T' is the set of histories in
+        this DAG, then the returned sum is:
+
+        .. math::
+
+            \sum_{t\in T} \sum_{t'\in T'} d(t, t')
+
+        That is, since RF distance is symmetric, when T = T' (such as when ``reference_dag=None``),
+        or when the intersection of T and T' is nonempty, some distances are counted twice.
+
+        Args:
+            reference_dag: If None, the sum of pairwise distances between histories in this DAG
+                is computed. If provided, the sum is over pairs containing one history in this DAG and
+                one from ``reference_dag``.
+
+        Returns:
+            An integer sum of RF distances.
+        """
+
+        def get_data(dag):
+            n_histories = dag.count_histories()
+            N = reference_dag.count_nodes(collapse=True)
+            for child in reference_dag.dagroot.children():
+                N[child.clade_union()] -= n_histories
+            try:
+                N.pop(frozenset())
+            except KeyError:
+                pass
+            return (n_histories, N)
+            
+
+        n_histories_prime, N_prime = get_data(self)
+        
+        if reference_dag is None:
+            n_histories, N = n_histories_prime, N_prime
+        else:
+            n_histories, N = get_data(reference_dag)
+
+        re
+
+
+
     def trim_optimal_weight(
         self,
         start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -839,7 +839,8 @@ class HistoryDag:
         return self.find_nodes(HistoryDagNode.is_leaf)
 
     def num_edges(self) -> int:
-        """Return the number of edges in the DAG, including edges descending from the UA node"""
+        """Return the number of edges in the DAG, including edges descending
+        from the UA node."""
         return sum(len(list(n.children())) for n in self.preorder())
 
     def num_nodes(self) -> int:
@@ -1492,8 +1493,12 @@ class HistoryDag:
         print(f"Trees:\t{self.count_histories()}")
         print(f"Leaves:\t{self.num_leaves()}")
         min_nodes, max_nodes = self.weight_range_annotate(**utils.node_countfuncs)
-        print(f"Smallest tree has {min_nodes} nodes, largest tree has {max_nodes} nodes")
-        print(f"Average number of parents of internal nodes:\t{self.internal_avg_parents()}")
+        print(
+            f"Smallest tree has {min_nodes} nodes, largest tree has {max_nodes} nodes"
+        )
+        print(
+            f"Average number of parents of internal nodes:\t{self.internal_avg_parents()}"
+        )
 
     def label_uncertainty_summary(self):
         """Print information about internal nodes which have the same child

--- a/historydag/mutation_annotated_dag.py
+++ b/historydag/mutation_annotated_dag.py
@@ -70,6 +70,11 @@ class CGHistoryDag(HistoryDag):
 
     # #### Overridden Methods ####
 
+    def summary(self):
+        HistoryDag.summary(self)
+        min_pars, max_pars = self.weight_range_annotate(**compact_genome_hamming_distance_countfuncs)
+        print(f"Parsimony score range {min_pars} to {max_pars}")
+
     def weight_count(
         self,
         *args,

--- a/historydag/mutation_annotated_dag.py
+++ b/historydag/mutation_annotated_dag.py
@@ -72,7 +72,9 @@ class CGHistoryDag(HistoryDag):
 
     def summary(self):
         HistoryDag.summary(self)
-        min_pars, max_pars = self.weight_range_annotate(**compact_genome_hamming_distance_countfuncs)
+        min_pars, max_pars = self.weight_range_annotate(
+            **compact_genome_hamming_distance_countfuncs
+        )
         print(f"Parsimony score range {min_pars} to {max_pars}")
 
     def weight_count(

--- a/historydag/sequence_dag.py
+++ b/historydag/sequence_dag.py
@@ -77,7 +77,9 @@ class SequenceHistoryDag(HistoryDag):
 
     def summary(self):
         HistoryDag.summary(self)
-        min_pars, max_pars = self.weight_range_annotate(**historydag.utils.hamming_distance_countfuncs)
+        min_pars, max_pars = self.weight_range_annotate(
+            **historydag.utils.hamming_distance_countfuncs
+        )
         print(f"Parsimony score range {min_pars} to {max_pars}")
 
 
@@ -163,5 +165,7 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
 
     def summary(self):
         HistoryDag.summary(self)
-        min_pars, max_pars = self.weight_range_annotate(**leaf_ambiguous_hamming_distance_countfuncs)
+        min_pars, max_pars = self.weight_range_annotate(
+            **leaf_ambiguous_hamming_distance_countfuncs
+        )
         print(f"Parsimony score range {min_pars} to {max_pars}")

--- a/historydag/sequence_dag.py
+++ b/historydag/sequence_dag.py
@@ -75,6 +75,11 @@ class SequenceHistoryDag(HistoryDag):
         """
         return self.weight_count(**historydag.utils.hamming_distance_countfuncs)
 
+    def summary(self):
+        HistoryDag.summary(self)
+        min_pars, max_pars = self.weight_range_annotate(**historydag.utils.hamming_distance_countfuncs)
+        print(f"Parsimony score range {min_pars} to {max_pars}")
+
 
 class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     """A HistoryDag subclass with node labels containing full nucleotide
@@ -155,3 +160,8 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
         """See :meth:`historydag.sequence_dag.SequenceHistoryDag.hamming_parsim
         ony_count`"""
         return self.weight_count(**leaf_ambiguous_hamming_distance_countfuncs)
+
+    def summary(self):
+        HistoryDag.summary(self)
+        min_pars, max_pars = self.weight_range_annotate(**leaf_ambiguous_hamming_distance_countfuncs)
+        print(f"Parsimony score range {min_pars} to {max_pars}")

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -330,6 +330,8 @@ class AddFuncDict(UserDict):
             self.name = name
             self.names = (self.name,)
         elif names is not None:
+            if not isinstance(names, tuple):
+                raise ValueError("``names`` keyword argument expects a tuple.")
             self.names = names
             self.name = None
         if not set(initialdata.keys()) == self.requiredkeys:

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -35,10 +35,9 @@ def compare_dag_and_tree_parsimonies(dag, transition_weights=None):
     # parsimony score depends on the choice of `transition_weights` arg
     if transition_weights is not None:
 
-        def weight_func(x, y):
-            return dag_parsimony.edge_weight_func_from_weight_matrix(
-                x, y, transition_weights, dag_parsimony.bases
-            )
+        weight_func = dag_parsimony.make_weighted_hamming_edge_func(
+            transition_weights, bases=dag_parsimony.bases
+        )
 
         s_ete_weight = s_ete_as_dag.optimal_weight_annotate(
             edge_weight_func=weight_func

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -784,3 +784,12 @@ def test_trim_filter():
     print(p_n_f)
     print(pnf_f)
     print(lc_f)
+
+
+def test_weight_range_annotate():
+    kwargs = hdag.utils.hamming_distance_countfuncs
+    for dag in dags:
+        assert dag.weight_range_annotate(**kwargs) == (
+            dag.optimal_weight_annotate(**kwargs, optimal_func=min),
+            dag.optimal_weight_annotate(**kwargs, optimal_func=max),
+        )

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -794,21 +794,23 @@ def test_weight_range_annotate():
             dag.optimal_weight_annotate(**kwargs, optimal_func=max),
         )
 
+
 def test_sum_all_pair_rf_distance():
     dag = dags[-1]
 
     # check 0 on single-tree dag vs itself:
     assert dag[0].sum_rf_distances() == 0
-    assert dag[0].sum_rf_distances(reference_dag = dag[0]) == 0
-
+    assert dag[0].sum_rf_distances(reference_dag=dag[0]) == 0
 
     # check matches single rf distance between two single-tree dags:
     udag = dag.unlabel()
-    assert udag[0].sum_rf_distances(reference_dag=udag[-1]) == udag[0].optimal_rf_distance(udag[-1])
-
+    assert udag[0].sum_rf_distances(reference_dag=udag[-1]) == udag[
+        0
+    ].optimal_rf_distance(udag[-1])
 
     # check matches truth on whole DAG vs self:
     assert dag.sum_rf_distances() == sum(dag.count_sum_rf_distances(dag).elements())
+
 
 def test_intersection():
     dag = dags[-1]

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -793,3 +793,19 @@ def test_weight_range_annotate():
             dag.optimal_weight_annotate(**kwargs, optimal_func=min),
             dag.optimal_weight_annotate(**kwargs, optimal_func=max),
         )
+
+def test_sum_all_pair_rf_distance():
+    dag = dags[-1]
+
+    # check 0 on single-tree dag vs itself:
+    assert dag[0].sum_rf_distances() == 0
+    assert dag[0].sum_rf_distances(reference_dag = dag[0]) == 0
+
+
+    # check matches single rf distance between two single-tree dags:
+    udag = dag.unlabel()
+    assert udag[0].sum_rf_distances(reference_dag=udag[-1]) == udag[0].optimal_rf_distance(udag[-1])
+
+
+    # check matches truth on whole DAG vs self:
+    assert dag.sum_rf_distances() == sum(dag.count_sum_rf_distances(dag).elements())

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -751,16 +751,16 @@ def test_trim_filter():
     node_f = hdag.utils.HistoryDagFilter(node_d, max)
     p_n_f = pars_f + node_f
 
-    assert ((cdag & pars_f) & node_f).weight_count(**p_n_f) == (
-        cdag & p_n_f
-    ).weight_count(**p_n_f)
+    assert (cdag[pars_f][node_f]).weight_count(**p_n_f) == (cdag[p_n_f]).weight_count(
+        **p_n_f
+    )
     print("sequential trimming is the same as trimming with sum of filters")
     # >>
     rf_d = hdag.utils.make_rfdistance_countfuncs(dag[25])
     rf_f = hdag.utils.HistoryDagFilter(rf_d, min)
 
     pnf_f = p_n_f + rf_f
-    assert ((cdag & p_n_f) & rf_f).weight_count(**pnf_f) == (cdag & pnf_f).weight_count(
+    assert (cdag[p_n_f][rf_f]).weight_count(**pnf_f) == (cdag[pnf_f]).weight_count(
         **pnf_f
     )
     print("sequential addition of Filters works")
@@ -775,7 +775,7 @@ def test_trim_filter():
         for w in weights.elements()
         if sum(c * ww for c, ww in zip([1, 2, 0], w)) == min_weight
     )
-    assert (cdag & lc_f).weight_count(**pnf_f) == min_weights
+    assert (cdag[lc_f]).weight_count(**pnf_f) == min_weights
     print("linear combination trimming works")
 
     # >>

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -809,3 +809,12 @@ def test_sum_all_pair_rf_distance():
 
     # check matches truth on whole DAG vs self:
     assert dag.sum_rf_distances() == sum(dag.count_sum_rf_distances(dag).elements())
+
+def test_intersection():
+    dag = dags[-1]
+    dag1 = hdag.history_dag_from_histories(dag.sample() for _ in range(8)) | dag[0]
+    dag2 = hdag.history_dag_from_histories(dag.sample() for _ in range(8)) | dag[0]
+    idag = dag1 & dag2
+
+    assert len(idag | dag1) == len(dag1)
+    assert len(idag | dag2) == len(dag2)


### PR DESCRIPTION
This PR adds methods `HistoryDag.sum_rf_distances` and `HistoryDag.average_pairwise_rf_distance`, which compute the sum of rooted RF distances over all pairs of histories in a DAG, or between two DAGs.

Also added, a method `HistoryDag.history_intersect` which trims the DAG to contain only the histories which are also in a passed reference DAG. This method can be run using the `&` operator.

