### PR TITLE
HistoryDag subclass defaults

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         make lint
     - name: Check format with black
       run: |
-        black --check historydag
+        make checkformat
     - name: Test
       run: |
         make test

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ format:
 	black tests
 	docformatter --in-place historydag/*.py
 
+checkformat:
+	black --check historydag --exclude historydag/dag_pb2.py
+	black --check tests
+	docformatter --in-place historydag/*.py
+
 lint:
 	# stop the build if there are Python syntax errors or undefined names
 	flake8 historydag --count --select=E9,F63,F7,F82 --show-source --statistics --exclude historydag/dag_pb2.py

--- a/historydag/__init__.py
+++ b/historydag/__init__.py
@@ -23,7 +23,7 @@ from . import (  # noqa
 
 try:
     # requires dendropy
-    from . import beast_loader
+    from . import beast_loader  # noqa
 except ModuleNotFoundError:
     pass
 

--- a/historydag/__init__.py
+++ b/historydag/__init__.py
@@ -21,4 +21,10 @@ from . import (  # noqa
     compact_genome,
 )
 
+try:
+    # requires dendropy
+    from . import beast_loader
+except ModuleNotFoundError:
+    pass
+
 __version__ = _version.get_versions()["version"]

--- a/historydag/beast_loader.py
+++ b/historydag/beast_loader.py
@@ -1,0 +1,188 @@
+import historydag as hdag
+from frozendict import frozendict
+from historydag.compact_genome import CompactGenome
+from warnings import warn
+from functools import lru_cache
+import dendropy
+import xml.etree.ElementTree as ET
+from historydag.parsimony import bases, ambiguous_dna_values
+
+
+ambiguous_dna_values = ambiguous_dna_values.copy()
+# Set '-' to be equivalent to 'N'.
+ambiguous_dna_values.update({"?": "GATC", "-": "GATC"})
+character_lookup = {frozenset(char_set): character for character, char_set in ambiguous_dna_values.items()}
+
+def dag_from_beast_trees(
+    beast_xml_file,
+    beast_output_file,
+    reference_sequence=None,
+    mask_ambiguous_sites=True
+):
+    """A convenience method to build a dag out of the output from :meth:`load_beast_trees`."""
+    dp_trees = load_beast_trees(
+        beast_xml_file,
+        beast_output_file,
+        reference_sequence=reference_sequence,
+        mask_ambiguous_sites=mask_ambiguous_sites
+    )
+    dag = hdag.history_dag_from_trees(
+        [tree.seed_node for tree in dp_trees],
+        [],
+        label_functions={
+            "compact_genome": lambda n: n.cg,
+        },
+        attr_func=lambda n: {
+            "name": (n.taxon.label if n.is_leaf() else "internal")
+        },
+        child_node_func=dendropy.Node.child_nodes,
+        leaf_node_func=dendropy.Node.leaf_iter,
+    )
+    return hdag.mutation_annotated_dag.CGHistoryDag.from_history_dag(dag)
+
+def load_beast_trees(
+    beast_xml_file,
+    beast_output_file,
+    reference_sequence=None,
+    mask_ambiguous_sites=True
+):
+    """Load trees from BEAST output.
+
+    Loads trees from BEAST output, in which each node has a `history_all` attribute
+    containing the mutations inferred along that node's parent branch.
+
+    Args:
+        beast_xml_file: The xml input file to BEAST
+        beast_output_file: The .trees output file from BEAST
+        reference_sequence: If provided, a reference sequence which will be used for all
+            compact genomes. By default, uses the ancestral sequence of the first tree.
+        mask_ambiguous_sites: If True, ignore mutations for all sites whose observed set
+            of characters is a subset of {N, -, ?} (recommended).
+
+    Returns:
+        A :class:`dendropy.TreeList` containing the trees output by BEAST. Each tree has:
+        * ancestral sequence attribute on each tree object, containing the complete reference
+            for that tree
+        * cg attribute on all nodes, containing a compact genome relative to the reference
+            sequence
+        * mut attribute on all nodes containing a list of mutations on parent branch, in
+            order of occurrence"""
+    # get alignment from xml:
+    _etree = ET.parse('clade_13.GTR.xml')
+    _alignment = _etree.getroot().find('alignment')
+    unmasked_fasta = {a[0].attrib['idref'].strip(): a[0].tail.strip() for a in _alignment}
+    masked_sites = {i for i in range(len(next(iter(unmasked_fasta.values()))))
+                    if len({seq[i] for seq in unmasked_fasta.values()} - {'N', '?'}) == 0}
+    def mask_sequence(unmasked):
+        return ''.join(char for i, char in enumerate(unmasked) if i not in masked_sites)
+
+    fasta = {key: mask_sequence(val) for key, val in unmasked_fasta.items()}
+
+    def get_column(in_fasta, zero_site):
+        return [val[zero_site] for val in in_fasta.values()]
+
+    def comment_parser(node_comments):
+        if len(node_comments) == 0:
+            yield from ()
+            return
+        elif len(node_comments) == 1:
+            comment_string = node_comments[0]
+        else:
+            raise ValueError("node_comments has more than one element" + str(node_comments))
+        if "history_all=" not in comment_string:
+            yield from ()
+            return
+        else:
+            mutations_string = comment_string.split("history_all=")[-1]
+            stripped_mutations_list = mutations_string[2:-2]
+            if stripped_mutations_list:
+                mutations_list = stripped_mutations_list.split("},{")
+                for mut in mutations_list:
+                    try:
+                        idx_str, _, from_base, to_base = mut.split(",")
+                    except ValueError:
+                        raise ValueError("comment_parser failed on: " + str(node_comments))
+                    assert to_base in 'AGCT'
+                    yield from_base + idx_str + to_base
+            else:
+                yield from ()
+                return
+
+    def recover_reference(tree):
+        sequence_dict = {}
+
+        def mut_upward_child(c_node):
+            for mut in reversed(c_node.muts):
+                upbase = mut[0]
+                downbase = mut[-1]
+                site = int(mut[1:-1]) - 1
+                if downbase not in ambiguous_dna_values[sequence_dict[c_node][site]]:
+                    warn("child base doesn't match mut base")
+                sequence_dict[c_node][site] = upbase
+
+        for node in tree.postorder_node_iter():
+            if node.is_leaf():
+                sequence_dict[node] = list(fasta[node.taxon.label])
+            else:
+                children = node.child_nodes()
+                mut_upward_child(children[0])
+                sequence = sequence_dict[children[0]]
+                for child in children[1:]:
+                    mut_upward_child(child)
+                    for site, (obase, nbase) in enumerate(zip(sequence, sequence_dict[child])):
+                        intersection = frozenset(ambiguous_dna_values[obase]) & frozenset(ambiguous_dna_values[nbase])
+                        if len(intersection) == 0:
+                            warn("conflicting base found between children, using base from first child")
+                        else:
+                            sequence[site] = character_lookup[intersection]
+                sequence_dict[node] = sequence
+        mut_upward_child(tree.seed_node)
+        return ''.join(sequence_dict[tree.seed_node])
+
+    # dendropy doesn't parse nested lists correctly in metadata, so we load the
+    # trees with raw comment strings using `extract_comment_metadata`
+    dp_trees = dendropy.TreeList.get(
+        path="clade_13.GTR.history.trees", schema="nexus", extract_comment_metadata=False
+    )
+
+    for tree in dp_trees:
+        for node in tree.postorder_node_iter():
+            node.muts = list(comment_parser(node.comments))
+        tree.ancestral_sequence = recover_reference(tree)
+
+    if reference_sequence is None:
+        reference_sequence = dp_trees[0].ancestral_sequence
+
+
+    def compute_cgs(tree):
+        if mask_ambiguous_sites:
+            extra_masked_sites = {i for i in range(len(next(iter(fasta.values()))))
+                            if len({seq[i] for seq in fasta.values()} - {'N', '?', '-'}) == 0}
+
+            def cg_transform(cg):
+                return cg.mask_sites(extra_masked_sites, one_based=False)
+
+        else:
+
+            def cg_transform(cg):
+                return cg
+
+        ancestral_cg = hdag.compact_genome.compact_genome_from_sequence(tree.ancestral_sequence,
+                                                                        reference_sequence)
+
+        @lru_cache(maxsize=(2 * len(dp_trees[0].nodes())))
+        def compute_cg(node):
+            if node.parent_node is None:
+                # base case: node is a root node
+                parent_cg_mut = ancestral_cg
+            else:
+                parent_cg_mut = compute_cg(node.parent_node)
+            return parent_cg_mut.apply_muts(node.muts)
+
+        for node in tree.preorder_node_iter():
+            node.cg = cg_transform(compute_cg(node))
+
+    for tree in dp_trees:
+        compute_cgs(tree)
+
+    return dp_trees

--- a/historydag/beast_loader.py
+++ b/historydag/beast_loader.py
@@ -1,30 +1,33 @@
 import historydag as hdag
-from frozendict import frozendict
-from historydag.compact_genome import CompactGenome
 from warnings import warn
 from functools import lru_cache
 import dendropy
 import xml.etree.ElementTree as ET
-from historydag.parsimony import bases, ambiguous_dna_values
+from historydag.parsimony import ambiguous_dna_values
 
 
 ambiguous_dna_values = ambiguous_dna_values.copy()
 # Set '-' to be equivalent to 'N'.
 ambiguous_dna_values.update({"?": "GATC", "-": "GATC"})
-character_lookup = {frozenset(char_set): character for character, char_set in ambiguous_dna_values.items()}
+character_lookup = {
+    frozenset(char_set): character
+    for character, char_set in ambiguous_dna_values.items()
+}
+
 
 def dag_from_beast_trees(
     beast_xml_file,
     beast_output_file,
     reference_sequence=None,
-    mask_ambiguous_sites=True
+    mask_ambiguous_sites=True,
 ):
-    """A convenience method to build a dag out of the output from :meth:`load_beast_trees`."""
+    """A convenience method to build a dag out of the output from
+    :meth:`load_beast_trees`."""
     dp_trees = load_beast_trees(
         beast_xml_file,
         beast_output_file,
         reference_sequence=reference_sequence,
-        mask_ambiguous_sites=mask_ambiguous_sites
+        mask_ambiguous_sites=mask_ambiguous_sites,
     )
     dag = hdag.history_dag_from_trees(
         [tree.seed_node for tree in dp_trees],
@@ -32,19 +35,18 @@ def dag_from_beast_trees(
         label_functions={
             "compact_genome": lambda n: n.cg,
         },
-        attr_func=lambda n: {
-            "name": (n.taxon.label if n.is_leaf() else "internal")
-        },
+        attr_func=lambda n: {"name": (n.taxon.label if n.is_leaf() else "internal")},
         child_node_func=dendropy.Node.child_nodes,
         leaf_node_func=dendropy.Node.leaf_iter,
     )
     return hdag.mutation_annotated_dag.CGHistoryDag.from_history_dag(dag)
 
+
 def load_beast_trees(
     beast_xml_file,
     beast_output_file,
     reference_sequence=None,
-    mask_ambiguous_sites=True
+    mask_ambiguous_sites=True,
 ):
     """Load trees from BEAST output.
 
@@ -66,98 +68,48 @@ def load_beast_trees(
         * cg attribute on all nodes, containing a compact genome relative to the reference
             sequence
         * mut attribute on all nodes containing a list of mutations on parent branch, in
-            order of occurrence"""
+            order of occurrence
+    """
     # get alignment from xml:
-    _etree = ET.parse('clade_13.GTR.xml')
-    _alignment = _etree.getroot().find('alignment')
-    unmasked_fasta = {a[0].attrib['idref'].strip(): a[0].tail.strip() for a in _alignment}
-    masked_sites = {i for i in range(len(next(iter(unmasked_fasta.values()))))
-                    if len({seq[i] for seq in unmasked_fasta.values()} - {'N', '?'}) == 0}
+    _etree = ET.parse("clade_13.GTR.xml")
+    _alignment = _etree.getroot().find("alignment")
+    unmasked_fasta = {
+        a[0].attrib["idref"].strip(): a[0].tail.strip() for a in _alignment
+    }
+    masked_sites = {
+        i
+        for i in range(len(next(iter(unmasked_fasta.values()))))
+        if len({seq[i] for seq in unmasked_fasta.values()} - {"N", "?"}) == 0
+    }
+
     def mask_sequence(unmasked):
-        return ''.join(char for i, char in enumerate(unmasked) if i not in masked_sites)
+        return "".join(char for i, char in enumerate(unmasked) if i not in masked_sites)
 
     fasta = {key: mask_sequence(val) for key, val in unmasked_fasta.items()}
-
-    def get_column(in_fasta, zero_site):
-        return [val[zero_site] for val in in_fasta.values()]
-
-    def comment_parser(node_comments):
-        if len(node_comments) == 0:
-            yield from ()
-            return
-        elif len(node_comments) == 1:
-            comment_string = node_comments[0]
-        else:
-            raise ValueError("node_comments has more than one element" + str(node_comments))
-        if "history_all=" not in comment_string:
-            yield from ()
-            return
-        else:
-            mutations_string = comment_string.split("history_all=")[-1]
-            stripped_mutations_list = mutations_string[2:-2]
-            if stripped_mutations_list:
-                mutations_list = stripped_mutations_list.split("},{")
-                for mut in mutations_list:
-                    try:
-                        idx_str, _, from_base, to_base = mut.split(",")
-                    except ValueError:
-                        raise ValueError("comment_parser failed on: " + str(node_comments))
-                    assert to_base in 'AGCT'
-                    yield from_base + idx_str + to_base
-            else:
-                yield from ()
-                return
-
-    def recover_reference(tree):
-        sequence_dict = {}
-
-        def mut_upward_child(c_node):
-            for mut in reversed(c_node.muts):
-                upbase = mut[0]
-                downbase = mut[-1]
-                site = int(mut[1:-1]) - 1
-                if downbase not in ambiguous_dna_values[sequence_dict[c_node][site]]:
-                    warn("child base doesn't match mut base")
-                sequence_dict[c_node][site] = upbase
-
-        for node in tree.postorder_node_iter():
-            if node.is_leaf():
-                sequence_dict[node] = list(fasta[node.taxon.label])
-            else:
-                children = node.child_nodes()
-                mut_upward_child(children[0])
-                sequence = sequence_dict[children[0]]
-                for child in children[1:]:
-                    mut_upward_child(child)
-                    for site, (obase, nbase) in enumerate(zip(sequence, sequence_dict[child])):
-                        intersection = frozenset(ambiguous_dna_values[obase]) & frozenset(ambiguous_dna_values[nbase])
-                        if len(intersection) == 0:
-                            warn("conflicting base found between children, using base from first child")
-                        else:
-                            sequence[site] = character_lookup[intersection]
-                sequence_dict[node] = sequence
-        mut_upward_child(tree.seed_node)
-        return ''.join(sequence_dict[tree.seed_node])
 
     # dendropy doesn't parse nested lists correctly in metadata, so we load the
     # trees with raw comment strings using `extract_comment_metadata`
     dp_trees = dendropy.TreeList.get(
-        path="clade_13.GTR.history.trees", schema="nexus", extract_comment_metadata=False
+        path="clade_13.GTR.history.trees",
+        schema="nexus",
+        extract_comment_metadata=False,
     )
 
     for tree in dp_trees:
         for node in tree.postorder_node_iter():
-            node.muts = list(comment_parser(node.comments))
-        tree.ancestral_sequence = recover_reference(tree)
+            node.muts = list(_comment_parser(node.comments))
+        tree.ancestral_sequence = _recover_reference(tree, fasta)
 
     if reference_sequence is None:
         reference_sequence = dp_trees[0].ancestral_sequence
 
-
     def compute_cgs(tree):
         if mask_ambiguous_sites:
-            extra_masked_sites = {i for i in range(len(next(iter(fasta.values()))))
-                            if len({seq[i] for seq in fasta.values()} - {'N', '?', '-'}) == 0}
+            extra_masked_sites = {
+                i
+                for i in range(len(next(iter(fasta.values()))))
+                if len({seq[i] for seq in fasta.values()} - {"N", "?", "-"}) == 0
+            }
 
             def cg_transform(cg):
                 return cg.mask_sites(extra_masked_sites, one_based=False)
@@ -167,8 +119,9 @@ def load_beast_trees(
             def cg_transform(cg):
                 return cg
 
-        ancestral_cg = hdag.compact_genome.compact_genome_from_sequence(tree.ancestral_sequence,
-                                                                        reference_sequence)
+        ancestral_cg = hdag.compact_genome.compact_genome_from_sequence(
+            tree.ancestral_sequence, reference_sequence
+        )
 
         @lru_cache(maxsize=(2 * len(dp_trees[0].nodes())))
         def compute_cg(node):
@@ -186,3 +139,69 @@ def load_beast_trees(
         compute_cgs(tree)
 
     return dp_trees
+
+
+def _comment_parser(node_comments):
+    if len(node_comments) == 0:
+        yield from ()
+        return
+    elif len(node_comments) == 1:
+        comment_string = node_comments[0]
+    else:
+        raise ValueError("node_comments has more than one element" + str(node_comments))
+    if "history_all=" not in comment_string:
+        yield from ()
+        return
+    else:
+        mutations_string = comment_string.split("history_all=")[-1]
+        stripped_mutations_list = mutations_string[2:-2]
+        if stripped_mutations_list:
+            mutations_list = stripped_mutations_list.split("},{")
+            for mut in mutations_list:
+                try:
+                    idx_str, _, from_base, to_base = mut.split(",")
+                except ValueError:
+                    raise ValueError("comment_parser failed on: " + str(node_comments))
+                assert to_base in "AGCT"
+                yield from_base + idx_str + to_base
+        else:
+            yield from ()
+            return
+
+
+def _recover_reference(tree, fasta):
+    sequence_dict = {}
+
+    def mut_upward_child(c_node):
+        for mut in reversed(c_node.muts):
+            upbase = mut[0]
+            downbase = mut[-1]
+            site = int(mut[1:-1]) - 1
+            if downbase not in ambiguous_dna_values[sequence_dict[c_node][site]]:
+                warn("child base doesn't match mut base")
+            sequence_dict[c_node][site] = upbase
+
+    for node in tree.postorder_node_iter():
+        if node.is_leaf():
+            sequence_dict[node] = list(fasta[node.taxon.label])
+        else:
+            children = node.child_nodes()
+            mut_upward_child(children[0])
+            sequence = sequence_dict[children[0]]
+            for child in children[1:]:
+                mut_upward_child(child)
+                for site, (obase, nbase) in enumerate(
+                    zip(sequence, sequence_dict[child])
+                ):
+                    intersection = frozenset(ambiguous_dna_values[obase]) & frozenset(
+                        ambiguous_dna_values[nbase]
+                    )
+                    if len(intersection) == 0:
+                        warn(
+                            "conflicting base found between children, using base from first child"
+                        )
+                    else:
+                        sequence[site] = character_lookup[intersection]
+            sequence_dict[node] = sequence
+    mut_upward_child(tree.seed_node)
+    return "".join(sequence_dict[tree.seed_node])

--- a/historydag/beast_loader.py
+++ b/historydag/beast_loader.py
@@ -259,7 +259,6 @@ def fasta_from_beast_file(filepath, remove_ignored_sites=True):
     }
 
     if remove_ignored_sites:
-
         return (
             {
                 key: mask_sequence(val, masked_sites)

--- a/historydag/compact_genome.py
+++ b/historydag/compact_genome.py
@@ -1,10 +1,6 @@
 from frozendict import frozendict
 from typing import Dict, Sequence
 from warnings import warn
-import historydag.utils
-
-# from historydag.parsimony import ambiguous_dna_values
-import functools
 
 
 class CompactGenome:

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -394,6 +394,16 @@ def get_default_args(argnamelist, positional_count=0):
     return weight_count_args
 
 
+def convert(dag, newclass):
+    """Convert ``dag`` to the HistoryDag subclass ``newclass``.
+
+    This is a wrapper for the ``newclass.from_history_dag`` method,
+    which for most subclasses should be identical to
+    :meth:`HistoryDag.from_history_dag`.
+    """
+    return newclass.from_history_dag(dag)
+
+
 class HistoryDag:
     r"""An object to represent a collection of internally labeled trees. A
     wrapper object to contain exposed HistoryDag methods and point to a

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -3131,6 +3131,7 @@ def from_tree(
         HistoryDag object, which has the same topology as the input tree, with the required
         UA node added as a new root.
     """
+
     # see https://stackoverflow.com/questions/50298582/why-does-python-asyncio-loop-call-soon-overwrite-data
     # or https://stackoverflow.com/questions/25670516/strange-overwriting-occurring-when-using-lambda-functions-as-dict-values
     # for why we can't just use lambda funcs defined in dict comprehension.

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1480,7 +1480,7 @@ class HistoryDag:
         self,
         expand_func: Callable[
             [Label], Iterable[Label]
-        ] = parsimony_utils.default_aa_transitions.ambiguity_map.get_sequence_resolution_func(
+        ] = parsimony_utils.default_nt_transitions.ambiguity_map.get_sequence_resolution_func(
             "sequence"
         ),
         expand_node_func: Callable[[HistoryDagNode], Iterable[Label]] = None,
@@ -2165,14 +2165,14 @@ class HistoryDag:
         edge_func: Callable[[Label, Label], Weight] = lambda l1, l2: (
             0
             if isinstance(l1, UALabel)
-            else parsimony_utils.default_aa_transitions.weighted_hamming_distance(
+            else parsimony_utils.default_nt_transitions.weighted_hamming_distance(
                 l1.sequence, l2.sequence
             )
         ),
         accum_func: Callable[[List[Weight]], Weight] = sum,
         expand_func: Callable[
             [Label], Iterable[Label]
-        ] = parsimony_utils.default_aa_transitions.ambiguity_map.get_sequence_resolution_func(
+        ] = parsimony_utils.default_nt_transitions.ambiguity_map.get_sequence_resolution_func(
             "sequence"
         ),
     ):

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -27,6 +27,7 @@ from copy import deepcopy
 from historydag import utils
 from historydag.utils import Weight, Label, UALabel, prod
 from historydag.counterops import counter_sum, counter_prod
+import historydag.parsimony_utils as parsimony_utils
 
 
 class IntersectionError(ValueError):
@@ -568,7 +569,7 @@ class HistoryDag:
         start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
         edge_weight_func: Callable[
             [HistoryDagNode, HistoryDagNode], Weight
-        ] = utils.wrapped_hamming_distance,
+        ] = parsimony_utils.hamming_edge_weight,
         min_possible_weight=-float("inf"),
         max_possible_weight=float("inf"),
     ):
@@ -591,7 +592,7 @@ class HistoryDag:
         start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
         edge_weight_func: Callable[
             [HistoryDagNode, HistoryDagNode], Weight
-        ] = utils.wrapped_hamming_distance,
+        ] = parsimony_utils.hamming_edge_weight,
         min_possible_weight=-float("inf"),
     ):
         """Trim the dag to contain at least all the histories within the
@@ -1477,7 +1478,11 @@ class HistoryDag:
 
     def explode_nodes(
         self,
-        expand_func: Callable[[Label], Iterable[Label]] = utils.sequence_resolutions,
+        expand_func: Callable[
+            [Label], Iterable[Label]
+        ] = parsimony_utils.default_aa_transitions.ambiguity_map.get_sequence_resolution_func(
+            "sequence"
+        ),
         expand_node_func: Callable[[HistoryDagNode], Iterable[Label]] = None,
         expandable_func: Callable[[Label], bool] = None,
     ) -> int:
@@ -1736,7 +1741,7 @@ class HistoryDag:
         start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
         edge_weight_func: Callable[
             ["HistoryDagNode", "HistoryDagNode"], Weight
-        ] = utils.wrapped_hamming_distance,
+        ] = parsimony_utils.hamming_edge_weight,
         accum_func: Callable[[List[Weight]], Weight] = sum,
         optimal_func: Callable[[List[Weight]], Weight] = min,
         **kwargs,
@@ -1770,7 +1775,7 @@ class HistoryDag:
         start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
         edge_weight_func: Callable[
             ["HistoryDagNode", "HistoryDagNode"], Weight
-        ] = utils.wrapped_hamming_distance,
+        ] = parsimony_utils.hamming_edge_weight,
         accum_func: Callable[[List[Weight]], Weight] = sum,
         optimal_func: Callable[[List[Weight]], Weight] = min,
         eq_func: Callable[[Weight, Weight], bool] = lambda w1, w2: w1 == w2,
@@ -1825,7 +1830,7 @@ class HistoryDag:
         start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
         edge_weight_func: Callable[
             ["HistoryDagNode", "HistoryDagNode"], Weight
-        ] = utils.wrapped_hamming_distance,
+        ] = parsimony_utils.hamming_edge_weight,
         accum_func: Callable[[List[Weight]], Weight] = sum,
         **kwargs,
     ):
@@ -2158,10 +2163,18 @@ class HistoryDag:
         self,
         start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
         edge_func: Callable[[Label, Label], Weight] = lambda l1, l2: (
-            0 if isinstance(l1, UALabel) else utils.hamming_distance(l1.sequence, l2.sequence)  # type: ignore
+            0
+            if isinstance(l1, UALabel)
+            else parsimony_utils.default_aa_transitions.weighted_hamming_distance(
+                l1.sequence, l2.sequence
+            )
         ),
         accum_func: Callable[[List[Weight]], Weight] = sum,
-        expand_func: Callable[[Label], Iterable[Label]] = utils.sequence_resolutions,
+        expand_func: Callable[
+            [Label], Iterable[Label]
+        ] = parsimony_utils.default_aa_transitions.ambiguity_map.get_sequence_resolution_func(
+            "sequence"
+        ),
     ):
         r"""Template method for counting tree weights in the DAG, with exploded
         labels. Like :meth:`HistoryDag.weight_count`, but creates dictionaries
@@ -2427,7 +2440,7 @@ class HistoryDag:
         start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
         edge_weight_func: Callable[
             [HistoryDagNode, HistoryDagNode], Weight
-        ] = utils.wrapped_hamming_distance,
+        ] = parsimony_utils.hamming_edge_weight,
         accum_func: Callable[[List[Weight]], Weight] = sum,
         optimal_func: Callable[[List[Weight]], Weight] = min,
         # max_weight: Weight = None,
@@ -2678,7 +2691,7 @@ class HistoryDag:
         id_name: str = "sequence",
         dist: Callable[
             [HistoryDagNode, HistoryDagNode], Weight
-        ] = utils.wrapped_hamming_distance,
+        ] = parsimony_utils.hamming_edge_weight,
     ):
         """Inserts a sequence into the DAG.
 

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -853,14 +853,26 @@ class HistoryDag:
         """Deprecated name for :meth:`get_histories`"""
         return self.get_histories()
 
-    def get_leaves(self) -> Generator["HistoryDag", None, None]:
+    def get_leaves(self) -> Generator["HistoryDagNode", None, None]:
         """Return a generator containing all leaf nodes in the history DAG."""
         return self.find_nodes(HistoryDagNode.is_leaf)
 
-    def num_edges(self) -> int:
+    def get_edges(
+        self, skip_ua_node=False
+    ) -> Generator[Tuple["HistoryDagNode", "HistoryDagNode"], None, None]:
+        """Return a generator containing all edges in the history DAG, as
+        parent, child node tuples.
+
+        Edges' parent nodes will be in preorder.
+        """
+        for parent in self.preorder(skip_ua_node=skip_ua_node):
+            for child in parent.children():
+                yield (parent, child)
+
+    def num_edges(self, skip_ua_node=False) -> int:
         """Return the number of edges in the DAG, including edges descending
-        from the UA node."""
-        return sum(len(list(n.children())) for n in self.preorder())
+        from the UA node, unless skip_ua_node is True."""
+        return sum(1 for _ in self.get_edges(skip_ua_node=skip_ua_node))
 
     def num_nodes(self) -> int:
         """Return the number of nodes in the DAG, not counting the UA node."""

--- a/historydag/mutation_annotated_dag.py
+++ b/historydag/mutation_annotated_dag.py
@@ -10,14 +10,12 @@ import functools
 from frozendict import frozendict
 from historydag.dag import HistoryDag, HistoryDagNode, UANode, EdgeSet
 import historydag.utils
-from historydag.utils import Weight
 from historydag.compact_genome import (
     CompactGenome,
     compact_genome_from_sequence,
     cg_diff,
 )
 from historydag.parsimony_utils import (
-    hamming_cg_edge_weight_ambiguous_leaves,
     compact_genome_hamming_distance_countfuncs,
     leaf_ambiguous_compact_genome_hamming_distance_countfuncs,
 )
@@ -73,7 +71,7 @@ class CGHistoryDag(HistoryDag):
         ]
     }
 
-    _default_args = dict(compact_genome_hamming_distance_countfuncs) | {
+    _default_args = frozendict(compact_genome_hamming_distance_countfuncs) | {
         "start_func": (lambda n: 0),
         "optimal_func": min,
     }
@@ -307,67 +305,14 @@ class AmbiguousLeafCGHistoryDag(CGHistoryDag):
     'reference'.
     """
 
+    _default_args = frozendict(
+        leaf_ambiguous_compact_genome_hamming_distance_countfuncs
+    ) | {
+        "start_func": (lambda n: 0),
+        "optimal_func": min,
+    }
+
     # #### Overridden Methods ####
-
-    def weight_count(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.weight_count`"""
-        return super().weight_count(*args, edge_weight_func=edge_weight_func, **kwargs)
-
-    def optimal_weight_annotate(
-        self, *args, edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves, **kwargs
-    ) -> Weight:
-        """See :meth:`historydag.HistoryDag.optimal_weight_annotate`"""
-        return super().optimal_weight_annotate(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def trim_optimal_weight(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ) -> Weight:
-        """See :meth:`historydag.HistoryDag.trim_optimal_weight`"""
-        return super().trim_optimal_weight(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def trim_within_range(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.trim_within_range`"""
-        return super().trim_within_range(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def trim_below_weight(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.trim_below_weight`"""
-        return super().trim_below_weight(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def insert_node(
-        self,
-        *args,
-        dist=hamming_cg_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.insert_node`"""
-        return super().insert_node(*args, dist=dist, **kwargs)
-
     def hamming_parsimony_count(self):
         """See :meth:`historydag.sequence_dag.SequenceHistoryDag.hamming_parsim
         ony_count`"""

--- a/historydag/mutation_annotated_dag.py
+++ b/historydag/mutation_annotated_dag.py
@@ -16,10 +16,12 @@ from historydag.compact_genome import (
     compact_genome_from_sequence,
     wrapped_cg_hamming_distance,
     cg_diff,
+    wrapped_ambiguous_cg_hamming_distance,
 )
 import historydag.dag_pb2 as dpb
 import json
 from typing import NamedTuple
+
 
 _pb_nuc_lookup = {0: "A", 1: "C", 2: "G", 3: "T"}
 _pb_nuc_codes = {nuc: code for code, nuc in _pb_nuc_lookup.items()}
@@ -338,6 +340,98 @@ class CGHistoryDag(HistoryDag):
             fh.write(self.to_json(sort_compact_genomes=sort_compact_genomes))
 
 
+class AmbiguousLeafCGHistoryDag(CGHistoryDag):
+    """A HistoryDag subclass with node labels containing compact genomes.
+
+    The constructor for this class requires that each node label contain a 'compact_genome'
+    field, which is expected to hold a :class:`compact_genome.CompactGenome` object, which is
+    expected to hold an unambiguous sequence if the node is internal. The sequence may contain
+    ambiguities if the node is a leaf.
+
+    A HistoryDag containing 'sequence' node label fields may be automatically converted to
+    this subclass by calling the class method :meth:`CGHistoryDag.from_dag`, providing the
+    HistoryDag object to be converted, and the reference sequence to the keyword argument
+    'reference'.
+    """
+
+    # #### Overridden Methods ####
+
+    def weight_count(
+        self,
+        *args,
+        edge_weight_func=wrapped_ambiguous_cg_hamming_distance,
+        **kwargs,
+    ):
+        """See :meth:`historydag.HistoryDag.weight_count`"""
+        return super().weight_count(*args, edge_weight_func=edge_weight_func, **kwargs)
+
+    def optimal_weight_annotate(
+        self, *args, edge_weight_func=wrapped_ambiguous_cg_hamming_distance, **kwargs
+    ) -> Weight:
+        """See :meth:`historydag.HistoryDag.optimal_weight_annotate`"""
+        return super().optimal_weight_annotate(
+            *args, edge_weight_func=edge_weight_func, **kwargs
+        )
+
+    def trim_optimal_weight(
+        self,
+        *args,
+        edge_weight_func=wrapped_ambiguous_cg_hamming_distance,
+        **kwargs,
+    ) -> Weight:
+        """See :meth:`historydag.HistoryDag.trim_optimal_weight`"""
+        return super().trim_optimal_weight(
+            *args, edge_weight_func=edge_weight_func, **kwargs
+        )
+
+    def trim_within_range(
+        self,
+        *args,
+        edge_weight_func=wrapped_ambiguous_cg_hamming_distance,
+        **kwargs,
+    ):
+        """See :meth:`historydag.HistoryDag.trim_within_range`"""
+        return super().trim_within_range(
+            *args, edge_weight_func=edge_weight_func, **kwargs
+        )
+
+    def trim_below_weight(
+        self,
+        *args,
+        edge_weight_func=wrapped_ambiguous_cg_hamming_distance,
+        **kwargs,
+    ):
+        """See :meth:`historydag.HistoryDag.trim_below_weight`"""
+        return super().trim_below_weight(
+            *args, edge_weight_func=edge_weight_func, **kwargs
+        )
+
+    def insert_node(
+        self,
+        *args,
+        dist=wrapped_ambiguous_cg_hamming_distance,
+        **kwargs,
+    ):
+        """See :meth:`historydag.HistoryDag.insert_node`"""
+        return super().insert_node(*args, dist=dist, **kwargs)
+
+    def hamming_parsimony_count(self):
+        """See :meth:`historydag.sequence_dag.SequenceHistoryDag.hamming_parsim
+        ony_count`"""
+        return self.weight_count(
+            **leaf_ambiguous_compact_genome_hamming_distance_countfuncs
+        )
+
+    def summary(self):
+        HistoryDag.summary(self)
+        min_pars, max_pars = self.weight_range_annotate(
+            **leaf_ambiguous_compact_genome_hamming_distance_countfuncs
+        )
+        print(f"Parsimony score range {min_pars} to {max_pars}")
+
+    # #### End Overridden Methods ####
+
+
 def load_json_file(filename):
     """Load a Mutation Annotated DAG stored in a JSON file and return a
     CGHistoryDag."""
@@ -530,3 +624,18 @@ compact_genome_hamming_distance_countfuncs = historydag.utils.AddFuncDict(
 """Provides functions to count hamming distance parsimony when sequences are
 stored as CompactGenomes.
 For use with :meth:`historydag.CGHistoryDag.weight_count`."""
+
+
+leaf_ambiguous_compact_genome_hamming_distance_countfuncs = (
+    historydag.utils.AddFuncDict(
+        {
+            "start_func": lambda n: 0,
+            "edge_weight_func": wrapped_ambiguous_cg_hamming_distance,
+            "accum_func": sum,
+        },
+        name="HammingParsimony",
+    )
+)
+"""Provides functions to count hamming distance parsimony when leaf compact genomes
+may be ambiguous.
+For use with :meth:`historydag.AmbiguousLeafCGHistoryDag.weight_count`."""

--- a/historydag/mutation_annotated_dag.py
+++ b/historydag/mutation_annotated_dag.py
@@ -14,9 +14,13 @@ from historydag.utils import Weight
 from historydag.compact_genome import (
     CompactGenome,
     compact_genome_from_sequence,
-    wrapped_cg_hamming_distance,
     cg_diff,
-    wrapped_ambiguous_cg_hamming_distance,
+)
+from historydag.parsimony_utils import (
+    hamming_cg_edge_weight,
+    hamming_cg_edge_weight_ambiguous_leaves,
+    compact_genome_hamming_distance_countfuncs,
+    leaf_ambiguous_compact_genome_hamming_distance_countfuncs,
 )
 import historydag.dag_pb2 as dpb
 import json
@@ -82,14 +86,14 @@ class CGHistoryDag(HistoryDag):
     def weight_count(
         self,
         *args,
-        edge_weight_func=wrapped_cg_hamming_distance,
+        edge_weight_func=hamming_cg_edge_weight,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.weight_count`"""
         return super().weight_count(*args, edge_weight_func=edge_weight_func, **kwargs)
 
     def optimal_weight_annotate(
-        self, *args, edge_weight_func=wrapped_cg_hamming_distance, **kwargs
+        self, *args, edge_weight_func=hamming_cg_edge_weight, **kwargs
     ) -> Weight:
         """See :meth:`historydag.HistoryDag.optimal_weight_annotate`"""
         return super().optimal_weight_annotate(
@@ -99,7 +103,7 @@ class CGHistoryDag(HistoryDag):
     def trim_optimal_weight(
         self,
         *args,
-        edge_weight_func=wrapped_cg_hamming_distance,
+        edge_weight_func=hamming_cg_edge_weight,
         **kwargs,
     ) -> Weight:
         """See :meth:`historydag.HistoryDag.trim_optimal_weight`"""
@@ -110,7 +114,7 @@ class CGHistoryDag(HistoryDag):
     def trim_within_range(
         self,
         *args,
-        edge_weight_func=wrapped_cg_hamming_distance,
+        edge_weight_func=hamming_cg_edge_weight,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.trim_within_range`"""
@@ -121,7 +125,7 @@ class CGHistoryDag(HistoryDag):
     def trim_below_weight(
         self,
         *args,
-        edge_weight_func=wrapped_cg_hamming_distance,
+        edge_weight_func=hamming_cg_edge_weight,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.trim_below_weight`"""
@@ -132,7 +136,7 @@ class CGHistoryDag(HistoryDag):
     def insert_node(
         self,
         *args,
-        dist=wrapped_cg_hamming_distance,
+        dist=hamming_cg_edge_weight,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.insert_node`"""
@@ -359,14 +363,14 @@ class AmbiguousLeafCGHistoryDag(CGHistoryDag):
     def weight_count(
         self,
         *args,
-        edge_weight_func=wrapped_ambiguous_cg_hamming_distance,
+        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.weight_count`"""
         return super().weight_count(*args, edge_weight_func=edge_weight_func, **kwargs)
 
     def optimal_weight_annotate(
-        self, *args, edge_weight_func=wrapped_ambiguous_cg_hamming_distance, **kwargs
+        self, *args, edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves, **kwargs
     ) -> Weight:
         """See :meth:`historydag.HistoryDag.optimal_weight_annotate`"""
         return super().optimal_weight_annotate(
@@ -376,7 +380,7 @@ class AmbiguousLeafCGHistoryDag(CGHistoryDag):
     def trim_optimal_weight(
         self,
         *args,
-        edge_weight_func=wrapped_ambiguous_cg_hamming_distance,
+        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
         **kwargs,
     ) -> Weight:
         """See :meth:`historydag.HistoryDag.trim_optimal_weight`"""
@@ -387,7 +391,7 @@ class AmbiguousLeafCGHistoryDag(CGHistoryDag):
     def trim_within_range(
         self,
         *args,
-        edge_weight_func=wrapped_ambiguous_cg_hamming_distance,
+        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.trim_within_range`"""
@@ -398,7 +402,7 @@ class AmbiguousLeafCGHistoryDag(CGHistoryDag):
     def trim_below_weight(
         self,
         *args,
-        edge_weight_func=wrapped_ambiguous_cg_hamming_distance,
+        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.trim_below_weight`"""
@@ -409,7 +413,7 @@ class AmbiguousLeafCGHistoryDag(CGHistoryDag):
     def insert_node(
         self,
         *args,
-        dist=wrapped_ambiguous_cg_hamming_distance,
+        dist=hamming_cg_edge_weight_ambiguous_leaves,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.insert_node`"""
@@ -611,31 +615,3 @@ def load_MAD_protobuf_file(filename):
         pb_data = dpb.data()
         pb_data.ParseFromString(fh.read())
     return load_MAD_protobuf(pb_data)
-
-
-compact_genome_hamming_distance_countfuncs = historydag.utils.AddFuncDict(
-    {
-        "start_func": lambda n: 0,
-        "edge_weight_func": wrapped_cg_hamming_distance,
-        "accum_func": sum,
-    },
-    name="HammingParsimony",
-)
-"""Provides functions to count hamming distance parsimony when sequences are
-stored as CompactGenomes.
-For use with :meth:`historydag.CGHistoryDag.weight_count`."""
-
-
-leaf_ambiguous_compact_genome_hamming_distance_countfuncs = (
-    historydag.utils.AddFuncDict(
-        {
-            "start_func": lambda n: 0,
-            "edge_weight_func": wrapped_ambiguous_cg_hamming_distance,
-            "accum_func": sum,
-        },
-        name="HammingParsimony",
-    )
-)
-"""Provides functions to count hamming distance parsimony when leaf compact genomes
-may be ambiguous.
-For use with :meth:`historydag.AmbiguousLeafCGHistoryDag.weight_count`."""

--- a/historydag/mutation_annotated_dag.py
+++ b/historydag/mutation_annotated_dag.py
@@ -17,7 +17,6 @@ from historydag.compact_genome import (
     cg_diff,
 )
 from historydag.parsimony_utils import (
-    hamming_cg_edge_weight,
     hamming_cg_edge_weight_ambiguous_leaves,
     compact_genome_hamming_distance_countfuncs,
     leaf_ambiguous_compact_genome_hamming_distance_countfuncs,
@@ -74,7 +73,16 @@ class CGHistoryDag(HistoryDag):
         ]
     }
 
+    _default_args = dict(compact_genome_hamming_distance_countfuncs) | {
+        "start_func": (lambda n: 0),
+        "optimal_func": min,
+    }
     # #### Overridden Methods ####
+
+    def weight_counts_with_ambiguities(self, *args, **kwargs):
+        raise NotImplementedError(
+            "This method is only implemented for DAGs with node labels containing sequences."
+        )
 
     def summary(self):
         HistoryDag.summary(self)
@@ -82,65 +90,6 @@ class CGHistoryDag(HistoryDag):
             **compact_genome_hamming_distance_countfuncs
         )
         print(f"Parsimony score range {min_pars} to {max_pars}")
-
-    def weight_count(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.weight_count`"""
-        return super().weight_count(*args, edge_weight_func=edge_weight_func, **kwargs)
-
-    def optimal_weight_annotate(
-        self, *args, edge_weight_func=hamming_cg_edge_weight, **kwargs
-    ) -> Weight:
-        """See :meth:`historydag.HistoryDag.optimal_weight_annotate`"""
-        return super().optimal_weight_annotate(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def trim_optimal_weight(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight,
-        **kwargs,
-    ) -> Weight:
-        """See :meth:`historydag.HistoryDag.trim_optimal_weight`"""
-        return super().trim_optimal_weight(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def trim_within_range(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.trim_within_range`"""
-        return super().trim_within_range(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def trim_below_weight(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.trim_below_weight`"""
-        return super().trim_below_weight(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def insert_node(
-        self,
-        *args,
-        dist=hamming_cg_edge_weight,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.insert_node`"""
-        return super().insert_node(*args, dist=dist, **kwargs)
 
     def hamming_parsimony_count(self):
         """See :meth:`historydag.sequence_dag.SequenceHistoryDag.hamming_parsim

--- a/historydag/parsimony.py
+++ b/historydag/parsimony.py
@@ -25,7 +25,7 @@ def replace_label_attr(original_label, list_of_replacements={}):
 
 
 def make_weighted_hamming_count_funcs(
-    transition_model=parsimony_utils.default_aa_transitions,
+    transition_model=parsimony_utils.default_nt_transitions,
     allow_ambiguous_leaves=False,
     sequence_label="sequence",
 ):
@@ -91,7 +91,7 @@ def sankoff_upward(
     node_list,
     seq_len,
     sequence_attr_name="sequence",
-    transition_model=parsimony_utils.default_aa_transitions,
+    transition_model=parsimony_utils.default_nt_transitions,
     use_internal_node_sequences=False,
 ):
     """Compute Sankoff cost vectors at nodes in a postorder traversal, and
@@ -208,7 +208,7 @@ def sankoff_downward(
     partial_node_list=None,
     sequence_attr_name="sequence",
     compute_cvs=True,
-    transition_model=parsimony_utils.default_aa_transitions,
+    transition_model=parsimony_utils.default_nt_transitions,
     trim=True,
 ):
     """Assign sequences to internal nodes of dag using a weighted Sankoff
@@ -348,7 +348,7 @@ def disambiguate(
     random_state=None,
     remove_cvs=False,
     adj_dist=False,
-    transition_model=parsimony_utils.default_aa_transitions,
+    transition_model=parsimony_utils.default_nt_transitions,
     min_ambiguities=False,
 ):
     """Randomly resolve ambiguous bases using a two-pass Sankoff Algorithm on
@@ -502,7 +502,7 @@ def build_trees_from_files(newickfiles, fastafile, **kwargs):
         yield build_tree(newick, fasta_map, **kwargs)
 
 
-def parsimony_score(tree, transition_model=parsimony_utils.default_aa_transitions):
+def parsimony_score(tree, transition_model=parsimony_utils.default_nt_transitions):
     """returns the parsimony score of a (disambiguated) ete tree.
 
     Tree must have 'sequence' attributes on all nodes.

--- a/historydag/parsimony.py
+++ b/historydag/parsimony.py
@@ -12,6 +12,7 @@ from historydag.dag import (
 from copy import deepcopy
 import historydag.parsimony_utils as parsimony_utils
 
+
 def replace_label_attr(original_label, list_of_replacements={}):
     """Generalizes :meth: ``_replace()`` for namedtuple datatype to replace
     multiple fields at once, and by string rather than as a keyword argument.

--- a/historydag/parsimony.py
+++ b/historydag/parsimony.py
@@ -1,10 +1,7 @@
 """A module implementing Sankoff Algorithm."""
-
 import random
 import ete3
 import numpy as np
-import Bio.Data.IUPACData
-from frozendict import frozendict
 from itertools import product
 from historydag.dag import (
     history_dag_from_histories,
@@ -13,276 +10,7 @@ from historydag.dag import (
     utils,
 )
 from copy import deepcopy
-
-
-class AmbiguityMap:
-    """Implements a bijection between a subset of the power set of an alphabet
-    of bases, and an expanded alphabet of ambiguity codes.
-
-    To look up the set of bases represented by an ambiguity code, use the object like a dictionary.
-    To look up an ambiguity code representing a set of bases, use the ``reversed`` attribute.
-
-    Args:
-        ambiguity_character_map: A mapping from ambiguity codes to collections of bases represented by that code.
-        bases: A collection of bases. If not provided, this will be inferred from the ambiguity_character_map.
-    """
-
-    def __init__(self, ambiguity_character_map, bases=None):
-        ambiguous_values = {
-            char: frozenset(bases) for char, bases in ambiguity_character_map.items()
-        }
-        if bases is None:
-            self.bases = frozenset(
-                base for bset in self.ambiguous_values for base in bset
-            )
-        else:
-            self.bases = frozenset(bases)
-
-        ambiguous_values.update({base: frozenset({base}) for base in self.bases})
-        self.ambiguous_values = frozendict(ambiguous_values)
-        self.reversed = ReversedAmbiguityMap(
-            {bases: char for char, bases in self.ambiguous_values.items()}
-        )
-
-    def __getitem__(self, key):
-        try:
-            return self.ambiguous_values[key]
-        except KeyError:
-            raise KeyError(f"{key} is not a valid ambiguity code for this map.")
-
-    def __iter__(self):
-        return self.ambiguous_values.__iter__()
-
-    def items(self):
-        return self.ambiguous_values.items()
-
-
-class ReversedAmbiguityMap(frozendict):
-    def __getitem__(self, key):
-        try:
-            return super().__getitem__(key)
-        except KeyError:
-            raise KeyError(f"No ambiguity code is defined for the set of bases {key}")
-
-
-_ambiguous_dna_values_gap_as_char = Bio.Data.IUPACData.ambiguous_dna_values.copy()
-_ambiguous_dna_values_gap_as_char.update({"?": "GATC-", "-": "-"})
-_ambiguous_dna_values = Bio.Data.IUPACData.ambiguous_dna_values.copy()
-_ambiguous_dna_values.update({"?": "GATC", "-": "GATC"})
-
-standard_aa_ambiguity_map = AmbiguityMap(_ambiguous_dna_values, "AGCT")
-standard_aa_ambiguity_map_gap_as_char = AmbiguityMap(
-    _ambiguous_dna_values_gap_as_char, "AGCT-"
-)
-
-
-class TransitionAlphabet:
-    def __init__(
-        self, bases=tuple("AGCT"), transition_weights=None, ambiguity_map=None
-    ):
-        self.bases = tuple(bases)
-        self.base_indices = frozendict({base: idx for idx, base in enumerate(bases)})
-        self.yey = np.array(
-            [[i != j for i in range(len(self.bases))] for j in range(len(self.bases))]
-        )
-        if transition_weights is None:
-            self.transition_weights = self.yey
-        else:
-            if len(transition_weights) != len(self.bases) or len(
-                transition_weights[0]
-            ) != len(self.bases):
-                raise ValueError(
-                    "transition_weights must be a nxn matrix, with n=len(bases)"
-                )
-            self.transition_weights = transition_weights
-        if ambiguity_map is None:
-            if self.bases == tuple("AGCT"):
-                self.ambiguity_map = standard_aa_ambiguity_map
-            elif self.bases == tuple("AGCT-"):
-                self.ambiguity_map = standard_aa_ambiguity_map_gap_as_char
-            else:
-                self.ambiguity_map = AmbiguityMap({}, self.bases)
-        else:
-            self.ambiguity_map = ambiguity_map
-
-        # This is applicable even when diagonal entries in transition rate matrix are
-        # nonzero, since it is only a mask on allowable sites based on each base.
-        self.mask_vectors = {
-            code: np.array(
-                [
-                    0 if base in self.ambiguity_map[code] else float("inf")
-                    for base in self.bases
-                ]
-            )
-            for code in self.ambiguity_map
-        }
-
-    def get_ambiguity_from_tuple(self, tup):
-        """Retrieve an ambiguity code encoded by tup, which encodes a set of
-        bases with a tuple of 0's and 1's.
-
-        For example, with ``bases='AGCT'``, ``(0, 1, 1, 1)`` would
-        return `A`.
-        """
-        return self.ambiguity_map.reversed[
-            frozenset(self.bases[i] for i, flag in enumerate(tup) if flag == 0)
-        ]
-
-    def character_distance(self, parent_char, child_char):
-        return self.transition_weights[self.base_indices[parent_char]][
-            self.base_indices[child_char]
-        ]
-
-    def weighted_hamming_distance(self, parent_seq, child_seq):
-        if len(parent_seq) != len(child_seq):
-            raise ValueError("sequence lengths do not match!")
-        return sum(
-            self.character_distance(pchar, cchar)
-            for pchar, cchar in zip(parent_seq, child_seq)
-        )
-
-    def min_character_distance(self, parent_char, child_char):
-        """Allowing child_char to be ambiguous, returns the minimum possible
-        transition weight between parent_char and child_char."""
-        child_set = self.ambiguity_map[child_char]
-        p_idx = self.base_indices[parent_char]
-        return min(
-            self.transition_weights[p_idx][self.base_indices[cbase]]
-            for cbase in child_set
-        )
-
-    def min_weighted_hamming_distance(self, parent_seq, child_seq):
-        """Assuming the child_seq may contain ambiguous characters, returns the
-        minimum possible transition weight between parent_seq and child_seq."""
-        if len(parent_seq) != len(child_seq):
-            raise ValueError("sequence lengths do not match!")
-        return sum(
-            self.min_character_distance(pchar, cchar)
-            for pchar, cchar in zip(parent_seq, child_seq)
-        )
-
-    def get_adjacency_array(self, seq_len):
-        return np.array([self.transition_weights] * seq_len)
-
-    def weighted_hamming_edge_weight(self, field_name):
-        """Returns a function for computing weighted hamming distance between
-        two nodes' sequences.
-
-        Args:
-            field_name: The name of the node label field which contains sequences.
-
-        Returns:
-            A function accepting two :class:`HistoryDagNode` objects ``n1`` and ``n2`` and returning
-            a float: the transition cost from ``n1.label.<field_name>`` to ``n2.label.<field_name>``, or 0 if
-            n1 is the UA node.
-        """
-
-        @utils.access_nodefield_default(field_name, 0)
-        def edge_weight(parent, child):
-            return self.weighted_hamming_distance(parent, child)
-
-        return edge_weight
-
-    def min_weighted_hamming_edge_weight(self, field_name):
-        """Returns a function for computing weighted hamming distance between
-        two nodes' sequences.
-
-        If the child node is a leaf node, and its sequence contains ambiguities, the minimum possible
-        transition cost from parent to child will be returned.
-
-        Args:
-            field_name: The name of the node label field which contains sequences.
-
-        Returns:
-            A function accepting two :class:`HistoryDagNode` objects ``n1`` and ``n2`` and returning
-            a float: the transition cost from ``n1.label.<field_name>`` to ``n2.label.<field_name>``, or 0 if
-            n1 is the UA node.
-        """
-
-        def edge_weight(parent, child):
-            if parent.is_ua_node():
-                return 0
-            elif child.is_leaf():
-                return self.min_weighted_hamming_distance(
-                    getattr(parent.label, field_name), getattr(child.label, field_name)
-                )
-            else:
-                return self.weighted_hamming_distance(
-                    getattr(parent.label, field_name), getattr(child.label, field_name)
-                )
-
-        return edge_weight
-
-
-class UnitTransitionAlphabet(TransitionAlphabet):
-    """A subclass of :class:`TransitionAlphabet` to be used when all
-    transitions have unit cost."""
-
-    def __init__(self, bases="AGCT", ambiguity_map=None):
-        super().__init__(bases=bases, ambiguity_map=None)
-
-    def min_character_distance(self, parent_char, child_char):
-        return int(parent_char not in self.ambiguity_map[child_char])
-
-    def weighted_hamming_distance(self, parent_seq, child_seq):
-        if len(parent_seq) != len(child_seq):
-            raise ValueError("sequence lengths do not match!")
-        return sum(x != y for x, y in zip(parent_seq, child_seq))
-
-
-class VariableTransitionAlphabet(TransitionAlphabet):
-    """A subclass of :class:`TransitionAlphabet` to be used when transition
-    costs depend on site."""
-
-    def __init__(self, bases="AGCT", transition_matrix=None, ambiguity_map=None):
-        assert transition_matrix.shape[1:] == (len(bases), len(bases))
-        super().__init__(bases=bases, ambiguity_map=None)
-        self.transition_weights = None
-        self.sitewise_transition_matrix = transition_matrix
-        self._seq_len
-
-    def character_distance(self, parent_char, child_char, site):
-        return self.sitewise_transition_matrix[site - 1][parent_char][child_char]
-
-    def weighted_hamming_distance(self, parent_seq, child_seq):
-        if len(parent_seq) != self._seq_len or len(child_seq) != self._seq_len:
-            raise ValueError("Sequence lengths must match transition matrix length")
-        return sum(
-            self.character_distance(pchar, cchar, idx + 1)
-            for idx, (pchar, cchar) in enumerate(zip(parent_seq, child_seq))
-        )
-
-    def min_character_distance(self, parent_char, child_char, site):
-        """Allowing child_char to be ambiguous, returns the minimum possible
-        transition weight between parent_char and child_char."""
-        child_set = self.ambiguity_map[child_char]
-        p_idx = self.base_indices[parent_char]
-        return min(
-            self.transition_weights[site - 1][p_idx][self.base_indices[cbase]]
-            for cbase in child_set
-        )
-
-    def min_weighted_hamming_distance(self, parent_seq, child_seq):
-        """Assuming the child_seq may contain ambiguous characters, returns the
-        minimum possible transition weight between parent_seq and child_seq."""
-        if len(parent_seq) != len(child_seq):
-            raise ValueError("sequence lengths do not match!")
-        return sum(
-            self.min_character_distance(pchar, cchar, idx + 1)
-            for idx, (pchar, cchar) in enumerate(zip(parent_seq, child_seq))
-        )
-
-    def get_adjacency_array(self, seq_len):
-        if seq_len != self._seq_len:
-            raise ValueError(
-                f"VariableTransitionAlphabet instance supports sequence length of {self._seq_len}"
-            )
-        return self.sitewise_transition_matrix
-
-
-default_aa_transitions = UnitTransitionAlphabet(bases="AGCT")
-default_aa_gaps_transitions = UnitTransitionAlphabet(bases="AGCT-")
-
+import historydag.parsimony_utils as parsimony_utils
 
 def replace_label_attr(original_label, list_of_replacements={}):
     """Generalizes :meth: ``_replace()`` for namedtuple datatype to replace
@@ -296,7 +24,7 @@ def replace_label_attr(original_label, list_of_replacements={}):
 
 
 def make_weighted_hamming_count_funcs(
-    transition_model=default_aa_transitions,
+    transition_model=parsimony_utils.default_aa_transitions,
     allow_ambiguous_leaves=False,
     sequence_label="sequence",
 ):
@@ -362,7 +90,7 @@ def sankoff_upward(
     node_list,
     seq_len,
     sequence_attr_name="sequence",
-    transition_model=default_aa_transitions,
+    transition_model=parsimony_utils.default_aa_transitions,
     use_internal_node_sequences=False,
 ):
     """Compute Sankoff cost vectors at nodes in a postorder traversal, and
@@ -479,7 +207,7 @@ def sankoff_downward(
     partial_node_list=None,
     sequence_attr_name="sequence",
     compute_cvs=True,
-    transition_model=default_aa_transitions,
+    transition_model=parsimony_utils.default_aa_transitions,
     trim=True,
 ):
     """Assign sequences to internal nodes of dag using a weighted Sankoff
@@ -619,7 +347,7 @@ def disambiguate(
     random_state=None,
     remove_cvs=False,
     adj_dist=False,
-    transition_model=default_aa_transitions,
+    transition_model=parsimony_utils.default_aa_transitions,
     min_ambiguities=False,
 ):
     """Randomly resolve ambiguous bases using a two-pass Sankoff Algorithm on
@@ -773,7 +501,7 @@ def build_trees_from_files(newickfiles, fastafile, **kwargs):
         yield build_tree(newick, fasta_map, **kwargs)
 
 
-def parsimony_score(tree, transition_model=default_aa_transitions):
+def parsimony_score(tree, transition_model=parsimony_utils.default_aa_transitions):
     """returns the parsimony score of a (disambiguated) ete tree.
 
     Tree must have 'sequence' attributes on all nodes.

--- a/historydag/parsimony.py
+++ b/historydag/parsimony.py
@@ -4,6 +4,7 @@ import random
 import ete3
 import numpy as np
 import Bio.Data.IUPACData
+from frozendict import frozendict
 from itertools import product
 from historydag.dag import (
     history_dag_from_histories,
@@ -13,65 +14,274 @@ from historydag.dag import (
 )
 from copy import deepcopy
 
-bases = "AGCT-"
-ambiguous_dna_values = Bio.Data.IUPACData.ambiguous_dna_values.copy()
-ambiguous_dna_values.update({"?": "GATC-", "-": "-"})
 
+class AmbiguityMap:
+    """Implements a bijection between a subset of the power set of an alphabet
+    of bases, and an expanded alphabet of ambiguity codes.
 
-def hamming_distance(seq1: str, seq2: str) -> int:
-    r"""Hamming distance between two sequences of equal length.
+    To look up the set of bases represented by an ambiguity code, use the object like a dictionary.
+    To look up an ambiguity code representing a set of bases, use the ``reversed`` attribute.
 
     Args:
-        seq1: sequence 1
-        seq2: sequence 2
+        ambiguity_character_map: A mapping from ambiguity codes to collections of bases represented by that code.
+        bases: A collection of bases. If not provided, this will be inferred from the ambiguity_character_map.
     """
-    if len(seq1) != len(seq2):
-        raise ValueError("sequence lengths do not match!")
-    return sum(x != y for x, y in zip(seq1, seq2))
+
+    def __init__(self, ambiguity_character_map, bases=None):
+        ambiguous_values = {
+            char: frozenset(bases) for char, bases in ambiguity_character_map.items()
+        }
+        if bases is None:
+            self.bases = frozenset(
+                base for bset in self.ambiguous_values for base in bset
+            )
+        else:
+            self.bases = frozenset(bases)
+
+        ambiguous_values.update({base: frozenset({base}) for base in self.bases})
+        self.ambiguous_values = frozendict(ambiguous_values)
+        self.reversed = ReversedAmbiguityMap(
+            {bases: char for char, bases in self.ambiguous_values.items()}
+        )
+
+    def __getitem__(self, key):
+        try:
+            return self.ambiguous_values[key]
+        except KeyError:
+            raise KeyError(f"{key} is not a valid ambiguity code for this map.")
+
+    def __iter__(self):
+        return self.ambiguous_values.__iter__()
+
+    def items(self):
+        return self.ambiguous_values.items()
 
 
-_yey = np.array(
-    [
-        [0, 1, 1, 1, 1],
-        [1, 0, 1, 1, 1],
-        [1, 1, 0, 1, 1],
-        [1, 1, 1, 0, 1],
-        [1, 1, 1, 1, 0],
-    ]
+class ReversedAmbiguityMap(frozendict):
+    def __getitem__(self, key):
+        try:
+            return super().__getitem__(key)
+        except KeyError:
+            raise KeyError(f"No ambiguity code is defined for the set of bases {key}")
+
+
+_ambiguous_dna_values_gap_as_char = Bio.Data.IUPACData.ambiguous_dna_values.copy()
+_ambiguous_dna_values_gap_as_char.update({"?": "GATC-", "-": "-"})
+_ambiguous_dna_values = Bio.Data.IUPACData.ambiguous_dna_values.copy()
+_ambiguous_dna_values.update({"?": "GATC", "-": "GATC"})
+
+standard_aa_ambiguity_map = AmbiguityMap(_ambiguous_dna_values, "AGCT")
+standard_aa_ambiguity_map_gap_as_char = AmbiguityMap(
+    _ambiguous_dna_values_gap_as_char, "AGCT-"
 )
 
-# This is applicable even when diagonal entries in transition rate matrix are
-# nonzero, since it is only a mask on allowable sites based on each base.
-code_vectors = {
-    code: np.array(
-        [0 if base in ambiguous_dna_values[code] else float("inf") for base in bases]
-    )
-    for code in ambiguous_dna_values
-}
 
-ambiguous_codes_from_vecs = {
-    tuple(0 if base in base_set else 1 for base in bases): code
-    for code, base_set in ambiguous_dna_values.items()
-}
-
-
-def _get_adj_array(seq_len, transition_weights=None, bases="AGCT-"):
-    if transition_weights is None:
-        transition_weights = _yey
-    else:
-        transition_weights = np.array(transition_weights)
-
-    num_bases = len(bases)
-    if transition_weights.shape == (num_bases, num_bases):
-        adj_arr = np.array([transition_weights] * seq_len)
-    elif transition_weights.shape == (seq_len, num_bases, num_bases):
-        adj_arr = transition_weights
-    else:
-        raise RuntimeError(
-            "Transition weight matrix must have shape (%d, %d) or (sequence_length, %d, %d)."
-            % (num_bases, num_bases, num_bases, num_bases)
+class TransitionAlphabet:
+    def __init__(
+        self, bases=tuple("AGCT"), transition_weights=None, ambiguity_map=None
+    ):
+        self.bases = tuple(bases)
+        self.base_indices = frozendict({base: idx for idx, base in enumerate(bases)})
+        self.yey = np.array(
+            [[i != j for i in range(len(self.bases))] for j in range(len(self.bases))]
         )
-    return adj_arr
+        if transition_weights is None:
+            self.transition_weights = self.yey
+        else:
+            if len(transition_weights) != len(self.bases) or len(
+                transition_weights[0]
+            ) != len(self.bases):
+                raise ValueError(
+                    "transition_weights must be a nxn matrix, with n=len(bases)"
+                )
+            self.transition_weights = transition_weights
+        if ambiguity_map is None:
+            if self.bases == tuple("AGCT"):
+                self.ambiguity_map = standard_aa_ambiguity_map
+            elif self.bases == tuple("AGCT-"):
+                self.ambiguity_map = standard_aa_ambiguity_map_gap_as_char
+            else:
+                self.ambiguity_map = AmbiguityMap({}, self.bases)
+        else:
+            self.ambiguity_map = ambiguity_map
+
+        # This is applicable even when diagonal entries in transition rate matrix are
+        # nonzero, since it is only a mask on allowable sites based on each base.
+        self.mask_vectors = {
+            code: np.array(
+                [
+                    0 if base in self.ambiguity_map[code] else float("inf")
+                    for base in self.bases
+                ]
+            )
+            for code in self.ambiguity_map
+        }
+
+    def get_ambiguity_from_tuple(self, tup):
+        """Retrieve an ambiguity code encoded by tup, which encodes a set of
+        bases with a tuple of 0's and 1's.
+
+        For example, with ``bases='AGCT'``, ``(0, 1, 1, 1)`` would
+        return `A`.
+        """
+        return self.ambiguity_map.reversed[
+            frozenset(self.bases[i] for i, flag in enumerate(tup) if flag == 0)
+        ]
+
+    def character_distance(self, parent_char, child_char):
+        return self.transition_weights[self.base_indices[parent_char]][
+            self.base_indices[child_char]
+        ]
+
+    def weighted_hamming_distance(self, parent_seq, child_seq):
+        if len(parent_seq) != len(child_seq):
+            raise ValueError("sequence lengths do not match!")
+        return sum(
+            self.character_distance(pchar, cchar)
+            for pchar, cchar in zip(parent_seq, child_seq)
+        )
+
+    def min_character_distance(self, parent_char, child_char):
+        """Allowing child_char to be ambiguous, returns the minimum possible
+        transition weight between parent_char and child_char."""
+        child_set = self.ambiguity_map[child_char]
+        p_idx = self.base_indices[parent_char]
+        return min(
+            self.transition_weights[p_idx][self.base_indices[cbase]]
+            for cbase in child_set
+        )
+
+    def min_weighted_hamming_distance(self, parent_seq, child_seq):
+        """Assuming the child_seq may contain ambiguous characters, returns the
+        minimum possible transition weight between parent_seq and child_seq."""
+        if len(parent_seq) != len(child_seq):
+            raise ValueError("sequence lengths do not match!")
+        return sum(
+            self.min_character_distance(pchar, cchar)
+            for pchar, cchar in zip(parent_seq, child_seq)
+        )
+
+    def get_adjacency_array(self, seq_len):
+        return np.array([self.transition_weights] * seq_len)
+
+    def weighted_hamming_edge_weight(self, field_name):
+        """Returns a function for computing weighted hamming distance between
+        two nodes' sequences.
+
+        Args:
+            field_name: The name of the node label field which contains sequences.
+
+        Returns:
+            A function accepting two :class:`HistoryDagNode` objects ``n1`` and ``n2`` and returning
+            a float: the transition cost from ``n1.label.<field_name>`` to ``n2.label.<field_name>``, or 0 if
+            n1 is the UA node.
+        """
+
+        @utils.access_nodefield_default(field_name, 0)
+        def edge_weight(parent, child):
+            return self.weighted_hamming_distance(parent, child)
+
+        return edge_weight
+
+    def min_weighted_hamming_edge_weight(self, field_name):
+        """Returns a function for computing weighted hamming distance between
+        two nodes' sequences.
+
+        If the child node is a leaf node, and its sequence contains ambiguities, the minimum possible
+        transition cost from parent to child will be returned.
+
+        Args:
+            field_name: The name of the node label field which contains sequences.
+
+        Returns:
+            A function accepting two :class:`HistoryDagNode` objects ``n1`` and ``n2`` and returning
+            a float: the transition cost from ``n1.label.<field_name>`` to ``n2.label.<field_name>``, or 0 if
+            n1 is the UA node.
+        """
+
+        def edge_weight(parent, child):
+            if parent.is_ua_node():
+                return 0
+            elif child.is_leaf():
+                return self.min_weighted_hamming_distance(
+                    getattr(parent.label, field_name), getattr(child.label, field_name)
+                )
+            else:
+                return self.weighted_hamming_distance(
+                    getattr(parent.label, field_name), getattr(child.label, field_name)
+                )
+
+        return edge_weight
+
+
+class UnitTransitionAlphabet(TransitionAlphabet):
+    """A subclass of :class:`TransitionAlphabet` to be used when all
+    transitions have unit cost."""
+
+    def __init__(self, bases="AGCT", ambiguity_map=None):
+        super().__init__(bases=bases, ambiguity_map=None)
+
+    def min_character_distance(self, parent_char, child_char):
+        return int(parent_char not in self.ambiguity_map[child_char])
+
+    def weighted_hamming_distance(self, parent_seq, child_seq):
+        if len(parent_seq) != len(child_seq):
+            raise ValueError("sequence lengths do not match!")
+        return sum(x != y for x, y in zip(parent_seq, child_seq))
+
+
+class VariableTransitionAlphabet(TransitionAlphabet):
+    """A subclass of :class:`TransitionAlphabet` to be used when transition
+    costs depend on site."""
+
+    def __init__(self, bases="AGCT", transition_matrix=None, ambiguity_map=None):
+        assert transition_matrix.shape[1:] == (len(bases), len(bases))
+        super().__init__(bases=bases, ambiguity_map=None)
+        self.transition_weights = None
+        self.sitewise_transition_matrix = transition_matrix
+        self._seq_len
+
+    def character_distance(self, parent_char, child_char, site):
+        return self.sitewise_transition_matrix[site - 1][parent_char][child_char]
+
+    def weighted_hamming_distance(self, parent_seq, child_seq):
+        if len(parent_seq) != self._seq_len or len(child_seq) != self._seq_len:
+            raise ValueError("Sequence lengths must match transition matrix length")
+        return sum(
+            self.character_distance(pchar, cchar, idx + 1)
+            for idx, (pchar, cchar) in enumerate(zip(parent_seq, child_seq))
+        )
+
+    def min_character_distance(self, parent_char, child_char, site):
+        """Allowing child_char to be ambiguous, returns the minimum possible
+        transition weight between parent_char and child_char."""
+        child_set = self.ambiguity_map[child_char]
+        p_idx = self.base_indices[parent_char]
+        return min(
+            self.transition_weights[site - 1][p_idx][self.base_indices[cbase]]
+            for cbase in child_set
+        )
+
+    def min_weighted_hamming_distance(self, parent_seq, child_seq):
+        """Assuming the child_seq may contain ambiguous characters, returns the
+        minimum possible transition weight between parent_seq and child_seq."""
+        if len(parent_seq) != len(child_seq):
+            raise ValueError("sequence lengths do not match!")
+        return sum(
+            self.min_character_distance(pchar, cchar, idx + 1)
+            for idx, (pchar, cchar) in enumerate(zip(parent_seq, child_seq))
+        )
+
+    def get_adjacency_array(self, seq_len):
+        if seq_len != self._seq_len:
+            raise ValueError(
+                f"VariableTransitionAlphabet instance supports sequence length of {self._seq_len}"
+            )
+        return self.sitewise_transition_matrix
+
+
+default_aa_transitions = UnitTransitionAlphabet(bases="AGCT")
+default_aa_gaps_transitions = UnitTransitionAlphabet(bases="AGCT-")
 
 
 def replace_label_attr(original_label, list_of_replacements={}):
@@ -85,64 +295,10 @@ def replace_label_attr(original_label, list_of_replacements={}):
     return type(original_label)(**fields)
 
 
-def weighted_hamming_distance_from_weight_matrix(weight_mat, bases="AGCT-"):
-    """Returns a function for computing weighted hamming distance between two
-    sequences.
-
-    Args:
-        weight_mat: A transition matrix describing the cost of transitions between bases in ``bases``.
-            For example, with bases ``AGCT-``, ``weight_mat[0][3]`` should contain the cost of a transition
-            from A to T.
-        bases: A sequence of characters describing the order of bases whose transition weights are expressed
-            in ``weight_mat``.
-
-    Returns:
-        A function taking two sequences of equal length and returning a float: the cost of transition
-            from the first sequence to the second.
-    """
-
-    if len(weight_mat) != len(bases) or len(weight_mat[0]) != len(bases):
-        raise ValueError(
-            "``weight_mat`` must be a n x n matrix, where ``n = len(bases)``."
-        )
-    base_indices = {k: v for v, k in enumerate(bases)}
-
-    def weighted_hamming_distance(seq1, seq2):
-        if len(seq1) != len(seq2):
-            raise ValueError("Sequences must have the same length!")
-        return sum(
-            weight_mat[base_indices[x], base_indices[y]] for x, y in zip(seq1, seq2)
-        )
-
-    return weighted_hamming_distance
-
-
-def make_weighted_hamming_edge_func(
-    weight_mat, sequence_attr_name="sequence", bases="AGCT-"
-):
-    """Returns function for computing weighted hamming distance between two
-    nodes' sequences.
-
-    Args:
-        weight_mat: A transition matrix describing the cost of transitions between bases in ``bases``.
-            For example, with bases ``AGCT-``, ``weight_mat[0][3]`` should contain the cost of a transition
-            from A to T.
-        bases: A sequence of characters describing the order of bases whose transition weights are expressed
-            in ``weight_mat``.
-
-    Returns:
-        A function accepting two :class:`HistoryDagNode` objects ``n1`` and ``n2`` and returning
-        a float: the transition cost from ``n1.label.sequence`` to ``n2.label.sequence``, or 0 if
-        n1 is the UA node.
-    """
-
-    return utils.access_nodefield_default(sequence_attr_name, 0)(
-        weighted_hamming_distance_from_weight_matrix(weight_mat, bases=bases)
-    )
-
-
 def make_weighted_hamming_count_funcs(
-    weight_mat, sequence_attr_name="sequence", bases="AGCT-"
+    transition_model=default_aa_transitions,
+    allow_ambiguous_leaves=False,
+    sequence_label="sequence",
 ):
     """Returns an :class:`AddFuncDict` for computing weighted parsimony.
 
@@ -150,22 +306,19 @@ def make_weighted_hamming_count_funcs(
     have unambiguous sequences stored in label attributes named ``sequence``.
 
     Args:
-        weight_mat: A transition matrix describing the cost of transitions between bases in ``bases``.
-            For example, with bases ``AGCT-``, ``weight_mat[0][3]`` should contain the cost of a transition
-            from A to T.
-        bases: A sequence of characters describing the order of bases whose transition weights are expressed
-            in ``weight_mat``.
 
     Returns:
         :class:`AddFuncDict` object for computing weighted parsimony.
     """
 
+    if allow_ambiguous_leaves:
+        weight_func = transition_model.min_weighted_hamming_edge_weight(sequence_label)
+    else:
+        weight_func = transition_model.weighted_hamming_edge_weight(sequence_label)
     return utils.AddFuncDict(
         {
             "start_func": lambda n: 0,
-            "edge_weight_func": make_weighted_hamming_edge_func(
-                weight_mat, sequence_attr_name=sequence_attr_name, bases=bases
-            ),
+            "edge_weight_func": weight_func,
             "accum_func": sum,
         },
         name="WeightedParsimony",
@@ -209,9 +362,7 @@ def sankoff_upward(
     node_list,
     seq_len,
     sequence_attr_name="sequence",
-    gap_as_char=False,
-    bases=bases,
-    transition_weights=None,
+    transition_model=default_aa_transitions,
     use_internal_node_sequences=False,
 ):
     """Compute Sankoff cost vectors at nodes in a postorder traversal, and
@@ -230,35 +381,16 @@ def sankoff_upward(
             the transition cost for sequences assigned to internal nodes. This assumes that internal
             nodes have a field with name ``sequence``.
     """
-    if gap_as_char:
 
-        def translate_base(char):
-            return char
-
-    else:
-
-        def translate_base(char):
-            if char == "-":
-                return "N"
-            else:
-                return char
-
-    code_vectors = {
-        code: [0 if b == code else float("inf") for b in bases] for code in bases
-    }
-
+    adj_arr = transition_model.get_adjacency_array(seq_len)
     if isinstance(node_list, ete3.TreeNode):
-        adj_arr = _get_adj_array(
-            seq_len, transition_weights=transition_weights, bases=bases
-        )
-
         # First pass of Sankoff: compute cost vectors
         for node in node_list.traverse(strategy="postorder"):
             node.add_feature(
                 "cost_vector",
                 np.array(
                     [
-                        code_vectors[translate_base(base)].copy()
+                        transition_model.mask_vectors[base].copy()
                         for base in getattr(node, sequence_attr_name)
                     ]
                 ),
@@ -267,7 +399,7 @@ def sankoff_upward(
                 child_costs = []
                 for child in node.children:
                     stacked_child_cv = np.stack(
-                        (child.cost_vector,) * len(bases), axis=1
+                        (child.cost_vector,) * len(transition_model.bases), axis=1
                     )
                     total_cost = adj_arr + stacked_child_cv
                     child_costs.append(np.min(total_cost, axis=2))
@@ -276,7 +408,7 @@ def sankoff_upward(
             if use_internal_node_sequences:
                 node.cost_vector += np.array(
                     [
-                        code_vectors[translate_base(base)]
+                        transition_model.mask_vectors[base]
                         for base in getattr(node, sequence_attr_name)
                     ]
                 )
@@ -286,15 +418,12 @@ def sankoff_upward(
         node_list = list(node_list.postorder())
     if isinstance(node_list, list):
         sequence_attr_idx = node_list[0].label._fields.index(sequence_attr_name)
-        adj_arr = _get_adj_array(
-            seq_len, transition_weights=transition_weights, bases=bases
-        )
         max_transition_cost = np.amax(adj_arr) * seq_len
 
         def children_cost(child_cost_vectors):
             costs = []
             for c in child_cost_vectors:
-                cost = adj_arr + np.stack((c,) * len(bases), axis=1)
+                cost = adj_arr + np.stack((c,) * len(transition_model.bases), axis=1)
                 costs.append(np.min(cost, axis=2))
             return np.sum(costs, axis=0)
 
@@ -303,7 +432,7 @@ def sankoff_upward(
                 return [
                     np.array(
                         [
-                            code_vectors[translate_base(base)].copy()
+                            transition_model.mask_vectors[base].copy()
                             for base in node.label[sequence_attr_idx]
                         ]
                     )
@@ -314,7 +443,7 @@ def sankoff_upward(
                 return [
                     np.array(
                         [
-                            code_vectors[translate_base(base)].copy()
+                            transition_model.mask_vectors[base].copy()
                             for base in node.label[sequence_attr_idx]
                         ]
                     )
@@ -349,10 +478,8 @@ def sankoff_downward(
     dag,
     partial_node_list=None,
     sequence_attr_name="sequence",
-    gap_as_char=False,
     compute_cvs=True,
-    bases=bases,
-    transition_weights=None,
+    transition_model=default_aa_transitions,
     trim=True,
 ):
     """Assign sequences to internal nodes of dag using a weighted Sankoff
@@ -383,18 +510,15 @@ def sankoff_downward(
             partial_node_list,
             seq_len,
             sequence_attr_name=sequence_attr_name,
-            gap_as_char=gap_as_char,
-            bases=bases,
-            transition_weights=transition_weights,
+            transition_model=transition_model,
         )
     # save the field names/types of the label datatype for this dag
-    adj_arr = _get_adj_array(
-        seq_len, transition_weights=transition_weights, bases=bases
-    )
-    inverse_bases = {i: s for s, i in enumerate(bases)}
+    adj_arr = transition_model.get_adjacency_array(seq_len)
 
     def transition_cost(seq):
-        return adj_arr[np.arange(len(seq)), [inverse_bases[s] for s in seq]]
+        return adj_arr[
+            np.arange(len(seq)), [transition_model.base_indices[s] for s in seq]
+        ]
 
     def compute_sequence_data(cost_vector):
         """Compute all possible sequences that minimize transition costs as given by cost_vector.
@@ -417,7 +541,7 @@ def sankoff_downward(
             for base_indices in all_base_indices
         ]
         new_sequence = [
-            "".join([bases[base_index] for base_index in base_indices])
+            "".join([transition_model.bases[base_index] for base_index in base_indices])
             for base_indices in all_base_indices
         ]
         return list(zip(new_sequence, adj_vec, [min_cost] * len(new_sequence)))
@@ -479,14 +603,9 @@ def sankoff_downward(
     # still need to trim the dag since the final addition of all
     # parents/children to new nodes can yield suboptimal choices
 
-    if transition_weights is not None:
-        weight_func = make_weighted_hamming_edge_func(
-            adj_arr[0], sequence_attr_name=sequence_attr_name, bases=bases
-        )
-    else:
-        weight_func = utils.access_nodefield_default(sequence_attr_name, 0)(
-            utils.hamming_distance
-        )
+    weight_func = utils.access_nodefield_default(sequence_attr_name, 0)(
+        transition_model.weighted_hamming_distance
+    )
     if trim:
         optimal_weight = dag.trim_optimal_weight(edge_weight_func=weight_func)
     else:
@@ -500,8 +619,7 @@ def disambiguate(
     random_state=None,
     remove_cvs=False,
     adj_dist=False,
-    gap_as_char=False,
-    transition_weights=None,
+    transition_model=default_aa_transitions,
     min_ambiguities=False,
 ):
     """Randomly resolve ambiguous bases using a two-pass Sankoff Algorithm on
@@ -515,14 +633,6 @@ def disambiguate(
         remove_cvs: Remove sankoff cost vectors from tree nodes after disambiguation.
         adj_dist: Recompute hamming parsimony distances on tree after disambiguation, and store them
             in ``dist`` node attributes.
-        gap_as_char: if True, the gap character ``-`` will be treated as a fifth character. Otherwise,
-            it will be treated the same as an ``N``.
-        transition_weights: A 5x5 transition weight matrix, with base order `AGCT-`.
-            Rows contain targeting weights. That is, the first row contains the transition weights
-            from `A` to each possible target base. Alternatively, a sequence-length array of these
-            transition weight matrices, if transition weights vary by-site. By default, a constant
-            weight matrix will be used containing 1 in all off-diagonal positions, equivalent
-            to Hamming parsimony.
         min_ambiguities: If True, leaves ambiguities in reconstructed sequences, expressing which
             bases are possible at each site in a maximally parsimonious disambiguation of the given
             topology. In the history DAG paper, this is known as a strictly min-weight ambiguous labeling.
@@ -534,18 +644,19 @@ def disambiguate(
         random.setstate(random_state)
 
     seq_len = len(next(tree.iter_leaves()).sequence)
-    adj_arr = _get_adj_array(seq_len, transition_weights=transition_weights)
+    adj_arr = transition_model.get_adjacency_array(seq_len)
     if compute_cvs:
-        sankoff_upward(tree, gap_as_char=gap_as_char)
+        sankoff_upward(tree, transition_model=transition_model)
     # Second pass of Sankoff: choose bases
     preorder = list(tree.traverse(strategy="preorder"))
     for node in preorder:
         if min_ambiguities:
             adj_vec = node.cost_vector != np.stack(
-                (node.cost_vector.min(axis=1),) * len(bases), axis=1
+                (node.cost_vector.min(axis=1),) * len(transition_model.bases), axis=1
             )
             new_seq = [
-                ambiguous_codes_from_vecs[tuple(map(float, row))] for row in adj_vec
+                transition_model.get_ambiguity_from_tuple(tuple(map(float, row)))
+                for row in adj_vec
             ]
         else:
             base_indices = []
@@ -561,7 +672,9 @@ def disambiguate(
                 base_indices.append(base_index)
 
             adj_vec = adj_arr[np.arange(seq_len), base_indices]
-            new_seq = [bases[base_index] for base_index in base_indices]
+            new_seq = [
+                transition_model.bases[base_index] for base_index in base_indices
+            ]
 
         # Adjust child cost vectors
         for child in node.children:
@@ -577,7 +690,9 @@ def disambiguate(
     if adj_dist:
         tree.dist = 0
         for node in tree.iter_descendants():
-            node.dist = hamming_distance(node.up.sequence, node.sequence)
+            node.dist = transition_model.weighted_hamming_distance(
+                node.up.sequence, node.sequence
+            )
     return tree
 
 
@@ -658,13 +773,13 @@ def build_trees_from_files(newickfiles, fastafile, **kwargs):
         yield build_tree(newick, fasta_map, **kwargs)
 
 
-def parsimony_score(tree):
+def parsimony_score(tree, transition_model=default_aa_transitions):
     """returns the parsimony score of a (disambiguated) ete tree.
 
     Tree must have 'sequence' attributes on all nodes.
     """
     return sum(
-        hamming_distance(node.up.sequence, node.sequence)
+        transition_model.weighted_hamming_distance(node.up.sequence, node.sequence)
         for node in tree.iter_descendants()
     )
 
@@ -743,15 +858,6 @@ def build_dag_from_trees(trees):
         trees,
         ["sequence"],
     )
-
-
-def summarize_dag(dag):
-    """print summary information about the provided history DAG."""
-    print("DAG contains")
-    print("trees: ", dag.count_histories())
-    print("nodes: ", len(list(dag.preorder())))
-    print("edges: ", sum(len(list(node.children())) for node in dag.preorder()))
-    print("parsimony scores: ", dag.weight_count())
 
 
 def disambiguate_history(history):

--- a/historydag/parsimony_utils.py
+++ b/historydag/parsimony_utils.py
@@ -726,13 +726,8 @@ This edge weight function allows leaf nodes to have ambiguous compact
 genomes.
 """
 
-hamming_distance_countfuncs = AddFuncDict(
-    {
-        "start_func": lambda n: 0,
-        "edge_weight_func": hamming_edge_weight,
-        "accum_func": sum,
-    },
-    name="HammingParsimony",
+hamming_distance_countfuncs = default_nt_transitions.get_weighted_parsimony_countfuncs(
+    "sequence", leaf_ambiguities=False
 )
 """Provides functions to count hamming distance parsimony when leaf sequences
 may be ambiguous.
@@ -740,13 +735,10 @@ may be ambiguous.
 For use with :meth:`historydag.AmbiguousLeafSequenceHistoryDag.weight_count`.
 """
 
-leaf_ambiguous_hamming_distance_countfuncs = AddFuncDict(
-    {
-        "start_func": lambda n: 0,
-        "edge_weight_func": hamming_edge_weight_ambiguous_leaves,
-        "accum_func": sum,
-    },
-    name="HammingParsimony",
+leaf_ambiguous_hamming_distance_countfuncs = (
+    default_nt_transitions.get_weighted_parsimony_countfuncs(
+        "sequence", leaf_ambiguities=False
+    )
 )
 """Provides functions to count hamming distance parsimony when leaf sequences
 may be ambiguous.

--- a/historydag/parsimony_utils.py
+++ b/historydag/parsimony_utils.py
@@ -1,10 +1,41 @@
+"""This module provides tools for describing and computing parsimony and
+weighted parsimony, and for describing allowed characters and ambiguity codes.
+
+:class:`AmbiguityMap` stores a collection of ``Characters`` (for example the strings
+``'A'``, ``'G'``, ``'C'``, and ``'T'``) that are considered valid states, as well as
+a mapping between other ``Characters`` ('ambiguity codes') and subsets of these allowed
+characters. This type allows forward- and backward-lookup of ambiguity codes.
+
+:class:`TransitionModel` describes transition weights between an ordered collection of
+``Characters``, and provides methods for computing weighted parsimony. Functions in
+``historydag.parsimony`` accept ``TransitionModel`` objects to customize the implementation
+of Sankoff, for example. This class has two subclasses: :class:`UnitTransitionModel`,
+which describes unit transition costs between non-identical ``Characters``,
+and :class:`SitewiseTransitionModel`, which allows transition costs to depend on the
+location in a sequence in which a transition occurs.
+"""
 import numpy as np
 import historydag.utils as utils
+from historydag.utils import AddFuncDict, Label
 import Bio.Data.IUPACData
 from frozendict import frozendict
 from typing import (
     Generator,
+    Tuple,
+    Callable,
+    Iterable,
+    Sequence,
+    Any,
+    Mapping,
+    TYPE_CHECKING,
 )
+
+Character = Any
+CharacterSequence = Sequence[Character]
+
+if TYPE_CHECKING:
+    from historydag.dag import HistoryDagNode
+    from historydag.compact_genome import CompactGenome
 
 
 class AmbiguityMap:
@@ -19,7 +50,11 @@ class AmbiguityMap:
         bases: A collection of bases. If not provided, this will be inferred from the ambiguity_character_map.
     """
 
-    def __init__(self, ambiguity_character_map, bases=None):
+    def __init__(
+        self,
+        ambiguity_character_map: Mapping[Character, Iterable[Character]],
+        bases: Iterable[Character] = None,
+    ):
         ambiguous_values = {
             char: frozenset(bases) for char, bases in ambiguity_character_map.items()
         }
@@ -53,12 +88,14 @@ class AmbiguityMap:
     def items(self):
         return self.ambiguous_values.items()
 
-    def is_ambiguous(self, sequence: str) -> bool:
-        """Returns whether the provided sequence contains IUPAC nucleotide
-        ambiguity codes."""
+    def is_ambiguous(self, sequence: CharacterSequence) -> bool:
+        """Returns whether the provided sequence contains any non-base
+        characters (such as ambiguity codes)."""
         return any(code not in self.bases for code in sequence)
 
-    def sequence_resolutions(self, sequence: str) -> Generator[str, None, None]:
+    def sequence_resolutions(
+        self, sequence: CharacterSequence
+    ) -> Generator[CharacterSequence, None, None]:
         """Iterates through possible disambiguations of sequence, recursively.
 
         Recursion-depth-limited by number of ambiguity codes in
@@ -80,20 +117,27 @@ class AmbiguityMap:
 
         return _sequence_resolutions(sequence)
 
-    def get_sequence_resolution_func(self, field_name):
+    def get_sequence_resolution_func(
+        self, field_name: str
+    ) -> Callable[[Label], Generator[Label, None, None]]:
         """Returns a function which takes a Label, and returns a generator on
         labels containing all possible resolutions of the sequence in that
-        node's label's field_name attribute."""
+        node's label's ``field_name`` attribute."""
 
         @utils.explode_label(field_name)
-        def sequence_resolutions(sequence: str) -> Generator[str, None, None]:
+        def sequence_resolutions(
+            sequence: CharacterSequence,
+        ) -> Generator[CharacterSequence, None, None]:
             return self.sequence_resolutions(sequence)
 
         return sequence_resolutions
 
-    def sequence_resolution_count(self, sequence: str) -> int:
-        """Count the number of possible sequence resolutions Equivalent to the
-        length of the list returned by :meth:`sequence_resolutions`."""
+    def sequence_resolution_count(self, sequence: CharacterSequence) -> int:
+        """Count the number of possible sequence resolutions.
+
+        Equivalent to the number of items yielded by
+        :meth:`sequence_resolutions`.
+        """
         base_options = [
             len(self.ambiguous_values[base])
             for base in sequence
@@ -101,7 +145,13 @@ class AmbiguityMap:
         ]
         return utils.prod(base_options)
 
-    def get_sequence_resolution_count_func(self, field_name):
+    def get_sequence_resolution_count_func(
+        self, field_name: str
+    ) -> Callable[[Label], int]:
+        """Returns a function taking a Label and returning the number of
+        resolutions for the sequence held in the label's ``field_name``
+        attribute."""
+
         @utils.access_field(field_name)
         def sequence_resolution_count(sequence) -> int:
             return self.sequence_resolution_count(sequence)
@@ -110,6 +160,9 @@ class AmbiguityMap:
 
 
 class ReversedAmbiguityMap(frozendict):
+    """A subclass of frozendict for holding the reversed map in a
+    :class:`AmbiguityMap` instance."""
+
     def __getitem__(self, key):
         try:
             return super().__getitem__(key)
@@ -122,15 +175,44 @@ _ambiguous_dna_values_gap_as_char.update({"?": "GATC-", "-": "-"})
 _ambiguous_dna_values = Bio.Data.IUPACData.ambiguous_dna_values.copy()
 _ambiguous_dna_values.update({"?": "GATC", "-": "GATC"})
 
-standard_aa_ambiguity_map = AmbiguityMap(_ambiguous_dna_values, "AGCT")
-standard_aa_ambiguity_map_gap_as_char = AmbiguityMap(
+standard_nt_ambiguity_map = AmbiguityMap(_ambiguous_dna_values, "AGCT")
+"""The standard IUPAC nucleotide ambiguity map, in which 'N', '?', and '-' are all considered fully ambiguous."""
+
+standard_nt_ambiguity_map_gap_as_char = AmbiguityMap(
     _ambiguous_dna_values_gap_as_char, "AGCT-"
 )
+"""The standard IUPAC nucleotide ambiguity map, in which '-' is treated as a fifth base, '?' is fully ambiguous,
+and the ambiguity 'N' excludes '-'."""
 
 
-class TransitionAlphabet:
+class TransitionModel:
+    """A class describing a collection of states, and the transition costs
+    between them, for weighted parsimony.
+
+    In addition to them methods defined below, there are also attributes which are created by
+    the constructor, which should be ensured to be correct in any subclass of TransitionModel:
+
+    * ``base_indices`` is a dictionary mapping bases in ``self.bases`` to their indices
+    * ``mask_vectors`` is a dictionary mapping ambiguity codes (including non-ambiguous bases)
+    to vectors of floats which are 0 at indices compatible with the ambiguity code, and infinity
+    otherwise.
+    * ``bases`` is a tuple recording the correct order of unambiguous bases
+
+    Args:
+        bases: An ordered collection of valid character states
+        transition_weights: A matrix describing transition costs between bases, with index order (from_base, to_base)
+        ambiguity_map: An :class:`AmbiguityMap` object describing ambiguity codes. If not provided, the default
+            mapping depends on the provided bases. If provided bases are ``AGCT``, then
+            :class:`standard_nt_ambiguity_map` is used. If bases are ``AGCT-``, then
+            :class:`standard_nt_ambiguity_map_gap_as_char` is used. Otherwise, it is assumed that no ambiguity
+            codes are allowed. To override these defaults, provide an :class:`AmbiguityMap` explicitly.
+    """
+
     def __init__(
-        self, bases=tuple("AGCT"), transition_weights=None, ambiguity_map=None
+        self,
+        bases: CharacterSequence = tuple("AGCT"),
+        transition_weights: Sequence[Sequence[float]] = None,
+        ambiguity_map: AmbiguityMap = None,
     ):
         self.bases = tuple(bases)
         self.base_indices = frozendict({base: idx for idx, base in enumerate(bases)})
@@ -148,16 +230,20 @@ class TransitionAlphabet:
                 )
             self.transition_weights = transition_weights
         if ambiguity_map is None:
-            if self.bases == tuple("AGCT"):
-                self.ambiguity_map = standard_aa_ambiguity_map
-            elif self.bases == tuple("AGCT-"):
-                self.ambiguity_map = standard_aa_ambiguity_map_gap_as_char
+            if set(self.bases) == set("AGCT"):
+                self.ambiguity_map = standard_nt_ambiguity_map
+            elif set(self.bases) == set("AGCT-"):
+                self.ambiguity_map = standard_nt_ambiguity_map_gap_as_char
             else:
                 self.ambiguity_map = AmbiguityMap({}, self.bases)
         else:
             if not isinstance(ambiguity_map, AmbiguityMap):
                 raise ValueError(
                     "ambiguity_map, if provided, must be a historydag.parsimony.AmbiguityMap object"
+                )
+            if ambiguity_map.bases != set(self.bases):
+                raise ValueError(
+                    "ambiguity_map.bases does not match bases provided to TransitionModel constructor"
                 )
             self.ambiguity_map = ambiguity_map
 
@@ -173,26 +259,45 @@ class TransitionAlphabet:
             for code in self.ambiguity_map
         }
 
-    def get_adjacency_array(self, seq_len):
+    def get_adjacency_array(self, seq_len: int) -> np.array:
+        """Return an adjacency array for a sequence of length ``seq_len``.
+
+        This is a matrix containing transition costs, with index order
+        (site, from_base, to_base)
+        """
         return np.array([self.transition_weights] * seq_len)
 
-    def get_ambiguity_from_tuple(self, tup):
+    def get_ambiguity_from_tuple(self, tup: Tuple) -> Character:
         """Retrieve an ambiguity code encoded by tup, which encodes a set of
         bases with a tuple of 0's and 1's.
 
-        For example, with ``bases='AGCT'``, ``(0, 1, 1, 1)`` would
-        return `A`.
+        For example, if ``self.bases`` is 'AGCT'``, then ``(0, 1, 1,
+        1)`` would return `A`.
         """
         return self.ambiguity_map.reversed[
             frozenset(self.bases[i] for i, flag in enumerate(tup) if flag == 0)
         ]
 
-    def character_distance(self, parent_char, child_char, site=None):
+    def character_distance(
+        self, parent_char: Character, child_char: Character, site: int = None
+    ) -> float:
+        """Return the transition cost from parent_char to child_char, two
+        unambiguous characters.
+
+        keyword argument ``site`` is ignored in this base class.
+        """
         return self.transition_weights[self.base_indices[parent_char]][
             self.base_indices[child_char]
         ]
 
-    def weighted_hamming_distance(self, parent_seq, child_seq):
+    def weighted_hamming_distance(
+        self, parent_seq: CharacterSequence, child_seq: CharacterSequence
+    ) -> float:
+        """Return the sum of sitewise transition costs, from parent_seq to
+        child_seq.
+
+        Both parent_seq and child_seq are expected to be unambiguous.
+        """
         if len(parent_seq) != len(child_seq):
             raise ValueError("sequence lengths do not match!")
         return sum(
@@ -200,7 +305,18 @@ class TransitionAlphabet:
             for idx, (pchar, cchar) in enumerate(zip(parent_seq, child_seq))
         )
 
-    def weighted_cg_hamming_distance(self, parent_cg, child_cg):
+    def weighted_cg_hamming_distance(
+        self, parent_cg: "CompactGenome", child_cg: "CompactGenome"
+    ) -> float:
+        """Return the sum of sitewise transition costs, from parent_cg to
+        child_cg.
+
+        Both parent_seq and child_seq are expected to be unambiguous,
+        but sites where parent_cg and child_cg both match their
+        reference sequence are ignored, so this method is not suitable
+        for weighted parsimony for transition matrices that contain
+        nonzero entries along the diagonal.
+        """
         if parent_cg.reference != child_cg.reference:
             raise ValueError("Reference sequences do not match!")
         s1 = set(parent_cg.mutations.keys())
@@ -212,9 +328,14 @@ class TransitionAlphabet:
             for site in s1 | s2
         )
 
-    def min_character_distance(self, parent_char, child_char, site=None):
+    def min_character_distance(
+        self, parent_char: Character, child_char: Character, site=None
+    ) -> float:
         """Allowing child_char to be ambiguous, returns the minimum possible
-        transition weight between parent_char and child_char."""
+        transition weight between parent_char and child_char.
+
+        Keyword argument ``site`` is ignored in this base class.
+        """
         child_set = self.ambiguity_map[child_char]
         p_idx = self.base_indices[parent_char]
         return min(
@@ -222,7 +343,9 @@ class TransitionAlphabet:
             for cbase in child_set
         )
 
-    def min_weighted_hamming_distance(self, parent_seq, child_seq):
+    def min_weighted_hamming_distance(
+        self, parent_seq: CharacterSequence, child_seq: CharacterSequence
+    ) -> float:
         """Assuming the child_seq may contain ambiguous characters, returns the
         minimum possible transition weight between parent_seq and child_seq."""
         if len(parent_seq) != len(child_seq):
@@ -232,7 +355,19 @@ class TransitionAlphabet:
             for idx, (pchar, cchar) in enumerate(zip(parent_seq, child_seq))
         )
 
-    def min_weighted_cg_hamming_distance(self, parent_cg, child_cg):
+    def min_weighted_cg_hamming_distance(
+        self, parent_cg: "CompactGenome", child_cg: "CompactGenome"
+    ) -> float:
+        """Return the sum of sitewise transition costs, from parent_cg to
+        child_cg.
+
+        child_cg may contain ambiguous characters, and in this case those sites will contribute the minimum
+        possible transition cost to the returned value.
+
+        Sites where parent_cg and child_cg
+        both match their reference sequence are ignored, so this method is not suitable for weighted parsimony
+        for transition matrices that contain nonzero entries along the diagonal.
+        """
         if parent_cg.reference != child_cg.reference:
             raise ValueError("Reference sequences do not match!")
         s1 = set(parent_cg.mutations.keys())
@@ -244,7 +379,9 @@ class TransitionAlphabet:
             for site in s1 | s2
         )
 
-    def weighted_hamming_edge_weight(self, field_name):
+    def weighted_hamming_edge_weight(
+        self, field_name: str
+    ) -> Callable[["HistoryDagNode", "HistoryDagNode"], float]:
         """Returns a function for computing weighted hamming distance between
         two nodes' sequences.
 
@@ -263,7 +400,9 @@ class TransitionAlphabet:
 
         return edge_weight
 
-    def weighted_cg_hamming_edge_weight(self, field_name):
+    def weighted_cg_hamming_edge_weight(
+        self, field_name: str
+    ) -> Callable[["HistoryDagNode", "HistoryDagNode"], float]:
         """Returns a function for computing weighted hamming distance between
         two nodes' compact genomes.
 
@@ -274,6 +413,10 @@ class TransitionAlphabet:
             A function accepting two :class:`HistoryDagNode` objects ``n1`` and ``n2`` and returning
             a float: the transition cost from ``n1.label.<field_name>`` to ``n2.label.<field_name>``, or 0 if
             n1 is the UA node.
+
+        Sites where parent_cg and child_cg
+        both match their reference sequence are ignored, so this method is not suitable for weighted parsimony
+        for transition matrices that contain nonzero entries along the diagonal.
         """
 
         @utils.access_nodefield_default(field_name, 0)
@@ -282,7 +425,9 @@ class TransitionAlphabet:
 
         return edge_weight
 
-    def min_weighted_hamming_edge_weight(self, field_name):
+    def min_weighted_hamming_edge_weight(
+        self, field_name: str
+    ) -> Callable[["HistoryDagNode", "HistoryDagNode"], float]:
         """Returns a function for computing weighted hamming distance between
         two nodes' sequences.
 
@@ -312,7 +457,9 @@ class TransitionAlphabet:
 
         return edge_weight
 
-    def min_weighted_cg_hamming_edge_weight(self, field_name):
+    def min_weighted_cg_hamming_edge_weight(
+        self, field_name: str
+    ) -> Callable[["HistoryDagNode", "HistoryDagNode"], float]:
         """Returns a function for computing weighted hamming distance between
         two nodes' compact genomes.
 
@@ -343,13 +490,25 @@ class TransitionAlphabet:
         return edge_weight
 
     def get_weighted_cg_parsimony_countfuncs(
-        self, field_name, leaf_ambiguities=False, name="WeightedParsimony"
-    ):
+        self,
+        field_name: str,
+        leaf_ambiguities: bool = False,
+        name: str = "WeightedParsimony",
+    ) -> AddFuncDict:
+        """Create a :class:`historydag.utils.AddFuncDict` object for counting
+        weighted parsimony in a HistoryDag with labels containing compact
+        genomes.
+
+        Args:
+            field_name: the label field name in which compact genomes can be found
+            leaf_ambiguities: if True, leaf compact genomes are permitted to contain ambiguity codes
+            name: the name for the returned AddFuncDict object
+        """
         if leaf_ambiguities:
             edge_weight = self.min_weighted_cg_hamming_edge_weight(field_name)
         else:
             edge_weight = self.weighted_cg_hamming_edge_weight(field_name)
-        return utils.AddFuncDict(
+        return AddFuncDict(
             {
                 "start_func": lambda n: 0,
                 "edge_weight_func": edge_weight,
@@ -359,13 +518,24 @@ class TransitionAlphabet:
         )
 
     def get_weighted_parsimony_countfuncs(
-        self, field_name, leaf_ambiguities=False, name="WeightedParsimony"
+        self,
+        field_name: str,
+        leaf_ambiguities: bool = False,
+        name: str = "WeightedParsimony",
     ):
+        """Create a :class:`historydag.utils.AddFuncDict` object for counting
+        weighted parsimony in a HistoryDag with labels containing sequences.
+
+        Args:
+            field_name: the label field name in which sequences can be found
+            leaf_ambiguities: if True, leaf sequences are permitted to contain ambiguity codes
+            name: the name for the returned AddFuncDict object
+        """
         if leaf_ambiguities:
             edge_weight = self.min_weighted_hamming_edge_weight(field_name)
         else:
             edge_weight = self.weighted_hamming_edge_weight(field_name)
-        return utils.AddFuncDict(
+        return AddFuncDict(
             {
                 "start_func": lambda n: 0,
                 "edge_weight_func": edge_weight,
@@ -375,51 +545,124 @@ class TransitionAlphabet:
         )
 
 
-class UnitTransitionAlphabet(TransitionAlphabet):
-    """A subclass of :class:`TransitionAlphabet` to be used when all
-    transitions have unit cost."""
+class UnitTransitionModel(TransitionModel):
+    """A subclass of :class:`TransitionModel` to be used when all non-identical
+    transitions have unit cost.
 
-    def __init__(self, bases="AGCT", ambiguity_map=None):
+    Args:
+        bases: An ordered container of allowed character states
+        ambiguity_map: A :class:`AmbiguityMap` object describing allowed ambiguity codes.
+            If not provided, a default will be chosen by the same method as the constructor for
+            :class:`TransitionModel`.
+    """
+
+    def __init__(
+        self, bases: CharacterSequence = "AGCT", ambiguity_map: AmbiguityMap = None
+    ):
         super().__init__(bases=bases, ambiguity_map=None)
 
-    def character_distance(self, parent_char, child_char, site=None):
+    def character_distance(
+        self, parent_char: Character, child_char: Character, site: int = None
+    ) -> int:
+        """Return the transition cost from parent_char to child_char, two
+        unambiguous characters.
+
+        keyword argument ``site`` is ignored in this subclass.
+        """
         return int(parent_char != child_char)
 
-    def min_character_distance(self, parent_char, child_char, site=None):
-        return int(parent_char not in self.ambiguity_map[child_char])
+    def min_character_distance(
+        self, parent_char: Character, child_char: Character, site: int = None
+    ) -> int:
+        """Allowing child_char to be ambiguous, returns the minimum possible
+        transition weight between parent_char and child_char.
+
+        Keyword argument ``site`` is ignored in this subclass.
+        """
+        if parent_char == child_char:
+            return 0  # TODO do we really want this?
+        else:
+            return int(parent_char not in self.ambiguity_map[child_char])
 
     def get_weighted_cg_parsimony_countfuncs(
-        self, field_name, leaf_ambiguities=False, name="HammingParsimony"
-    ):
+        self,
+        field_name: str,
+        leaf_ambiguities: AmbiguityMap = False,
+        name: str = "HammingParsimony",
+    ) -> AddFuncDict:
+        """Create a :class:`historydag.utils.AddFuncDict` object for counting
+        parsimony in a HistoryDag with labels containing compact genomes.
+
+        Args:
+            field_name: the label field name in which compact genomes can be found
+            leaf_ambiguities: if True, leaf compact genomes are permitted to contain ambiguity codes
+            name: the name for the returned AddFuncDict object
+        """
         return super().get_weighted_cg_parsimony_countfuncs(
             field_name, leaf_ambiguities=leaf_ambiguities, name=name
         )
 
     def get_weighted_parsimony_countfuncs(
-        self, field_name, leaf_ambiguities=False, name="HammingParsimony"
-    ):
+        self,
+        field_name: str,
+        leaf_ambiguities: AmbiguityMap = False,
+        name: str = "HammingParsimony",
+    ) -> AddFuncDict:
+        """Create a :class:`historydag.utils.AddFuncDict` object for counting
+        weighted parsimony in a HistoryDag with labels containing sequences.
+
+        Args:
+            field_name: the label field name in which sequences can be found
+            leaf_ambiguities: if True, leaf sequences are permitted to contain ambiguity codes
+            name: the name for the returned AddFuncDict object
+        """
         return super().get_weighted_parsimony_countfuncs(
             field_name, leaf_ambiguities=leaf_ambiguities, name=name
         )
 
 
-class VariableTransitionAlphabet(TransitionAlphabet):
-    """A subclass of :class:`TransitionAlphabet` to be used when transition
-    costs depend on site."""
+class SitewiseTransitionModel(TransitionModel):
+    """A subclass of :class:`TransitionModel` to be used when transition costs
+    depend on site.
 
-    def __init__(self, bases="AGCT", transition_matrix=None, ambiguity_map=None):
+    Args:
+        bases: An ordered container of allowed character states
+        transition_matrix: A matrix of transition costs between provided bases, in which
+            index order is (site, from_base, to_base)
+        ambiguity_map: An :class:`AmbiguityMap` object describing ambiguous characters. If not provided
+            a default will be chosen as in the constructor for :class:`TransitionModel`.
+    """
+
+    def __init__(
+        self,
+        bases: CharacterSequence = "AGCT",
+        transition_matrix: Sequence[Sequence[Sequence[float]]] = None,
+        ambiguity_map: AmbiguityMap = None,
+    ):
         assert transition_matrix.shape[1:] == (len(bases), len(bases))
         super().__init__(bases=bases, ambiguity_map=None)
         self.transition_weights = None
         self.sitewise_transition_matrix = transition_matrix
-        self._seq_len
+        self._seq_len = len(self.sitewise_transition_matrix)
 
-    def character_distance(self, parent_char, child_char, site):
+    def character_distance(
+        self, parent_char: Character, child_char: Character, site: int
+    ) -> float:
+        """Returns the transition cost from ``parent_char`` to ``child_char``,
+        assuming each character is at the one-based ``site`` in their
+        respective sequences.
+
+        Both parent_char and child_char are expected to be unambiguous.
+        """
         return self.sitewise_transition_matrix[site - 1][parent_char][child_char]
 
-    def min_character_distance(self, parent_char, child_char, site):
+    def min_character_distance(
+        self, parent_char: Character, child_char: Character, site: int
+    ) -> float:
         """Allowing child_char to be ambiguous, returns the minimum possible
-        transition weight between parent_char and child_char."""
+        transition weight between parent_char and child_char, given that these
+        characters are found at the (one-based) site in their respective
+        sequences."""
         child_set = self.ambiguity_map[child_char]
         p_idx = self.base_indices[parent_char]
         return min(
@@ -428,29 +671,53 @@ class VariableTransitionAlphabet(TransitionAlphabet):
         )
 
     def get_adjacency_array(self, seq_len):
+        """Return an adjacency array for a sequence of length ``seq_len``.
+
+        This is a matrix containing transition costs, with index order
+        (site, from_base, to_base)
+        """
         if seq_len != self._seq_len:
             raise ValueError(
-                f"VariableTransitionAlphabet instance supports sequence length of {self._seq_len}"
+                f"SitewiseTransitionModel instance supports sequence length of {self._seq_len}"
             )
         return self.sitewise_transition_matrix
 
 
-default_aa_transitions = UnitTransitionAlphabet(bases="AGCT")
-default_aa_gaps_transitions = UnitTransitionAlphabet(bases="AGCT-")
+default_nt_transitions = UnitTransitionModel(bases="AGCT")
+"""A transition model for nucleotides using unit transition weights, and the standard IUPAC
+ambiguity codes, with base order ``AGCT`` and ``N``, ``?`` and ``-`` treated as fully ambiguous
+characters."""
 
-hamming_edge_weight = default_aa_transitions.weighted_hamming_edge_weight("sequence")
+default_nt_gaps_transitions = UnitTransitionModel(bases="AGCT-")
+"""A transition model for nucleotides using unit transition weights, and the standard IUPAC
+nucleotide ambiguity map, with '-' is treated as a fifth base, '?' fully ambiguous,
+and the ambiguity 'N' excluding only '-'."""
+
+hamming_edge_weight = default_nt_transitions.weighted_hamming_edge_weight("sequence")
+"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes, and returning
+the hamming distance between the sequences stored in the ``sequence`` attributes of their labels."""
 hamming_edge_weight_ambiguous_leaves = (
-    default_aa_transitions.min_weighted_hamming_edge_weight("sequence")
+    default_nt_transitions.min_weighted_hamming_edge_weight("sequence")
 )
+"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes, and returning
+the hamming distance between the sequences stored in the ``sequence`` attributes of their labels.
+This edge weight function allows leaf nodes to have ambiguous sequences."""
 
-hamming_cg_edge_weight = default_aa_transitions.weighted_cg_hamming_edge_weight(
+hamming_cg_edge_weight = default_nt_transitions.weighted_cg_hamming_edge_weight(
     "compact_genome"
 )
-hamming_cg_edge_weight_ambiguous_leaves = (
-    default_aa_transitions.min_weighted_cg_hamming_edge_weight("compact_genome")
-)
+"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes, and returning
+the hamming distance between the compact genomes stored in the ``compact_genome`` attributes of their labels.
+"""
 
-hamming_distance_countfuncs = utils.AddFuncDict(
+hamming_cg_edge_weight_ambiguous_leaves = (
+    default_nt_transitions.min_weighted_cg_hamming_edge_weight("compact_genome")
+)
+"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes, and returning
+the hamming distance between the compact genomes stored in the ``compact_genome`` attributes of their labels.
+This edge weight function allows leaf nodes to have ambiguous compact genomes."""
+
+hamming_distance_countfuncs = AddFuncDict(
     {
         "start_func": lambda n: 0,
         "edge_weight_func": hamming_edge_weight,
@@ -462,7 +729,7 @@ hamming_distance_countfuncs = utils.AddFuncDict(
 may be ambiguous.
 For use with :meth:`historydag.AmbiguousLeafSequenceHistoryDag.weight_count`."""
 
-leaf_ambiguous_hamming_distance_countfuncs = utils.AddFuncDict(
+leaf_ambiguous_hamming_distance_countfuncs = AddFuncDict(
     {
         "start_func": lambda n: 0,
         "edge_weight_func": hamming_edge_weight_ambiguous_leaves,
@@ -476,7 +743,7 @@ For use with :meth:`historydag.AmbiguousLeafSequenceHistoryDag.weight_count`."""
 
 
 compact_genome_hamming_distance_countfuncs = (
-    default_aa_transitions.get_weighted_cg_parsimony_countfuncs(
+    default_nt_transitions.get_weighted_cg_parsimony_countfuncs(
         "compact_genome", leaf_ambiguities=False
     )
 )
@@ -486,7 +753,7 @@ For use with :meth:`historydag.CGHistoryDag.weight_count`."""
 
 
 leaf_ambiguous_compact_genome_hamming_distance_countfuncs = (
-    default_aa_transitions.get_weighted_cg_parsimony_countfuncs(
+    default_nt_transitions.get_weighted_cg_parsimony_countfuncs(
         "compact_genome", leaf_ambiguities=True
     )
 )

--- a/historydag/parsimony_utils.py
+++ b/historydag/parsimony_utils.py
@@ -1,0 +1,376 @@
+import numpy as np
+import historydag.utils as utils
+import Bio.Data.IUPACData
+from frozendict import frozendict
+
+
+class AmbiguityMap:
+    """Implements a bijection between a subset of the power set of an alphabet
+    of bases, and an expanded alphabet of ambiguity codes.
+
+    To look up the set of bases represented by an ambiguity code, use the object like a dictionary.
+    To look up an ambiguity code representing a set of bases, use the ``reversed`` attribute.
+
+    Args:
+        ambiguity_character_map: A mapping from ambiguity codes to collections of bases represented by that code.
+        bases: A collection of bases. If not provided, this will be inferred from the ambiguity_character_map.
+    """
+
+    def __init__(self, ambiguity_character_map, bases=None):
+        ambiguous_values = {
+            char: frozenset(bases) for char, bases in ambiguity_character_map.items()
+        }
+        if bases is None:
+            self.bases = frozenset(
+                base for bset in self.ambiguous_values for base in bset
+            )
+        else:
+            self.bases = frozenset(bases)
+
+        ambiguous_values.update({base: frozenset({base}) for base in self.bases})
+        self.ambiguous_values = frozendict(ambiguous_values)
+        self.reversed = ReversedAmbiguityMap(
+            {bases: char for char, bases in self.ambiguous_values.items()}
+        )
+
+    def __getitem__(self, key):
+        try:
+            return self.ambiguous_values[key]
+        except KeyError:
+            raise KeyError(f"{key} is not a valid ambiguity code for this map.")
+
+    def __iter__(self):
+        return self.ambiguous_values.__iter__()
+
+    def items(self):
+        return self.ambiguous_values.items()
+
+
+class ReversedAmbiguityMap(frozendict):
+    def __getitem__(self, key):
+        try:
+            return super().__getitem__(key)
+        except KeyError:
+            raise KeyError(f"No ambiguity code is defined for the set of bases {key}")
+
+
+_ambiguous_dna_values_gap_as_char = Bio.Data.IUPACData.ambiguous_dna_values.copy()
+_ambiguous_dna_values_gap_as_char.update({"?": "GATC-", "-": "-"})
+_ambiguous_dna_values = Bio.Data.IUPACData.ambiguous_dna_values.copy()
+_ambiguous_dna_values.update({"?": "GATC", "-": "GATC"})
+
+standard_aa_ambiguity_map = AmbiguityMap(_ambiguous_dna_values, "AGCT")
+standard_aa_ambiguity_map_gap_as_char = AmbiguityMap(
+    _ambiguous_dna_values_gap_as_char, "AGCT-"
+)
+
+
+class TransitionAlphabet:
+    def __init__(
+        self, bases=tuple("AGCT"), transition_weights=None, ambiguity_map=None
+    ):
+        self.bases = tuple(bases)
+        self.base_indices = frozendict({base: idx for idx, base in enumerate(bases)})
+        self.yey = np.array(
+            [[i != j for i in range(len(self.bases))] for j in range(len(self.bases))]
+        )
+        if transition_weights is None:
+            self.transition_weights = self.yey
+        else:
+            if len(transition_weights) != len(self.bases) or len(
+                transition_weights[0]
+            ) != len(self.bases):
+                raise ValueError(
+                    "transition_weights must be a nxn matrix, with n=len(bases)"
+                )
+            self.transition_weights = transition_weights
+        if ambiguity_map is None:
+            if self.bases == tuple("AGCT"):
+                self.ambiguity_map = standard_aa_ambiguity_map
+            elif self.bases == tuple("AGCT-"):
+                self.ambiguity_map = standard_aa_ambiguity_map_gap_as_char
+            else:
+                self.ambiguity_map = AmbiguityMap({}, self.bases)
+        else:
+            if not isinstance(ambiguity_map, AmbiguityMap):
+                raise ValueError(
+                    "ambiguity_map, if provided, must be a historydag.parsimony.AmbiguityMap object"
+                )
+            self.ambiguity_map = ambiguity_map
+
+        # This is applicable even when diagonal entries in transition rate matrix are
+        # nonzero, since it is only a mask on allowable sites based on each base.
+        self.mask_vectors = {
+            code: np.array(
+                [
+                    0 if base in self.ambiguity_map[code] else float("inf")
+                    for base in self.bases
+                ]
+            )
+            for code in self.ambiguity_map
+        }
+
+    def get_adjacency_array(self, seq_len):
+        return np.array([self.transition_weights] * seq_len)
+
+    def get_ambiguity_from_tuple(self, tup):
+        """Retrieve an ambiguity code encoded by tup, which encodes a set of
+        bases with a tuple of 0's and 1's.
+
+        For example, with ``bases='AGCT'``, ``(0, 1, 1, 1)`` would
+        return `A`.
+        """
+        return self.ambiguity_map.reversed[
+            frozenset(self.bases[i] for i, flag in enumerate(tup) if flag == 0)
+        ]
+
+    def character_distance(self, parent_char, child_char, site=None):
+        return self.transition_weights[self.base_indices[parent_char]][
+            self.base_indices[child_char]
+        ]
+
+    def weighted_hamming_distance(self, parent_seq, child_seq):
+        if len(parent_seq) != len(child_seq):
+            raise ValueError("sequence lengths do not match!")
+        return sum(
+            self.character_distance(pchar, cchar, site=(idx + 1))
+            for idx, (pchar, cchar) in enumerate(zip(parent_seq, child_seq))
+        )
+
+    def weighted_cg_hamming_distance(self, parent_cg, child_cg):
+        if parent_cg.reference != child_cg.reference:
+            raise ValueError("Reference sequences do not match!")
+        s1 = set(parent_cg.mutations.keys())
+        s2 = set(child_cg.mutations.keys())
+        return sum(
+            self.character_distance(
+                parent_cg.get_site(site), child_cg.get_site(site), site=site
+            )
+            for site in s1 | s2
+        )
+
+    def min_character_distance(self, parent_char, child_char, site=None):
+        """Allowing child_char to be ambiguous, returns the minimum possible
+        transition weight between parent_char and child_char."""
+        child_set = self.ambiguity_map[child_char]
+        p_idx = self.base_indices[parent_char]
+        return min(
+            self.transition_weights[p_idx][self.base_indices[cbase]]
+            for cbase in child_set
+        )
+
+    def min_weighted_hamming_distance(self, parent_seq, child_seq):
+        """Assuming the child_seq may contain ambiguous characters, returns the
+        minimum possible transition weight between parent_seq and child_seq."""
+        if len(parent_seq) != len(child_seq):
+            raise ValueError("sequence lengths do not match!")
+        return sum(
+            self.min_character_distance(pchar, cchar, site=(idx + 1))
+            for idx, (pchar, cchar) in enumerate(zip(parent_seq, child_seq))
+        )
+
+    def min_weighted_cg_hamming_distance(self, parent_cg, child_cg):
+        if parent_cg.reference != child_cg.reference:
+            raise ValueError("Reference sequences do not match!")
+        s1 = set(parent_cg.mutations.keys())
+        s2 = set(child_cg.mutations.keys())
+        return sum(
+            self.min_character_distance(
+                parent_cg.get_site(site), child_cg.get_site(site), site=site
+            )
+            for site in s1 | s2
+        )
+
+    def weighted_hamming_edge_weight(self, field_name):
+        """Returns a function for computing weighted hamming distance between
+        two nodes' sequences.
+
+        Args:
+            field_name: The name of the node label field which contains sequences.
+
+        Returns:
+            A function accepting two :class:`HistoryDagNode` objects ``n1`` and ``n2`` and returning
+            a float: the transition cost from ``n1.label.<field_name>`` to ``n2.label.<field_name>``, or 0 if
+            n1 is the UA node.
+        """
+
+        @utils.access_nodefield_default(field_name, 0)
+        def edge_weight(parent, child):
+            return self.weighted_hamming_distance(parent, child)
+
+        return edge_weight
+
+    def weighted_cg_hamming_edge_weight(self, field_name):
+        """Returns a function for computing weighted hamming distance between
+        two nodes' compact genomes.
+
+        Args:
+            field_name: The name of the node label field which contains compact genomes.
+
+        Returns:
+            A function accepting two :class:`HistoryDagNode` objects ``n1`` and ``n2`` and returning
+            a float: the transition cost from ``n1.label.<field_name>`` to ``n2.label.<field_name>``, or 0 if
+            n1 is the UA node.
+        """
+
+        @utils.access_nodefield_default(field_name, 0)
+        def edge_weight(parent, child):
+            return self.weighted_cg_hamming_distance(parent, child)
+
+        return edge_weight
+
+    def min_weighted_hamming_edge_weight(self, field_name):
+        """Returns a function for computing weighted hamming distance between
+        two nodes' sequences.
+
+        If the child node is a leaf node, and its sequence contains ambiguities, the minimum possible
+        transition cost from parent to child will be returned.
+
+        Args:
+            field_name: The name of the node label field which contains sequences.
+
+        Returns:
+            A function accepting two :class:`HistoryDagNode` objects ``n1`` and ``n2`` and returning
+            a float: the transition cost from ``n1.label.<field_name>`` to ``n2.label.<field_name>``, or 0 if
+            n1 is the UA node.
+        """
+
+        def edge_weight(parent, child):
+            if parent.is_ua_node():
+                return 0
+            elif child.is_leaf():
+                return self.min_weighted_hamming_distance(
+                    getattr(parent.label, field_name), getattr(child.label, field_name)
+                )
+            else:
+                return self.weighted_hamming_distance(
+                    getattr(parent.label, field_name), getattr(child.label, field_name)
+                )
+
+        return edge_weight
+
+    def min_weighted_cg_hamming_edge_weight(self, field_name):
+        """Returns a function for computing weighted hamming distance between
+        two nodes' compact genomes.
+
+        If the child node is a leaf node, and its compact genome contains ambiguities, the minimum possible
+        transition cost from parent to child will be returned by this function.
+
+        Args:
+            field_name: The name of the node label field which contains compact genomes.
+
+        Returns:
+            A function accepting two :class:`HistoryDagNode` objects ``n1`` and ``n2`` and returning
+            a float: the transition cost from ``n1.label.<field_name>`` to ``n2.label.<field_name>``, or 0 if
+            n1 is the UA node.
+        """
+
+        def edge_weight(parent, child):
+            if parent.is_ua_node():
+                return 0
+            elif child.is_leaf():
+                return self.min_weighted_cg_hamming_distance(
+                    getattr(parent.label, field_name), getattr(child.label, field_name)
+                )
+            else:
+                return self.weighted_cg_hamming_distance(
+                    getattr(parent.label, field_name), getattr(child.label, field_name)
+                )
+
+        return edge_weight
+
+    def get_weighted_cg_parsimony_countfuncs(self, field_name, leaf_ambiguities=False, name="WeightedParsimony"):
+        if leaf_ambiguities:
+            edge_weight = self.min_weighted_cg_hamming_edge_weight(field_name)
+        else:
+            edge_weight = self.weighted_cg_hamming_edge_weight(field_name)
+        return utils.AddFuncDict(
+            {
+                "start_func": lambda n: 0,
+                "edge_weight_func": edge_weight,
+                "accum_func": sum,
+            },
+            name=name,
+        )
+
+    def get_weighted_parsimony_countfuncs(self, field_name, leaf_ambiguities=False, name="WeightedParsimony"):
+        if leaf_ambiguities:
+            edge_weight = self.min_weighted_hamming_edge_weight(field_name)
+        else:
+            edge_weight = self.weighted_hamming_edge_weight(field_name)
+        return utils.AddFuncDict(
+            {
+                "start_func": lambda n: 0,
+                "edge_weight_func": edge_weight,
+                "accum_func": sum,
+            },
+            name=name,
+        )
+
+
+class UnitTransitionAlphabet(TransitionAlphabet):
+    """A subclass of :class:`TransitionAlphabet` to be used when all
+    transitions have unit cost."""
+
+    def __init__(self, bases="AGCT", ambiguity_map=None):
+        super().__init__(bases=bases, ambiguity_map=None)
+
+    def character_distance(self, parent_char, child_char, site=None):
+        return int(parent_char != child_char)
+
+    def min_character_distance(self, parent_char, child_char, site=None):
+        return int(parent_char not in self.ambiguity_map[child_char])
+
+    def get_weighted_cg_parsimony_countfuncs(self, field_name, leaf_ambiguities=False, name="HammingParsimony"):
+        return super().get_weighted_cg_parsimony_countfuncs(field_name, leaf_ambiguities=leaf_ambiguities, name=name)
+
+    def get_weighted_parsimony_countfuncs(self, field_name, leaf_ambiguities=False, name="HammingParsimony"):
+        return super().get_weighted_parsimony_countfuncs(field_name, leaf_ambiguities=leaf_ambiguities, name=name)
+
+
+class VariableTransitionAlphabet(TransitionAlphabet):
+    """A subclass of :class:`TransitionAlphabet` to be used when transition
+    costs depend on site."""
+
+    def __init__(self, bases="AGCT", transition_matrix=None, ambiguity_map=None):
+        assert transition_matrix.shape[1:] == (len(bases), len(bases))
+        super().__init__(bases=bases, ambiguity_map=None)
+        self.transition_weights = None
+        self.sitewise_transition_matrix = transition_matrix
+        self._seq_len
+
+    def character_distance(self, parent_char, child_char, site):
+        return self.sitewise_transition_matrix[site - 1][parent_char][child_char]
+
+    def min_character_distance(self, parent_char, child_char, site):
+        """Allowing child_char to be ambiguous, returns the minimum possible
+        transition weight between parent_char and child_char."""
+        child_set = self.ambiguity_map[child_char]
+        p_idx = self.base_indices[parent_char]
+        return min(
+            self.transition_weights[site - 1][p_idx][self.base_indices[cbase]]
+            for cbase in child_set
+        )
+
+    def get_adjacency_array(self, seq_len):
+        if seq_len != self._seq_len:
+            raise ValueError(
+                f"VariableTransitionAlphabet instance supports sequence length of {self._seq_len}"
+            )
+        return self.sitewise_transition_matrix
+
+
+default_aa_transitions = UnitTransitionAlphabet(bases="AGCT")
+default_aa_gaps_transitions = UnitTransitionAlphabet(bases="AGCT-")
+
+hamming_edge_weight = default_aa_transitions.weighted_hamming_edge_weight("sequence")
+hamming_edge_weight_ambiguous_leaves = (
+    default_aa_transitions.min_weighted_hamming_edge_weight("sequence")
+)
+
+hamming_cg_edge_weight = default_aa_transitions.weighted_cg_hamming_edge_weight(
+    "compact_genome"
+)
+hamming_cg_edge_weight_ambiguous_leaves = (
+    default_aa_transitions.min_weighted_cg_hamming_edge_weight("compact_genome")
+)

--- a/historydag/parsimony_utils.py
+++ b/historydag/parsimony_utils.py
@@ -32,6 +32,11 @@ class AmbiguityMap:
         self.reversed = ReversedAmbiguityMap(
             {bases: char for char, bases in self.ambiguous_values.items()}
         )
+        self.uninformative_chars = frozenset(
+            char
+            for char, base_set in self.ambiguous_values.items()
+            if base_set == self.bases
+        )
 
     def __getitem__(self, key):
         try:
@@ -279,7 +284,9 @@ class TransitionAlphabet:
 
         return edge_weight
 
-    def get_weighted_cg_parsimony_countfuncs(self, field_name, leaf_ambiguities=False, name="WeightedParsimony"):
+    def get_weighted_cg_parsimony_countfuncs(
+        self, field_name, leaf_ambiguities=False, name="WeightedParsimony"
+    ):
         if leaf_ambiguities:
             edge_weight = self.min_weighted_cg_hamming_edge_weight(field_name)
         else:
@@ -293,7 +300,9 @@ class TransitionAlphabet:
             name=name,
         )
 
-    def get_weighted_parsimony_countfuncs(self, field_name, leaf_ambiguities=False, name="WeightedParsimony"):
+    def get_weighted_parsimony_countfuncs(
+        self, field_name, leaf_ambiguities=False, name="WeightedParsimony"
+    ):
         if leaf_ambiguities:
             edge_weight = self.min_weighted_hamming_edge_weight(field_name)
         else:
@@ -321,11 +330,19 @@ class UnitTransitionAlphabet(TransitionAlphabet):
     def min_character_distance(self, parent_char, child_char, site=None):
         return int(parent_char not in self.ambiguity_map[child_char])
 
-    def get_weighted_cg_parsimony_countfuncs(self, field_name, leaf_ambiguities=False, name="HammingParsimony"):
-        return super().get_weighted_cg_parsimony_countfuncs(field_name, leaf_ambiguities=leaf_ambiguities, name=name)
+    def get_weighted_cg_parsimony_countfuncs(
+        self, field_name, leaf_ambiguities=False, name="HammingParsimony"
+    ):
+        return super().get_weighted_cg_parsimony_countfuncs(
+            field_name, leaf_ambiguities=leaf_ambiguities, name=name
+        )
 
-    def get_weighted_parsimony_countfuncs(self, field_name, leaf_ambiguities=False, name="HammingParsimony"):
-        return super().get_weighted_parsimony_countfuncs(field_name, leaf_ambiguities=leaf_ambiguities, name=name)
+    def get_weighted_parsimony_countfuncs(
+        self, field_name, leaf_ambiguities=False, name="HammingParsimony"
+    ):
+        return super().get_weighted_parsimony_countfuncs(
+            field_name, leaf_ambiguities=leaf_ambiguities, name=name
+        )
 
 
 class VariableTransitionAlphabet(TransitionAlphabet):
@@ -374,3 +391,22 @@ hamming_cg_edge_weight = default_aa_transitions.weighted_cg_hamming_edge_weight(
 hamming_cg_edge_weight_ambiguous_leaves = (
     default_aa_transitions.min_weighted_cg_hamming_edge_weight("compact_genome")
 )
+
+compact_genome_hamming_distance_countfuncs = (
+    default_aa_transitions.get_weighted_cg_parsimony_countfuncs(
+        "compact_genome", leaf_ambiguities=False
+    )
+)
+"""Provides functions to count hamming distance parsimony when sequences are
+stored as CompactGenomes.
+For use with :meth:`historydag.CGHistoryDag.weight_count`."""
+
+
+leaf_ambiguous_compact_genome_hamming_distance_countfuncs = (
+    default_aa_transitions.get_weighted_cg_parsimony_countfuncs(
+        "compact_genome", leaf_ambiguities=True
+    )
+)
+"""Provides functions to count hamming distance parsimony when leaf compact genomes
+may be ambiguous.
+For use with :meth:`historydag.AmbiguousLeafCGHistoryDag.weight_count`."""

--- a/historydag/parsimony_utils.py
+++ b/historydag/parsimony_utils.py
@@ -176,13 +176,14 @@ _ambiguous_dna_values = Bio.Data.IUPACData.ambiguous_dna_values.copy()
 _ambiguous_dna_values.update({"?": "GATC", "-": "GATC"})
 
 standard_nt_ambiguity_map = AmbiguityMap(_ambiguous_dna_values, "AGCT")
-"""The standard IUPAC nucleotide ambiguity map, in which 'N', '?', and '-' are all considered fully ambiguous."""
+"""The standard IUPAC nucleotide ambiguity map, in which 'N', '?', and '-' are
+all considered fully ambiguous."""
 
 standard_nt_ambiguity_map_gap_as_char = AmbiguityMap(
     _ambiguous_dna_values_gap_as_char, "AGCT-"
 )
-"""The standard IUPAC nucleotide ambiguity map, in which '-' is treated as a fifth base, '?' is fully ambiguous,
-and the ambiguity 'N' excludes '-'."""
+"""The standard IUPAC nucleotide ambiguity map, in which '-' is treated as a
+fifth base, '?' is fully ambiguous, and the ambiguity 'N' excludes '-'."""
 
 
 class TransitionModel:
@@ -684,38 +685,46 @@ class SitewiseTransitionModel(TransitionModel):
 
 
 default_nt_transitions = UnitTransitionModel(bases="AGCT")
-"""A transition model for nucleotides using unit transition weights, and the standard IUPAC
-ambiguity codes, with base order ``AGCT`` and ``N``, ``?`` and ``-`` treated as fully ambiguous
-characters."""
+"""A transition model for nucleotides using unit transition weights, and the
+standard IUPAC ambiguity codes, with base order ``AGCT`` and ``N``, ``?`` and
+``-`` treated as fully ambiguous characters."""
 
 default_nt_gaps_transitions = UnitTransitionModel(bases="AGCT-")
-"""A transition model for nucleotides using unit transition weights, and the standard IUPAC
-nucleotide ambiguity map, with '-' is treated as a fifth base, '?' fully ambiguous,
-and the ambiguity 'N' excluding only '-'."""
+"""A transition model for nucleotides using unit transition weights, and the
+standard IUPAC nucleotide ambiguity map, with '-' is treated as a fifth base,
+'?' fully ambiguous, and the ambiguity 'N' excluding only '-'."""
 
 hamming_edge_weight = default_nt_transitions.weighted_hamming_edge_weight("sequence")
-"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes, and returning
-the hamming distance between the sequences stored in the ``sequence`` attributes of their labels."""
+"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes,
+and returning the hamming distance between the sequences stored in the
+``sequence`` attributes of their labels."""
 hamming_edge_weight_ambiguous_leaves = (
     default_nt_transitions.min_weighted_hamming_edge_weight("sequence")
 )
-"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes, and returning
-the hamming distance between the sequences stored in the ``sequence`` attributes of their labels.
-This edge weight function allows leaf nodes to have ambiguous sequences."""
+"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes,
+and returning the hamming distance between the sequences stored in the
+``sequence`` attributes of their labels.
+
+This edge weight function allows leaf nodes to have ambiguous sequences.
+"""
 
 hamming_cg_edge_weight = default_nt_transitions.weighted_cg_hamming_edge_weight(
     "compact_genome"
 )
-"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes, and returning
-the hamming distance between the compact genomes stored in the ``compact_genome`` attributes of their labels.
-"""
+"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes,
+and returning the hamming distance between the compact genomes stored in the
+``compact_genome`` attributes of their labels."""
 
 hamming_cg_edge_weight_ambiguous_leaves = (
     default_nt_transitions.min_weighted_cg_hamming_edge_weight("compact_genome")
 )
-"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes, and returning
-the hamming distance between the compact genomes stored in the ``compact_genome`` attributes of their labels.
-This edge weight function allows leaf nodes to have ambiguous compact genomes."""
+"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes,
+and returning the hamming distance between the compact genomes stored in the
+``compact_genome`` attributes of their labels.
+
+This edge weight function allows leaf nodes to have ambiguous compact
+genomes.
+"""
 
 hamming_distance_countfuncs = AddFuncDict(
     {
@@ -727,7 +736,9 @@ hamming_distance_countfuncs = AddFuncDict(
 )
 """Provides functions to count hamming distance parsimony when leaf sequences
 may be ambiguous.
-For use with :meth:`historydag.AmbiguousLeafSequenceHistoryDag.weight_count`."""
+
+For use with :meth:`historydag.AmbiguousLeafSequenceHistoryDag.weight_count`.
+"""
 
 leaf_ambiguous_hamming_distance_countfuncs = AddFuncDict(
     {
@@ -739,7 +750,9 @@ leaf_ambiguous_hamming_distance_countfuncs = AddFuncDict(
 )
 """Provides functions to count hamming distance parsimony when leaf sequences
 may be ambiguous.
-For use with :meth:`historydag.AmbiguousLeafSequenceHistoryDag.weight_count`."""
+
+For use with :meth:`historydag.AmbiguousLeafSequenceHistoryDag.weight_count`.
+"""
 
 
 compact_genome_hamming_distance_countfuncs = (
@@ -749,7 +762,9 @@ compact_genome_hamming_distance_countfuncs = (
 )
 """Provides functions to count hamming distance parsimony when sequences are
 stored as CompactGenomes.
-For use with :meth:`historydag.CGHistoryDag.weight_count`."""
+
+For use with :meth:`historydag.CGHistoryDag.weight_count`.
+"""
 
 
 leaf_ambiguous_compact_genome_hamming_distance_countfuncs = (
@@ -757,6 +772,8 @@ leaf_ambiguous_compact_genome_hamming_distance_countfuncs = (
         "compact_genome", leaf_ambiguities=True
     )
 )
-"""Provides functions to count hamming distance parsimony when leaf compact genomes
-may be ambiguous.
-For use with :meth:`historydag.AmbiguousLeafCGHistoryDag.weight_count`."""
+"""Provides functions to count hamming distance parsimony when leaf compact
+genomes may be ambiguous.
+
+For use with :meth:`historydag.AmbiguousLeafCGHistoryDag.weight_count`.
+"""

--- a/historydag/sankoff_cli.py
+++ b/historydag/sankoff_cli.py
@@ -1,4 +1,5 @@
-import parsimony as pars
+import historydag.parsimony as pars
+import historydag.parsimony_utils as pars_utils
 import click
 import pickle
 
@@ -95,12 +96,16 @@ def _cli_build_trees(
         reference_id=root_id,
         ignore_internal_sequences=(not include_internal_sequences),
     )
+    if gap_as_char:
+        transition_model = pars_utils.default_nt_gaps_transitions
+    else:
+        transition_model = pars_utils.default_nt_gaps_transitions
     trees = (
         pars.disambiguate(
             tree,
-            gap_as_char=gap_as_char,
             min_ambiguities=preserve_ambiguities,
             remove_cvs=clean_trees,
+            transition_model=transition_model,
         )
         for tree in trees
     )
@@ -185,6 +190,10 @@ def _cli_parsimony_score_from_files(
         print(treepath)
         print(score)
 
+    if gap_as_char:
+        transition_model = pars_utils.default_nt_gaps_transitions
+    else:
+        transition_model = pars_utils.default_nt_gaps_transitions
     if save_to_dag is not None:
         trees = pars.build_trees_from_files(
             treefiles,
@@ -194,7 +203,9 @@ def _cli_parsimony_score_from_files(
         )
         trees = (
             pars.disambiguate(
-                tree, gap_as_char=gap_as_char, min_ambiguities=preserve_ambiguities
+                tree,
+                transition_model=transition_model,
+                min_ambiguities=preserve_ambiguities,
             )
             for tree in trees
         )

--- a/historydag/sequence_dag.py
+++ b/historydag/sequence_dag.py
@@ -1,6 +1,6 @@
 from historydag import HistoryDag
 import historydag.parsimony_utils as parsimony_utils
-from historydag.utils import Weight
+from historydag.utils import UALabel
 
 
 class SequenceHistoryDag(HistoryDag):
@@ -20,6 +20,21 @@ class SequenceHistoryDag(HistoryDag):
         "sequence": [
             (("compact_genome",), lambda node: node.label.compact_genome.to_sequence())
         ]
+    }
+
+    _default_args = dict(parsimony_utils.hamming_distance_countfuncs) | {
+        "start_func": (lambda n: 0),
+        "edge_func": lambda l1, l2: (
+            0
+            if isinstance(l1, UALabel)
+            else parsimony_utils.default_nt_transitions.weighted_hamming_distance(
+                l1.sequence, l2.sequence
+            )
+        ),
+        "expand_func": parsimony_utils.default_nt_transitions.ambiguity_map.get_sequence_resolution_func(
+            "sequence"
+        ),
+        "optimal_func": min,
     }
 
     def hamming_parsimony_count(self):
@@ -51,73 +66,26 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     HistoryDag object to be converted.
     """
 
-    # #### Overridden Methods ####
-
-    def weight_count(
-        self,
-        *args,
-        edge_weight_func=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.weight_count`"""
-        return super().weight_count(*args, edge_weight_func=edge_weight_func, **kwargs)
-
-    def optimal_weight_annotate(
-        self,
-        *args,
-        edge_weight_func=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ) -> Weight:
-        """See :meth:`historydag.HistoryDag.optimal_weight_annotate`"""
-        return super().optimal_weight_annotate(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def trim_optimal_weight(
-        self,
-        *args,
-        edge_weight_func=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ) -> Weight:
-        """See :meth:`historydag.HistoryDag.trim_optimal_weight`"""
-        return super().trim_optimal_weight(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def trim_within_range(
-        self,
-        *args,
-        edge_weight_func=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.trim_within_range`"""
-        return super().trim_within_range(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def trim_below_weight(
-        self,
-        *args,
-        edge_weight_func=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.trim_below_weight`"""
-        return super().trim_below_weight(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def insert_node(
-        self,
-        *args,
-        dist=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.insert_node`"""
-        return super().insert_node(*args, dist=dist, **kwargs)
+    _default_args = dict(parsimony_utils.leaf_ambiguous_hamming_distance_countfuncs) | {
+        "start_func": (lambda n: 0),
+        "edge_func": lambda l1, l2: (
+            0
+            if isinstance(l1, UALabel)
+            else parsimony_utils.default_nt_transitions.weighted_hamming_distance(
+                l1.sequence, l2.sequence
+            )
+        ),
+        "expand_func": parsimony_utils.default_nt_transitions.ambiguity_map.get_sequence_resolution_func(
+            "sequence"
+        ),
+        "optimal_func": min,
+    }
 
     def hamming_parsimony_count(self):
-        """See :meth:`historydag.sequence_dag.SequenceHistoryDag.hamming_parsim
-        ony_count`"""
+        """Count the hamming parsimony scores of all trees in the history DAG.
+
+        Returns a Counter with integer keys.
+        """
         return self.weight_count(
             **parsimony_utils.leaf_ambiguous_hamming_distance_countfuncs
         )

--- a/historydag/sequence_dag.py
+++ b/historydag/sequence_dag.py
@@ -1,54 +1,6 @@
 from historydag import HistoryDag
-from functools import lru_cache
-import historydag.utils
+import historydag.parsimony_utils as parsimony_utils
 from historydag.utils import Weight
-
-# from historydag.parsimony import ambiguous_dna_values
-
-
-def nonleaf_sequence_resolutions(node):
-    if node.is_leaf():
-        yield node.label
-    else:
-        yield from historydag.utils.sequence_resolutions(node.label)
-
-
-@lru_cache(maxsize=20000)
-def _ambiguous_hamming_distance(node1, node2):
-    return sum(
-        pbase not in historydag.parsimony.ambiguous_dna_values[cbase]
-        for pbase, cbase in zip(node1.label.sequence, node2.label.sequence)
-    )
-
-
-def ambiguous_hamming_distance(node1, node2):
-    """Returns the hamming distance between node1.label.sequence and
-    node2.label.sequence.
-
-    If node2 is a leaf node, then its sequence may be ambiguous, and the
-    minimum possible distance will be returned.
-    """
-    if node1.is_ua_node():
-        return 0
-    if node2.is_leaf():
-        return _ambiguous_hamming_distance(node1, node2)
-    else:
-        return historydag.utils.hamming_distance(
-            node1.label.sequence, node2.label.sequence
-        )
-
-
-leaf_ambiguous_hamming_distance_countfuncs = historydag.utils.AddFuncDict(
-    {
-        "start_func": lambda n: 0,
-        "edge_weight_func": ambiguous_hamming_distance,
-        "accum_func": sum,
-    },
-    name="HammingParsimony",
-)
-"""Provides functions to count hamming distance parsimony when leaf sequences
-may be ambiguous.
-For use with :meth:`historydag.AmbiguousLeafSequenceHistoryDag.weight_count`."""
 
 
 class SequenceHistoryDag(HistoryDag):
@@ -75,12 +27,12 @@ class SequenceHistoryDag(HistoryDag):
 
         Returns a Counter with integer keys.
         """
-        return self.weight_count(**historydag.utils.hamming_distance_countfuncs)
+        return self.weight_count(**parsimony_utils.hamming_distance_countfuncs)
 
     def summary(self):
         HistoryDag.summary(self)
         min_pars, max_pars = self.weight_range_annotate(
-            **historydag.utils.hamming_distance_countfuncs
+            **parsimony_utils.hamming_distance_countfuncs
         )
         print(f"Parsimony score range {min_pars} to {max_pars}")
 
@@ -104,14 +56,17 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     def weight_count(
         self,
         *args,
-        edge_weight_func=ambiguous_hamming_distance,
+        edge_weight_func=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.weight_count`"""
         return super().weight_count(*args, edge_weight_func=edge_weight_func, **kwargs)
 
     def optimal_weight_annotate(
-        self, *args, edge_weight_func=ambiguous_hamming_distance, **kwargs
+        self,
+        *args,
+        edge_weight_func=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
+        **kwargs,
     ) -> Weight:
         """See :meth:`historydag.HistoryDag.optimal_weight_annotate`"""
         return super().optimal_weight_annotate(
@@ -121,7 +76,7 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     def trim_optimal_weight(
         self,
         *args,
-        edge_weight_func=ambiguous_hamming_distance,
+        edge_weight_func=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
         **kwargs,
     ) -> Weight:
         """See :meth:`historydag.HistoryDag.trim_optimal_weight`"""
@@ -132,7 +87,7 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     def trim_within_range(
         self,
         *args,
-        edge_weight_func=ambiguous_hamming_distance,
+        edge_weight_func=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.trim_within_range`"""
@@ -143,7 +98,7 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     def trim_below_weight(
         self,
         *args,
-        edge_weight_func=ambiguous_hamming_distance,
+        edge_weight_func=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.trim_below_weight`"""
@@ -154,7 +109,7 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     def insert_node(
         self,
         *args,
-        dist=ambiguous_hamming_distance,
+        dist=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.insert_node`"""
@@ -163,11 +118,13 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     def hamming_parsimony_count(self):
         """See :meth:`historydag.sequence_dag.SequenceHistoryDag.hamming_parsim
         ony_count`"""
-        return self.weight_count(**leaf_ambiguous_hamming_distance_countfuncs)
+        return self.weight_count(
+            **parsimony_utils.leaf_ambiguous_hamming_distance_countfuncs
+        )
 
     def summary(self):
         HistoryDag.summary(self)
         min_pars, max_pars = self.weight_range_annotate(
-            **leaf_ambiguous_hamming_distance_countfuncs
+            **parsimony_utils.leaf_ambiguous_hamming_distance_countfuncs
         )
         print(f"Parsimony score range {min_pars} to {max_pars}")

--- a/historydag/sequence_dag.py
+++ b/historydag/sequence_dag.py
@@ -68,7 +68,9 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     HistoryDag object to be converted.
     """
 
-    _default_args = frozendict(parsimony_utils.leaf_ambiguous_hamming_distance_countfuncs) | {
+    _default_args = frozendict(
+        parsimony_utils.leaf_ambiguous_hamming_distance_countfuncs
+    ) | {
         "start_func": (lambda n: 0),
         "edge_func": lambda l1, l2: (
             0

--- a/historydag/sequence_dag.py
+++ b/historydag/sequence_dag.py
@@ -3,6 +3,8 @@ from functools import lru_cache
 import historydag.utils
 from historydag.utils import Weight
 
+# from historydag.parsimony import ambiguous_dna_values
+
 
 def nonleaf_sequence_resolutions(node):
     if node.is_leaf():
@@ -14,7 +16,7 @@ def nonleaf_sequence_resolutions(node):
 @lru_cache(maxsize=20000)
 def _ambiguous_hamming_distance(node1, node2):
     return sum(
-        pbase not in historydag.utils.ambiguous_dna_values[cbase]
+        pbase not in historydag.parsimony.ambiguous_dna_values[cbase]
         for pbase, cbase in zip(node1.label.sequence, node2.label.sequence)
     )
 

--- a/historydag/sequence_dag.py
+++ b/historydag/sequence_dag.py
@@ -1,3 +1,5 @@
+from frozendict import frozendict
+
 from historydag import HistoryDag
 import historydag.parsimony_utils as parsimony_utils
 from historydag.utils import UALabel
@@ -22,7 +24,7 @@ class SequenceHistoryDag(HistoryDag):
         ]
     }
 
-    _default_args = dict(parsimony_utils.hamming_distance_countfuncs) | {
+    _default_args = frozendict(parsimony_utils.hamming_distance_countfuncs) | {
         "start_func": (lambda n: 0),
         "edge_func": lambda l1, l2: (
             0
@@ -66,7 +68,7 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     HistoryDag object to be converted.
     """
 
-    _default_args = dict(parsimony_utils.leaf_ambiguous_hamming_distance_countfuncs) | {
+    _default_args = frozendict(parsimony_utils.leaf_ambiguous_hamming_distance_countfuncs) | {
         "start_func": (lambda n: 0),
         "edge_func": lambda l1, l2: (
             0

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -501,7 +501,9 @@ node_countfuncs = AddFuncDict(
     name="NodeCount",
 )
 """Provides functions to count the number of nodes in trees.
-For use with :meth:`historydag.HistoryDag.weight_count`."""
+
+For use with :meth:`historydag.HistoryDag.weight_count`.
+"""
 
 
 def natural_edge_probability(parent, child):

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -22,7 +22,7 @@ def collapse_adjacent_sequences(tree: ete3.TreeNode) -> ete3.TreeNode:
         # This must stay invariably hamming distance, since it's measuring equality of strings
         if (
             not node.is_leaf()
-            and parsimony_utils.default_aa_transitions.weighted_hamming_distance(
+            and parsimony_utils.default_nt_transitions.weighted_hamming_distance(
                 node.up.sequence, node.sequence
             )
             == 0

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -1,6 +1,6 @@
 import ete3
 import historydag.dag as hdag
-from historydag import utils
+from historydag import utils, parsimony_utils
 import pickle
 from test_factory import deterministic_newick
 
@@ -22,7 +22,10 @@ def collapse_adjacent_sequences(tree: ete3.TreeNode) -> ete3.TreeNode:
         # This must stay invariably hamming distance, since it's measuring equality of strings
         if (
             not node.is_leaf()
-            and utils.hamming_distance(node.up.sequence, node.sequence) == 0
+            and parsimony_utils.default_aa_transitions.weighted_hamming_distance(
+                node.up.sequence, node.sequence
+            )
+            == 0
         ):
             to_delete.append(node)
     for node in to_delete:

--- a/tests/test_compact_genome.py
+++ b/tests/test_compact_genome.py
@@ -1,8 +1,9 @@
 import historydag.compact_genome as compact_genome
+from historydag.compact_genome import ambiguous_cg_hamming_distance, CompactGenome
 from frozendict import frozendict
 
 
-def _test_sequence_cg_convert():
+def test_sequence_cg_convert():
     seqs = [
         "AAAA",
         "TAAT",
@@ -11,7 +12,7 @@ def _test_sequence_cg_convert():
     ]
     for refseq in seqs:
         for seq in seqs:
-            cg = compact_genome.sequence_to_cg(seq, refseq)
+            cg = compact_genome.compact_genome_from_sequence(seq, refseq)
             reseq = cg.to_sequence()
             if reseq != seq:
                 print("\nUnmatched reconstructed sequence:")
@@ -22,29 +23,32 @@ def _test_sequence_cg_convert():
                 assert False
 
 
-def _test_cg_diff():
+def test_cg_diff():
+    refseq = "C" * 1000
     cgs = [
-        frozendict({287: ("C", "G")}),
-        frozendict({287: ("C", "G"), 318: ("C", "A"), 495: ("C", "T")}),
-        frozendict({287: ("C", "G"), 80: ("A", "C"), 257: ("C", "G"), 591: ("G", "A")}),
-        frozendict(
+        CompactGenome({287: ("C", "G")}, refseq),
+        CompactGenome({287: ("C", "G"), 318: ("C", "A"), 495: ("C", "T")}, refseq),
+        CompactGenome(
+            {287: ("C", "G"), 80: ("C", "T"), 257: ("C", "G"), 591: ("C", "A")}, refseq
+        ),
+        CompactGenome(
             {
                 287: ("C", "G"),
-                191: ("A", "G"),
+                191: ("C", "G"),
                 492: ("C", "G"),
                 612: ("C", "G"),
-                654: ("A", "G"),
-            }
+                654: ("C", "G"),
+            },
+            refseq,
         ),
-        frozendict({287: ("C", "G"), 318: ("C", "A"), 495: ("C", "T")}),
+        CompactGenome({287: ("C", "G"), 318: ("C", "A"), 495: ("C", "T")}, refseq),
     ]
     for parent_cg in cgs:
         for child_cg in cgs:
             assert (
                 parent_cg.apply_muts(
-                    compact_genome.str_mut_from_tups(
-                        compact_genome.cg_diff(parent_cg, child_cg)
-                    )
+                    str(p) + str(key) + str(c)
+                    for p, c, key in compact_genome.cg_diff(parent_cg, child_cg)
                 )
                 == child_cg
             )
@@ -54,3 +58,19 @@ def _test_cg_diff():
                     parent_cg, child_cg
                 )
             )
+
+
+def test_ambiguous_cg_distance():
+    reference_seq = "AAAAAAAN"
+
+    s1 = compact_genome.CompactGenome({1: ("A", "T"), 2: ("A", "G")}, reference_seq)
+    s2 = compact_genome.CompactGenome({1: ("A", "T"), 2: ("A", "N")}, reference_seq)
+    s3 = compact_genome.CompactGenome({1: ("A", "T")}, reference_seq)
+    s4 = compact_genome.CompactGenome({8: ("N", "C")}, reference_seq)
+
+    assert ambiguous_cg_hamming_distance(s1, s2) == 0
+    assert ambiguous_cg_hamming_distance(s1, s3) == 1
+    assert ambiguous_cg_hamming_distance(s1, s4) == 2
+    assert ambiguous_cg_hamming_distance(s2, s3) == 0
+    assert ambiguous_cg_hamming_distance(s2, s4) == 1
+    assert ambiguous_cg_hamming_distance(s3, s4) == 1

--- a/tests/test_compact_genome.py
+++ b/tests/test_compact_genome.py
@@ -1,6 +1,6 @@
 import historydag.compact_genome as compact_genome
 from historydag.compact_genome import CompactGenome
-from historydag.parsimony_utils import default_aa_transitions
+from historydag.parsimony_utils import default_nt_transitions
 
 
 def test_sequence_cg_convert():
@@ -68,10 +68,10 @@ def test_ambiguous_cg_distance():
     s3 = compact_genome.CompactGenome({1: ("A", "T")}, reference_seq)
     s4 = compact_genome.CompactGenome({8: ("N", "C")}, reference_seq)
 
-    assert default_aa_transitions.min_weighted_cg_hamming_distance(s1, s2) == 0
-    assert default_aa_transitions.min_weighted_cg_hamming_distance(s1, s3) == 1
-    assert default_aa_transitions.min_weighted_cg_hamming_distance(s1, s4) == 3
-    assert default_aa_transitions.min_weighted_cg_hamming_distance(s4, s1) == 2
-    assert default_aa_transitions.min_weighted_cg_hamming_distance(s3, s2) == 0
-    assert default_aa_transitions.min_weighted_cg_hamming_distance(s4, s2) == 1
-    assert default_aa_transitions.min_weighted_cg_hamming_distance(s4, s3) == 1
+    assert default_nt_transitions.min_weighted_cg_hamming_distance(s1, s2) == 0
+    assert default_nt_transitions.min_weighted_cg_hamming_distance(s1, s3) == 1
+    assert default_nt_transitions.min_weighted_cg_hamming_distance(s1, s4) == 3
+    assert default_nt_transitions.min_weighted_cg_hamming_distance(s4, s1) == 2
+    assert default_nt_transitions.min_weighted_cg_hamming_distance(s3, s2) == 0
+    assert default_nt_transitions.min_weighted_cg_hamming_distance(s4, s2) == 1
+    assert default_nt_transitions.min_weighted_cg_hamming_distance(s4, s3) == 1

--- a/tests/test_compact_genome.py
+++ b/tests/test_compact_genome.py
@@ -1,6 +1,6 @@
 import historydag.compact_genome as compact_genome
-from historydag.compact_genome import ambiguous_cg_hamming_distance, CompactGenome
-from frozendict import frozendict
+from historydag.compact_genome import CompactGenome
+from historydag.parsimony_utils import default_aa_transitions
 
 
 def test_sequence_cg_convert():
@@ -68,9 +68,10 @@ def test_ambiguous_cg_distance():
     s3 = compact_genome.CompactGenome({1: ("A", "T")}, reference_seq)
     s4 = compact_genome.CompactGenome({8: ("N", "C")}, reference_seq)
 
-    assert ambiguous_cg_hamming_distance(s1, s2) == 0
-    assert ambiguous_cg_hamming_distance(s1, s3) == 1
-    assert ambiguous_cg_hamming_distance(s1, s4) == 2
-    assert ambiguous_cg_hamming_distance(s2, s3) == 0
-    assert ambiguous_cg_hamming_distance(s2, s4) == 1
-    assert ambiguous_cg_hamming_distance(s3, s4) == 1
+    assert default_aa_transitions.min_weighted_cg_hamming_distance(s1, s2) == 0
+    assert default_aa_transitions.min_weighted_cg_hamming_distance(s1, s3) == 1
+    assert default_aa_transitions.min_weighted_cg_hamming_distance(s1, s4) == 3
+    assert default_aa_transitions.min_weighted_cg_hamming_distance(s4, s1) == 2
+    assert default_aa_transitions.min_weighted_cg_hamming_distance(s3, s2) == 0
+    assert default_aa_transitions.min_weighted_cg_hamming_distance(s4, s2) == 1
+    assert default_aa_transitions.min_weighted_cg_hamming_distance(s4, s3) == 1

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -3,10 +3,11 @@ import random
 import numpy as np
 import historydag as hdag
 import historydag.parsimony as dag_parsimony
+import historydag.parsimony_utils as parsimony_utils
 
 
 def compare_dag_and_tree_parsimonies(
-    dag, transition_model=dag_parsimony.default_aa_transitions
+    dag, transition_model=parsimony_utils.default_aa_transitions
 ):
 
     # extract sample tree
@@ -55,7 +56,7 @@ def compare_dag_and_tree_parsimonies(
 
 
 def check_sankoff_on_dag(
-    dag, expected_score, transition_model=dag_parsimony.default_aa_gaps_transitions
+    dag, expected_score, transition_model=parsimony_utils.default_aa_gaps_transitions
 ):
     # perform upward sweep of sankoff to calculate overall parsimony score and assign cost vectors to internal nodes
     seq_len = len(next(dag.get_leaves()).label.sequence)
@@ -92,10 +93,10 @@ def test_sankoff_on_dag():
     dg.convert_to_collapsed()
 
     tw_options = [
-        (75, dag_parsimony.default_aa_transitions),
+        (75, parsimony_utils.default_aa_transitions),
         (
             93,
-            dag_parsimony.TransitionAlphabet(
+            parsimony_utils.TransitionAlphabet(
                 bases="AGCT-",
                 transition_weights=np.array(
                     [
@@ -110,7 +111,7 @@ def test_sankoff_on_dag():
         ),
         (
             106,
-            dag_parsimony.TransitionAlphabet(
+            parsimony_utils.TransitionAlphabet(
                 bases="AGCT-",
                 transition_weights=np.array(
                     [
@@ -192,7 +193,7 @@ def test_sankoff_with_alternative_sequence_name():
             i = i + 1
 
     dg = dg.add_label_fields(["location"], vals)
-    transition_model = dag_parsimony.TransitionAlphabet(bases="AB")
+    transition_model = parsimony_utils.TransitionAlphabet(bases="AB")
 
     upward_cost = dag_parsimony.sankoff_upward(
         dg,

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -7,7 +7,7 @@ import historydag.parsimony_utils as parsimony_utils
 
 
 def compare_dag_and_tree_parsimonies(
-    dag, transition_model=parsimony_utils.default_aa_transitions
+    dag, transition_model=parsimony_utils.default_nt_transitions
 ):
 
     # extract sample tree
@@ -56,7 +56,7 @@ def compare_dag_and_tree_parsimonies(
 
 
 def check_sankoff_on_dag(
-    dag, expected_score, transition_model=parsimony_utils.default_aa_gaps_transitions
+    dag, expected_score, transition_model=parsimony_utils.default_nt_gaps_transitions
 ):
     # perform upward sweep of sankoff to calculate overall parsimony score and assign cost vectors to internal nodes
     seq_len = len(next(dag.get_leaves()).label.sequence)
@@ -93,10 +93,10 @@ def test_sankoff_on_dag():
     dg.convert_to_collapsed()
 
     tw_options = [
-        (75, parsimony_utils.default_aa_transitions),
+        (75, parsimony_utils.default_nt_transitions),
         (
             93,
-            parsimony_utils.TransitionAlphabet(
+            parsimony_utils.TransitionModel(
                 bases="AGCT-",
                 transition_weights=np.array(
                     [
@@ -111,7 +111,7 @@ def test_sankoff_on_dag():
         ),
         (
             106,
-            parsimony_utils.TransitionAlphabet(
+            parsimony_utils.TransitionModel(
                 bases="AGCT-",
                 transition_weights=np.array(
                     [
@@ -193,7 +193,7 @@ def test_sankoff_with_alternative_sequence_name():
             i = i + 1
 
     dg = dg.add_label_fields(["location"], vals)
-    transition_model = parsimony_utils.TransitionAlphabet(bases="AB")
+    transition_model = parsimony_utils.TransitionModel(bases="AB")
 
     upward_cost = dag_parsimony.sankoff_upward(
         dg,

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -9,7 +9,6 @@ import historydag.parsimony_utils as parsimony_utils
 def compare_dag_and_tree_parsimonies(
     dag, transition_model=parsimony_utils.default_nt_transitions
 ):
-
     # extract sample tree
     s = dag.sample().copy()
     s.recompute_parents()
@@ -126,7 +125,7 @@ def test_sankoff_on_dag():
         ),
     ]
 
-    for (w, tm) in tw_options:
+    for w, tm in tw_options:
         check_sankoff_on_dag(dg.copy(), w, transition_model=tm)
         compare_dag_and_tree_parsimonies(dg.copy(), transition_model=tm)
 

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -2,6 +2,7 @@ from historydag import utils
 from historydag import dag as hdag
 import ete3
 from Bio.Data.IUPACData import ambiguous_dna_values
+from historydag import parsimony_utils
 
 bases = "AGCT-"
 ambiguous_dna_values.update({"?": "GATC-", "-": "-"})
@@ -112,7 +113,10 @@ def disambiguate_sitewise(tree: ete3.TreeNode) -> ete3.TreeNode:
     return disambiguated
 
 
-def disambiguate(tree: ete3.Tree, dist_func=utils.hamming_distance):
+def disambiguate(
+    tree: ete3.Tree,
+    dist_func=parsimony_utils.default_aa_transitions.weighted_hamming_distance,
+):
     """Resolve ambiguous bases using a two-pass Sankoff Algorithm on entire tree and entire sequence at each node.
     This does not disambiguate sitewise, so trees with many ambiguities may make this run very slowly.
     Returns a list of all possible disambiguations, minimizing the passed distance function dist_func.
@@ -136,7 +140,9 @@ def disambiguate(tree: ete3.Tree, dist_func=utils.hamming_distance):
 
     def incremental_disambiguate(ambig_tree):
         for node in ambig_tree.traverse(strategy="preorder"):
-            if not utils.is_ambiguous(node.sequence):
+            if not parsimony_utils.default_aa_transitions.ambiguity_map.is_ambiguous(
+                node.sequence
+            ):
                 continue
             else:
                 if not node.is_root():

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -115,7 +115,7 @@ def disambiguate_sitewise(tree: ete3.TreeNode) -> ete3.TreeNode:
 
 def disambiguate(
     tree: ete3.Tree,
-    dist_func=parsimony_utils.default_aa_transitions.weighted_hamming_distance,
+    dist_func=parsimony_utils.default_nt_transitions.weighted_hamming_distance,
 ):
     """Resolve ambiguous bases using a two-pass Sankoff Algorithm on entire tree and entire sequence at each node.
     This does not disambiguate sitewise, so trees with many ambiguities may make this run very slowly.
@@ -140,7 +140,7 @@ def disambiguate(
 
     def incremental_disambiguate(ambig_tree):
         for node in ambig_tree.traverse(strategy="preorder"):
-            if not parsimony_utils.default_aa_transitions.ambiguity_map.is_ambiguous(
+            if not parsimony_utils.default_nt_transitions.ambiguity_map.is_ambiguous(
                 node.sequence
             ):
                 continue

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -196,7 +196,6 @@ def treeprint(tree: ete3.TreeNode):
 
 
 def test_expand_ambiguities():
-
     for dag in dags:
         cdag = dag.copy()
         print(cdag.count_histories())

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -166,7 +166,7 @@ def test_parsimony_counts():
     def parsimony(tree):
         etetree = tree.to_ete(features=["sequence"])
         return sum(
-            parsimony_utils.default_aa_transitions.weighted_hamming_distance(
+            parsimony_utils.default_nt_transitions.weighted_hamming_distance(
                 n.up.sequence, n.sequence
             )
             for n in etetree.iter_descendants()
@@ -269,7 +269,7 @@ def test_count_histories_expanded():
         ndag.explode_nodes()
         assert (
             dag.count_histories(
-                expand_func=parsimony_utils.default_aa_transitions.ambiguity_map.get_sequence_resolution_func(
+                expand_func=parsimony_utils.default_nt_transitions.ambiguity_map.get_sequence_resolution_func(
                     "sequence"
                 )
             )

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -6,6 +6,7 @@ import historydag.utils as dagutils
 from collections import Counter, namedtuple
 import pytest
 import random
+from historydag import parsimony_utils
 
 
 def normalize_counts(counter):
@@ -152,7 +153,7 @@ def test_parsimony():
     def parsimony(tree):
         tree.recompute_parents()
         return sum(
-            dagutils.wrapped_hamming_distance(list(node.parents)[0], node)
+            parsimony_utils.hamming_edge_weight(list(node.parents)[0], node)
             for node in tree.postorder()
             if node.parents
         )
@@ -165,7 +166,9 @@ def test_parsimony_counts():
     def parsimony(tree):
         etetree = tree.to_ete(features=["sequence"])
         return sum(
-            dagutils.hamming_distance(n.up.sequence, n.sequence)
+            parsimony_utils.default_aa_transitions.weighted_hamming_distance(
+                n.up.sequence, n.sequence
+            )
             for n in etetree.iter_descendants()
         )
 
@@ -243,7 +246,7 @@ def test_min_weight():
     def parsimony(tree):
         tree.recompute_parents()
         return sum(
-            dagutils.wrapped_hamming_distance(list(node.parents)[0], node)
+            parsimony_utils.hamming_edge_weight(list(node.parents)[0], node)
             for node in tree.postorder()
             if node.parents
         )
@@ -265,7 +268,11 @@ def test_count_histories_expanded():
         ndag = dag.copy()
         ndag.explode_nodes()
         assert (
-            dag.count_histories(expand_func=dagutils.sequence_resolutions)
+            dag.count_histories(
+                expand_func=parsimony_utils.default_aa_transitions.ambiguity_map.get_sequence_resolution_func(
+                    "sequence"
+                )
+            )
             == ndag.count_histories()
         )
 
@@ -373,7 +380,7 @@ def test_trim_fixedleaves():
 
 def test_trim():
     kwarglist = [
-        (dagutils.hamming_distance_countfuncs, min),
+        (parsimony_utils.hamming_distance_countfuncs, min),
         (dagutils.node_countfuncs, min),
     ]
     for dag in dags + cdags:
@@ -733,7 +740,7 @@ def test_trim_weight():
 
 def test_trim_filter():
     dag = dags[-1].copy()
-    pars_d = hdag.utils.hamming_distance_countfuncs
+    pars_d = parsimony_utils.hamming_distance_countfuncs
     node_d = hdag.utils.node_countfuncs
 
     # >>
@@ -778,7 +785,7 @@ def test_trim_filter():
 
 
 def test_weight_range_annotate():
-    kwargs = hdag.utils.hamming_distance_countfuncs
+    kwargs = parsimony_utils.hamming_distance_countfuncs
     for dag in dags:
         assert dag.weight_range_annotate(**kwargs) == (
             dag.optimal_weight_annotate(**kwargs, optimal_func=min),

--- a/tests/test_historydag.py
+++ b/tests/test_historydag.py
@@ -307,7 +307,6 @@ def test_to_graphviz():
 
 
 def test_reproducible():
-
     dag = history_dag_from_newicks(
         [newickstring1, newickstring2, newickstring3], ["sequence"]
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,15 @@
 from historydag.utils import (
-    hamming_distance,
     hist,
     AddFuncDict,
-    hamming_distance_countfuncs,
     prod,
 )
 from collections import Counter
+from historydag.parsimony_utils import (
+    hamming_distance_countfuncs,
+    default_aa_transitions,
+)
+
+hamming_distance = default_aa_transitions.weighted_hamming_distance
 
 
 def test_hamming_distance():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,10 +6,10 @@ from historydag.utils import (
 from collections import Counter
 from historydag.parsimony_utils import (
     hamming_distance_countfuncs,
-    default_aa_transitions,
+    default_nt_transitions,
 )
 
-hamming_distance = default_aa_transitions.weighted_hamming_distance
+hamming_distance = default_nt_transitions.weighted_hamming_distance
 
 
 def test_hamming_distance():


### PR DESCRIPTION
This PR proposes a convenient interface for defining default arguments for weight counting-related methods of HistoryDag subclasses.

* Default arguments are read from a subclass's `_default_args` dictionary, and applied by the method decorator `dag.get_default_args`
* Using `get_default_args` on a method causes positional arguments to be positional-only, and keyword arguments to be keyword-only
* `get_default_args` takes a list of arguments to be potentially overridden, as well as a count of (non-self) positional arguments.
* the convenience function `dag.convert` is added as a wrapper for `HistoryDag.from_history_dag`.