### PR TITLE
fix compact genome mutation and add label change

### DIFF
--- a/historydag/compact_genome.py
+++ b/historydag/compact_genome.py
@@ -141,6 +141,15 @@ class CompactGenome:
         return "".join(newseq)
 
     def mask_sites(self, sites, one_based=True):
+        """Remove any mutations on sites in `sites`, leaving the reference
+        sequence unchanged.
+
+        Args:
+            sites: A collection of sites to be masked
+            one_based: If True, the provided sites will be interpreted as one-based sites. Otherwise,
+                they will be interpreted as 0-based sites.
+        """
+        sites = set(sites)
         if one_based:
 
             def site_translate(site):

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1117,9 +1117,9 @@ class HistoryDag:
         field_dict = {field: index for index, field in enumerate(label_type._fields)}
         try:
             update_indices = (field_dict[field] for field in field_names)
-        except KeyError as e:
+        except KeyError:
             raise KeyError(
-                f"One of the field names you provided does not appear on node labels."
+                "One of the field names you provided does not appear on node labels."
             )
 
         def update_fields(node):

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1105,6 +1105,32 @@ class HistoryDag:
 
         return self.relabel(update_fields)
 
+    def update_label_fields(self, field_names, new_field_values):
+        """Changes label field values to values returned by the function
+        new_field_values.
+
+        Args:
+            field_names: A list of strings containing names of label fields whose contents are to be modified
+            new_field_values: A function taking a node and returning a tuple of field values whose order matches field_names
+        """
+        label_type = self.get_label_type()
+        field_dict = {field: index for index, field in enumerate(label_type._fields)}
+        try:
+            update_indices = (field_dict[field] for field in field_names)
+        except KeyError as e:
+            raise KeyError(
+                f"One of the field names you provided does not appear on node labels."
+            )
+
+        def update_fields(node):
+            old_data = list(node.label)
+            new_data = new_field_values(node)
+            for idx, new_val in zip(update_indices, new_data):
+                old_data[idx] = new_val
+            return label_type(*old_data)
+
+        return self.relabel(update_fields)
+
     def is_history(self) -> bool:
         """Returns whether history DAG is a history.
 


### PR DESCRIPTION
Fixes an issue where compact genomes could contain mutations that matched the reference sequence.

Also adds the HistoryDag method `update_label_fields` which makes it convenient to change the data in existing label fields.