### PR TITLE
initial commit for adding alternate field name option

### DIFF
--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1077,10 +1077,33 @@ class HistoryDag:
         new_label = namedtuple("new_label", old_label._fields + tuple(new_field_names))
 
         def add_fields(node):
-            updated_fields = [x for x in node.label] + list(new_field_values[node])
+            updated_fields = [x for x in node.label] + new_field_values[node]
             return new_label(*updated_fields)
 
         return self.relabel(add_fields)
+
+    def remove_label_fields(self, fields_to_remove=[]):
+        """Removes a list of fields from each node's label in the DAG.
+
+        Args:
+            fields_to_remove: A list of strings consisting of the names of the new fields to remove.
+        """
+        old_label = self.get_label_type()
+        if len(set(old_label._fields) - set(fields_to_remove)) < 1:
+            return self.unlabel()
+
+        field_indices_to_keep = [
+            i for i, x in enumerate(old_label._fields) if x not in fields_to_remove
+        ]
+        new_label = namedtuple(
+            "new_label", tuple([old_label._fields[i] for i in field_indices_to_keep])
+        )
+
+        def update_fields(node):
+            updated_fields = [node.label[i] for i in field_indices_to_keep]
+            return new_label(*updated_fields)
+
+        return self.relabel(update_fields)
 
     def is_history(self) -> bool:
         """Returns whether history DAG is a history.

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -176,15 +176,19 @@ def test_partial_sankoff_on_dag():
         new_total_cost_after_random_sample <= total_cost
     ), "optimizing a random sample of nodes resulted in a DAG with higher parsimony score overall"
 
-def add_attr_to_hdag(dag, attr_name, attr_values = lambda n:""):
+
+def add_attr_to_hdag(dag, attr_name, attr_values=lambda n: ""):
     old_label = next(dag.get_leaves()).label
     if attr_name in old_label._fields:
         return dag
-    new_label = namedtuple("new_label", old_label._fields + (attr_name, ))
+    new_label = namedtuple("new_label", old_label._fields + (attr_name,))
+
     def add_field(node):
         updated_fields = [x for x in node.label] + [attr_values[node]]
         return new_label(*updated_fields)
+
     return dag.relabel(add_field)
+
 
 def test_sankoff_with_alternative_sequence_name():
     with open("sample_data/toy_trees.p", "rb") as f:
@@ -198,11 +202,15 @@ def test_sankoff_with_alternative_sequence_name():
     for n in dg.postorder():
         vals[n] = ""
         if n.is_leaf():
-            vals[n] = "A" if i < num_leaves/2 else "C"
+            vals[n] = "A" if i < num_leaves / 2 else "C"
             i = i + 1
 
     dg = add_attr_to_hdag(dg, "location", vals)
 
-    upward_cost = dag_parsimony.sankoff_upward(dg, seq_len=1, sequence_attr_name="location")
+    upward_cost = dag_parsimony.sankoff_upward(
+        dg, seq_len=1, sequence_attr_name="location"
+    )
     downward_cost = dag_parsimony.sankoff_downward(dg, sequence_attr_name="location")
-    assert(upward_cost == downward_cost), "upward and downward costs for sankoff on alt sequence label name are different"
+    assert (
+        upward_cost == downward_cost
+    ), "upward and downward costs for sankoff on alt sequence label name are different"

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -488,11 +488,24 @@ def test_relabel():
 
 def test_add_label_fields():
     dag = dags[-1]
-    old_fieldset = next(dag.get_leaves()).label._fields + ("isLeaf", "originalLocation")
+    old_fieldset = dag.get_label_type()._fields + tuple(["isLeaf", "originalLocation"])
     new_field_values = {n: [n.is_leaf(), "new location"] for n in dag.postorder()}
     ndag = dag.add_label_fields(["isLeaf", "originalLocation"], new_field_values)
     ndag._check_valid()
-    new_fieldset = next(ndag.get_leaves()).label._fields
+    new_fieldset = ndag.get_label_type()._fields
+    assert old_fieldset == new_fieldset
+
+
+def test_remove_label_fields():
+    dag = dags[-1]
+    old_fieldset = dag.get_label_type()._fields
+    new_field_values = {n: [n.is_leaf()] for n in dag.postorder()}
+    ndag = dag.add_label_fields(["added_field"], new_field_values)
+    ndag._check_valid()
+    # test removing a field that isn't there and one that is
+    odag = dag.remove_label_fields(["removed_field", "added_field"])
+    new_fieldset = odag.get_label_type()._fields
+    odag._check_valid()
     assert old_fieldset == new_fieldset
 
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -486,6 +486,16 @@ def test_relabel():
     assert dag.weight_count() == odag.weight_count()
 
 
+def test_add_label_fields():
+    dag = dags[-1]
+    old_fieldset = next(dag.get_leaves()).label._fields + ("isLeaf", "originalLocation")
+    new_field_values = {n: [n.is_leaf(), "new location"] for n in dag.postorder()}
+    ndag = dag.add_label_fields(["isLeaf", "originalLocation"], new_field_values)
+    ndag._check_valid()
+    new_fieldset = next(ndag.get_leaves()).label._fields
+    assert old_fieldset == new_fieldset
+
+
 def rooted_rf_distance(history1, history2):
     cladeset1 = {n.clade_union() for n in history1.preorder(skip_ua_node=True)}
     cladeset2 = {n.clade_union() for n in history2.preorder(skip_ua_node=True)}


### PR DESCRIPTION
needs the following steps complete:
- update the ete version of Sankoff upward to also admit alternative field names (only applied to DAG at the moment)
- tests
- fix the hamming distance/weight count calls for the return value of `sankoff_downward` so that they are wrapped with the correct `nodefield_default` value