### PR TITLE
Add average pairwise RF distance method

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -250,6 +250,34 @@ These operations may also be achieved using the :meth:`HistoryDag.merge` and
 >>> combined_dag = dag1.copy()
 >>> combined_dag.merge(dag2)
 
+Intersecting
+------------
+:class:`HistoryDag` also supports set-style intersection via ``&`` and ``&=``,
+so that the resulting history DAG contains the histories which were in both the
+intersected DAGs. In the following example, notice that both ``dag1`` and
+``dag2`` contain the history ``dag[0]``:
+
+>>> dag1 = dag[0] | (dag.sample() for _ in range(8))
+>>> dag2 = dag[0] | (dag.sample() for _ in range(8))
+>>> idag = dag1 & dag2
+>>> len(idag) >=1
+True
+>>> len(idag | dag1) == len(dag1)
+True
+>>> len(idag | dag2) == len(dag2)
+
+However, since a history DAG must contain at least a single history, empty
+intersections raise a :class:`dag.IntersectionError`:
+
+>>> dag[0] & dag[-1]
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "/home/user/historydag/historydag/dag.py", line 1086, in history_complement
+    raise IntersectionError("The requested complement contains no histories,"
+historydag.dag.IntersectionError: The requested complement contains no histories, and a history DAG must contain at least one history.
+
+The ``&`` operator is shorthand for :meth:`HistoryDag.history_intersect`.
+
 Completion
 ----------
 

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1552,6 +1552,7 @@ class HistoryDag:
         print(f"Leaf node count range: {min_leaves} to {max_leaves}")
         min_nodes, max_nodes = self.weight_range_annotate(**utils.node_countfuncs)
         print(f"Total node count range: {min_nodes} to {max_nodes}")
+        print(f"Average pairwise RF distance:\t{self.average_pairwise_rf_distance()}")
 
     def label_uncertainty_summary(self):
         """Print information about internal nodes which have the same child

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -29,6 +29,10 @@ from historydag.utils import Weight, Label, UALabel, prod
 from historydag.counterops import counter_sum, counter_prod
 
 
+class IntersectionError(ValueError):
+    pass
+
+
 def _clade_union_dict(nodeseq: Sequence["HistoryDagNode"]) -> Dict:
     clade_dict: Dict[FrozenSet[Label], List[HistoryDagNode]] = {}
     for node in nodeseq:
@@ -669,6 +673,20 @@ class HistoryDag:
     def __ror__(self, other) -> "HistoryDag":
         return other | self
 
+    def __iand__(self, other) -> "HistoryDag":
+        if not isinstance(other, HistoryDag):
+            raise TypeError(
+                f"Unsupported operand types for &: 'HistoryDag' and '{type(other)}'"
+            )
+        else:
+            self.history_intersect(other)
+            return self
+
+    def __and__(self, other) -> "HistoryDag":
+        cdag = self.copy()
+        cdag &= other
+        return cdag
+
     def __getstate__(self) -> Dict:
         r"""Converts HistoryDag to a bytestring-serializable dictionary.
 
@@ -1069,6 +1087,36 @@ class HistoryDag:
         However, other object attributes will not be copied.
         """
         return pickle.loads(pickle.dumps(self))
+
+    def history_intersect(self, other_dag: "HistoryDag", key=lambda n: n):
+        """Modify this HistoryDag to contain only the histories which are also
+        contained in ``other_dag``.
+
+        Args:
+            other_dag: The history DAG with which this one will be intersected. ``other_dag``
+                will not be modified.
+            key: A function accepting a node and returning a value which will be used to compare
+                nodes.
+        """
+
+        edge_set = set(
+            (key(n), key(c)) for n in other_dag.preorder() for c in n.children()
+        )
+
+        def edge_weight_func(n1, n2):
+            return int((key(n1), key(n2)) not in edge_set)
+
+        min_weight = self.trim_optimal_weight(
+            edge_weight_func=edge_weight_func,
+            accum_func=sum,
+            optimal_func=min,
+            start_func=lambda n: 0,
+        )
+        if min_weight > 0:
+            raise IntersectionError(
+                "Provided history DAGs have no histories in common,"
+                " and a history DAG must contain at least one history."
+            )
 
     def merge(self, trees: Union["HistoryDag", Sequence["HistoryDag"]]):
         r"""Graph union this history DAG with all those in a list of history
@@ -2108,7 +2156,114 @@ class HistoryDag:
         kwargs = utils.make_rfdistance_countfuncs(history, rooted=rooted)
         return self.weight_count(**kwargs)
 
+    def count_sum_rf_distances(self, reference_dag: "HistoryDag", rooted: bool = False):
+        """Returns a Counter containing all sum RF distances to a given
+        reference DAG.
+
+        The given history DAG must be on the same taxa as all trees in the DAG.
+
+        Since computing reference splits is expensive, it is better to use
+        :meth:`weight_count` and :meth:`utils.sum_rfdistance_funcs`
+        instead of making multiple calls to this method with the same reference
+        history DAG.
+        """
+        kwargs = utils.sum_rfdistance_funcs(reference_dag)
+        return self.weight_count(**kwargs)
+
     # ######## End Abstract DP method derivatives ########
+
+    def sum_rf_distances(self, reference_dag: "HistoryDag" = None):
+        r"""Computes the sum of all Robinson-Foulds distances between a history
+        in this DAG and a history in the reference DAG.
+
+        This is rooted RF distance.
+
+        If T is the set of histories in the reference DAG, and T' is the set of histories in
+        this DAG, then the returned sum is:
+
+        .. math::
+
+            \sum_{t\in T} \sum_{t'\in T'} d(t, t')
+
+        That is, since RF distance is symmetric, when T = T' (such as when ``reference_dag=None``),
+        or when the intersection of T and T' is nonempty, some distances are counted twice.
+
+        Args:
+            reference_dag: If None, the sum of pairwise distances between histories in this DAG
+                is computed. If provided, the sum is over pairs containing one history in this DAG and
+                one from ``reference_dag``.
+
+        Returns:
+            An integer sum of RF distances.
+        """
+
+        def get_data(dag):
+            n_histories = dag.count_histories()
+            N = dag.count_nodes(collapse=True)
+            for child in dag.dagroot.children():
+                N[child.clade_union()] -= n_histories
+            try:
+                N.pop(frozenset())
+            except KeyError:
+                pass
+
+            clade_count_sum = sum(N.values())
+            return (n_histories, N, clade_count_sum)
+
+        n_histories_prime, N_prime, clade_count_sum_prime = get_data(self)
+
+        if reference_dag is None:
+            n_histories, N, clade_count_sum = (
+                n_histories_prime,
+                N_prime,
+                clade_count_sum_prime,
+            )
+        else:
+            n_histories, N, clade_count_sum = get_data(reference_dag)
+
+        intersection_term = sum(
+            count_prime * N[clade]
+            for clade, count_prime in N_prime.items()
+            if clade in N
+        )
+
+        return (
+            n_histories * clade_count_sum_prime
+            + n_histories_prime * clade_count_sum
+            - 2 * intersection_term
+        )
+
+    def average_pairwise_rf_distance(self, reference_dag: "HistoryDag" = None):
+        """Return the average Robinson-Foulds distance between pairs of
+        histories.
+
+        Args:
+            reference_dag: A history DAG from which to take the second history in
+                each pair. If None, ``self`` will be used as the reference.
+
+        Returns:
+            The average rf-distance between pairs of histories, where the first history
+            comes from this DAG, and the second comes from ``reference_dag``. The normalization
+            constant is the product of the number of histories in the two DAGs.
+
+            If ``reference_dag`` is ``None`, then this method returns the average distance
+            between pairs of non-identical histories in ``self``. Since identical pairs are
+            excluded in this case, ``dag.average_pairwise_distance()`` will not match
+            (and should in general be greater than)
+            ``dag.average_pairwise_distance(reference_dag=dag)``.
+        """
+        sum_pairwise_distance = self.sum_rf_distances(reference_dag=reference_dag)
+        if reference_dag is None:
+            # ignore the diagonal in the distance matrix, since it contains
+            # zeros:
+            n = self.count_histories()
+            normalize_num = n * (n - 1)
+        else:
+            # cannot ignore diagonal:
+            n1 = self.count_histories()
+            n2 = reference_dag.count_histories()
+            normalize_num = n1 * n2
+        return sum_pairwise_distance / normalize_num
 
     def trim_optimal_weight(
         self,

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -2201,8 +2201,6 @@ class HistoryDag:
         def get_data(dag):
             n_histories = dag.count_histories()
             N = dag.count_nodes(collapse=True)
-            for child in dag.dagroot.children():
-                N[child.clade_union()] -= n_histories
             try:
                 N.pop(frozenset())
             except KeyError:

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -601,16 +601,18 @@ For use with :meth:`historydag.HistoryDag.weight_count`."""
 
 
 def natural_edge_probability(parent, child):
-    """Return the downward-conditional edge probability
-    of the edge from parent to child.
+    """Return the downward-conditional edge probability of the edge from parent
+    to child.
 
-    This is defined as 1/n, where n is the number of
-    edges descending from the same child clade of ``parent`` as this edge."""
+    This is defined as 1/n, where n is the number of edges descending
+    from the same child clade of ``parent`` as this edge.
+    """
     if parent.is_ua_node():
         return 1 / len(list(parent.children()))
     else:
         eset = parent.clades[child.clade_union()]
         return 1 / len(eset.targets)
+
 
 log_natural_probability_funcs = AddFuncDict(
     {
@@ -622,7 +624,7 @@ log_natural_probability_funcs = AddFuncDict(
 )
 """Provides functions to count the probabilities of histories in a DAG,
 according to the natural distribution induced by the DAG topology."""
-            
+
 
 def sum_rfdistance_funcs(reference_dag: "HistoryDag"):
     """Provides functions to compute the sum over all histories in the provided
@@ -642,7 +644,6 @@ def sum_rfdistance_funcs(reference_dag: "HistoryDag"):
     The weights are represented by an IntState object and are shifted by a constant K,
     which is the sum of number of clades in each tree in the DAG.
     """
-    n_histories = reference_dag.count_histories()
     N = reference_dag.count_nodes(collapse=True)
 
     # Remove the UA node clade union from N

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -794,6 +794,7 @@ def test_weight_range_annotate():
             dag.optimal_weight_annotate(**kwargs, optimal_func=max),
         )
 
+
 def test_sum_all_pair_rf_distance():
     dag = dags[-1]
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -498,7 +498,6 @@ def test_rf_rooted_distances():
 
         weight_to_self = ref_tree.optimal_weight_annotate(**weight_kwargs)
         if not (weight_to_self == 0):
-            print(ref_tree_ete)
             print("nonzero distance to self in this tree ^^: ", weight_to_self)
             assert False
 
@@ -508,32 +507,6 @@ def test_rf_rooted_distances():
         assert Counter(rf_distance(tree) for tree in dag) == dag.weight_count(
             **weight_kwargs
         )
-        
-        # if Counter(rf_distance(tree) for tree in dag) != dag.weight_count(
-        #     **weight_kwargs
-        # ):
-        #     print("label format ", next(dag.postorder()).label)
-        #     for tree in dag:
-        #         thistree = tree.to_ete(features=["sequence"])
-        #         tree_taxa = {n.sequence for n in thistree.get_leaves()}
-        #         if tree_taxa != ref_taxa:
-        #             continue
-        #         ref_dist = rf_distance(tree)
-        #         comp_dist = tree.optimal_weight_annotate(**weight_kwargs)
-        #         if ref_dist != comp_dist:
-        #             for node in thistree.get_leaves():
-        #                 node.name = node.sequence
-        #                 # node.name = str(namedict[node.sequence])
-        #             for node in ref_tree_ete.get_leaves():
-        #                 node.name = node.sequence
-        #                 # node.name = str(namedict[node.sequence])
-        #             print("reference tree:")
-        #             print(ref_tree_ete)
-        #             print("this tree:")
-        #             print(thistree)
-        #             print("correct RF: ", ref_dist)
-        #             print("computed RF: ", comp_dist)
-        #             assert False
 
 
 def test_rf_unrooted_distances():

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -793,3 +793,29 @@ def test_weight_range_annotate():
             dag.optimal_weight_annotate(**kwargs, optimal_func=min),
             dag.optimal_weight_annotate(**kwargs, optimal_func=max),
         )
+
+def test_sum_all_pair_rf_distance():
+    dag = dags[-1]
+
+    # check 0 on single-tree dag vs itself:
+    assert dag[0].sum_rf_distances() == 0
+    assert dag[0].sum_rf_distances(reference_dag=dag[0]) == 0
+
+    # check matches single rf distance between two single-tree dags:
+    udag = dag.unlabel()
+    assert udag[0].sum_rf_distances(reference_dag=udag[-1]) == udag[
+        0
+    ].optimal_rf_distance(udag[-1])
+
+    # check matches truth on whole DAG vs self:
+    assert dag.sum_rf_distances() == sum(dag.count_sum_rf_distances(dag).elements())
+
+
+def test_intersection():
+    dag = dags[-1]
+    dag1 = hdag.history_dag_from_histories(dag.sample() for _ in range(8)) | dag[0]
+    dag2 = hdag.history_dag_from_histories(dag.sample() for _ in range(8)) | dag[0]
+    idag = dag1 & dag2
+
+    assert len(idag | dag1) == len(dag1)
+    assert len(idag | dag2) == len(dag2)


### PR DESCRIPTION
This PR adds methods `HistoryDag.sum_rf_distances` and `HistoryDag.average_pairwise_rf_distance`, which compute the sum of rooted RF distances over all pairs of histories in a DAG, or between two DAGs.

Also added, a method `HistoryDag.history_intersect` which trims the DAG to contain only the histories which are also in a passed reference DAG. This method can be run using the `&` operator.
