### PR TITLE
Add beast tree loader

### DIFF
--- a/historydag/__init__.py
+++ b/historydag/__init__.py
@@ -21,4 +21,10 @@ from . import (  # noqa
     compact_genome,
 )
 
+try:
+    # requires dendropy
+    from . import beast_loader  # noqa
+except ModuleNotFoundError:
+    pass
+
 __version__ = _version.get_versions()["version"]

--- a/historydag/beast_loader.py
+++ b/historydag/beast_loader.py
@@ -1,0 +1,368 @@
+import historydag as hdag
+from warnings import warn
+import dendropy
+import xml.etree.ElementTree as ET
+import historydag.parsimony_utils as parsimony_utils
+
+
+def dag_from_beast_trees(
+    beast_xml_file,
+    beast_output_file,
+    reference_sequence=None,
+    topologies_only=False,
+    mask_ambiguous_sites=True,
+    remove_ambiguous_sites=False,
+    use_original_leaves=True,
+    include_sequence_names_in_labels=False,
+    transition_model=parsimony_utils.default_nt_transitions,
+):
+    """A convenience method to build a dag out of the output from
+    :meth:`load_beast_trees`.
+
+    Args:
+        beast_xml_file: ''
+        beast_output_file: ''
+        reference_sequence: Provide a reference sequence, if desired. Otherwise, an arbitrary
+            observed sequence will be used.
+        topologies_only: If True, no internal sequences will be recovered from the beast output.
+            In this case, leaf compact genomes will contain observed (possibly ambiguous)
+            sequences regardless of the value of `use_original_leaves`.
+        mask_ambiguous_sites: ''
+        remove_ambiguous_sites: ''
+        use_original_leaves: Use the original observed sequences for leaf node labels, instead
+            of thos derived from simulated mutations.
+        include_sequence_names_in_labels: If True, augment leaf node labels with a ``name`` attribute
+            containing the name of the corresponding sequence. Useful for distinguishing leaves when
+            observed sequences are not unique.
+
+    """
+    dp_trees = load_beast_trees(
+        beast_xml_file,
+        beast_output_file,
+        topologies_only=topologies_only,
+        reference_sequence=reference_sequence,
+        mask_ambiguous_sites=mask_ambiguous_sites,
+        remove_ambiguous_sites=remove_ambiguous_sites,
+        transition_model=transition_model,
+    )[0]
+
+    if topologies_only:
+
+        def cg_func(node):
+            if node.is_leaf():
+                return node.observed_cg
+            else:
+                return None
+
+    elif use_original_leaves:
+
+        def cg_func(node):
+            if node.is_leaf():
+                return node.observed_cg
+            else:
+                return node.cg
+
+    else:
+
+        def cg_func(node):
+            return node.cg
+
+    label_functions = {"compact_genome": cg_func}
+
+    if include_sequence_names_in_labels:
+        label_functions["name"] = lambda n: (
+            n.taxon.label if n.is_leaf() else "internal"
+        )
+
+    dag = hdag.history_dag_from_trees(
+        (tree.seed_node for tree in dp_trees),
+        [],
+        label_functions=label_functions,
+        attr_func=lambda n: {"name": (n.taxon.label if n.is_leaf() else "internal")},
+        child_node_func=dendropy.Node.child_nodes,
+        leaf_node_func=dendropy.Node.leaf_iter,
+    )
+    if topologies_only:
+        return dag
+    else:
+        return hdag.mutation_annotated_dag.AmbiguousLeafCGHistoryDag.from_history_dag(
+            dag
+        )
+
+
+def load_beast_trees(
+    beast_xml_file,
+    beast_output_file,
+    topologies_only=False,
+    reference_sequence=None,
+    mask_ambiguous_sites=True,
+    remove_ambiguous_sites=False,
+    transition_model=parsimony_utils.default_nt_transitions,
+):
+    """Load trees from BEAST output.
+
+    Loads trees from BEAST output, in which each node has a `history_all` attribute
+    containing the mutations inferred along that node's parent branch.
+
+    Args:
+        beast_xml_file: The xml input file to BEAST
+        beast_output_file: The .trees output file from BEAST
+        topologies_only: If True, no ancestral sequences are recovered from the `history_all`
+            node attribute. This makes it possible to load trees which don't have that attribute.
+        reference_sequence: If provided, a reference sequence which will be used for all
+            compact genomes. By default, uses the ancestral sequence of the first tree, or if
+            ``topologies_only`` is True, an arbitrary observed sequence.
+        mask_ambiguous_sites: If True, ignore mutations for all sites whose observed set
+            of characters is a subset of {N, -, ?} (recommended).
+        remove_ambiguous_sites: If True, acts like ``mask_ambiguous_sites=True``, except
+            the sites in question are actually removed from the sequence, rather than masked.
+
+    Returns:
+        A generator yielding :class:`dendropy.Tree`s output by BEAST, and a set of 0-based sites
+        which are removed from sequences. If remove_ambiguous_sites is False, this set contains only
+        sites ignored by BEAST. Otherwise, it also contains additional sites removed.
+        Each tree has:
+        * ancestral sequence attribute on each tree object, containing the complete reference
+            for that tree
+        * cg attribute on all nodes, containing a compact genome relative to the reference
+            sequence
+        * observed_cg attribute on leaf nodes, containing a compact genome describing the original
+            observed sequence, with ambiguities, but with sites ignored by BEAST removed.
+        * mut attribute on all nodes containing a list of mutations on parent branch, in
+            order of occurrence
+    """
+    fasta, all_removed_sites = fasta_from_beast_file(
+        beast_xml_file, remove_ignored_sites=True
+    )
+
+    all_removed_sites = set(all_removed_sites)
+    # dendropy doesn't parse nested lists correctly in metadata, so we load the
+    # trees with raw comment strings using `extract_comment_metadata`
+    dp_trees = dendropy.TreeList.get(
+        path=beast_output_file,
+        schema="nexus",
+        extract_comment_metadata=False,
+        preserve_underscores=True,
+    )
+
+    def result_generator():
+        # Get process_first, which recovers the tree ancestral sequence,
+        # if necessary, and returns the correct reference sequence.
+        if not topologies_only:
+            if reference_sequence is None:
+
+                def process_first(tree):
+                    ref = _recover_reference(
+                        tree, fasta, transition_model.ambiguity_map
+                    )
+                    return ref
+
+            else:
+
+                def process_first(tree):
+                    _recover_reference(tree, fasta, transition_model.ambiguity_map)
+                    return reference_sequence
+
+        else:
+            if reference_sequence is None:
+                ref = next(iter(fasta.values()))
+
+            def process_first(tree):
+                return ref
+
+        # Begin processing first tree and get reference sequence
+        ref = process_first(dp_trees[0])
+
+        if mask_ambiguous_sites or remove_ambiguous_sites:
+            extra_masked_sites = {
+                i
+                for i in range(len(next(iter(fasta.values()))))
+                if len(
+                    {seq[i] for seq in fasta.values()}
+                    - transition_model.ambiguity_map.uninformative_chars
+                )
+                == 0
+            }
+            if remove_ambiguous_sites:
+                all_removed_sites.update(extra_masked_sites)
+                new_reference = mask_sequence(ref, extra_masked_sites)
+
+                def cg_transform(cg):
+                    return cg.remove_sites(
+                        extra_masked_sites, one_based=False, new_reference=new_reference
+                    )
+
+            elif mask_ambiguous_sites:
+
+                def cg_transform(cg):
+                    return cg.mask_sites(extra_masked_sites, one_based=False)
+
+        else:
+
+            def cg_transform(cg):
+                return cg
+
+        def get_observed_cgs(tree):
+            for node in tree.leaf_node_iter():
+                node.observed_cg = cg_transform(
+                    hdag.compact_genome.compact_genome_from_sequence(
+                        fasta[node.taxon.label], ref
+                    )
+                )
+
+        if topologies_only:
+
+            def process_second(tree):
+                get_observed_cgs(tree)
+
+        else:
+
+            def process_second(tree):
+                get_observed_cgs(tree)
+                _recover_cgs(tree, ref, fasta, cg_transform, transition_model)
+
+        # finish processing first tree:
+        process_second(dp_trees[0])
+        yield dp_trees[0]
+
+        # process the rest:
+        for tree in dp_trees[1:]:
+            process_first(tree)
+            process_second(tree)
+            yield tree
+
+    return result_generator(), all_removed_sites
+
+
+def _recover_cgs(tree, reference_sequence, fasta, cg_transform, transition_model):
+    ancestral_cg = hdag.compact_genome.compact_genome_from_sequence(
+        tree.ancestral_sequence, reference_sequence
+    )
+
+    unmodified_node_cgs = {None: ancestral_cg}
+    for node in tree.preorder_node_iter():
+        parent_cg = unmodified_node_cgs[node.parent_node]
+        this_cg = parent_cg.apply_muts_raw(node.muts)
+        unmodified_node_cgs[node] = this_cg
+        node.cg = cg_transform(this_cg)
+
+
+def _comment_parser(node_comments):
+    if len(node_comments) == 0:
+        yield from ()
+        return
+    elif len(node_comments) == 1:
+        comment_string = node_comments[0]
+    else:
+        for comment in node_comments:
+            if "history_all" in comment:
+                comment_string = comment
+                break
+        else:
+            raise ValueError(
+                "history_all node attribute not found:" + str(node_comments)
+            )
+    if "history_all=" not in comment_string:
+        yield from ()
+        return
+    else:
+        mutations_string = comment_string.split("history_all=")[-1]
+        stripped_mutations_list = mutations_string[2:-2]
+        if stripped_mutations_list:
+            mutations_list = stripped_mutations_list.split("},{")
+            for mut in mutations_list:
+                try:
+                    idx_str, _, from_base, to_base = mut.split(",")
+                except ValueError:
+                    raise ValueError("comment_parser failed on: " + str(node_comments))
+                yield (int(idx_str), from_base, to_base)
+        else:
+            yield from ()
+            return
+
+
+def _recover_reference(tree, fasta, ambiguity_map):
+    def get_least_ambiguous_base(idx, fasta):
+        # looks at bases in fasta entries at (0-based) idx,
+        # returns the first which is a concrete base, or the
+        # intersection of all ambiguous bases
+        seen = set()
+        for val in fasta.values():
+            base = val[idx]
+            if base in ambiguity_map.bases:
+                return base
+            else:
+                seen.add(base)
+        intersection = set(ambiguity_map.bases)
+        for code in seen:
+            intersection.intersection_update(ambiguity_map[code])
+        try:
+            return ambiguity_map.reversed[frozenset(intersection)]
+        except KeyError:
+            warn(
+                f"No ambiguity code found for possible reference bases {intersection} at idx {idx}"
+            )
+            return next(iter(intersection))
+
+    ref_node = next(tree.postorder_node_iter())
+    ref_sequence = list(fasta[ref_node.taxon.label])
+
+    curr_sequence = [None] * len(ref_sequence)
+    unknown_site_count = len(ref_sequence)
+    for node in tree.preorder_node_iter():
+        node.muts = list(_comment_parser(node.comments))
+        if unknown_site_count > 0:
+            for site, upbase, _ in node.muts:
+                idx = site - 1
+                if curr_sequence[idx] is None:
+                    curr_sequence[idx] = upbase
+                    unknown_site_count -= 1
+
+    for idx, base in enumerate(curr_sequence):
+        if base is None:
+            curr_sequence[idx] = get_least_ambiguous_base(idx, fasta)
+
+    tree.ancestral_sequence = "".join(curr_sequence)
+
+    return tree.ancestral_sequence
+
+
+def fasta_from_beast_file(filepath, remove_ignored_sites=True):
+    """Produces an alignment dictionary from a BEAST xml file.
+
+    Args:
+        filepath: path to the BEAST xml file, containing an `alignment` block
+        remove_ignored_sites: remove sites which are 'N' or '?' in all samples
+
+    Returns:
+        The resulting alignment dictionary, containing sequences keyed by names,
+        and a tuple containing masked sites (this is empty if ``remove_ignored_sites``
+        is False). Site indices are 0-based.
+    """
+    _etree = ET.parse(filepath)
+    _alignment = _etree.getroot().find("alignment")
+    unmasked_fasta = {
+        a[0].attrib["idref"].strip(): a[0].tail.strip() for a in _alignment
+    }
+    masked_sites = {
+        i
+        for i in range(len(next(iter(unmasked_fasta.values()))))
+        if len({seq[i] for seq in unmasked_fasta.values()} - {"N", "?"}) == 0
+    }
+
+    if remove_ignored_sites:
+        return (
+            {
+                key: mask_sequence(val, masked_sites)
+                for key, val in unmasked_fasta.items()
+            },
+            tuple(masked_sites),
+        )
+    else:
+        return (unmasked_fasta, tuple())
+
+
+def mask_sequence(unmasked, masked_sites):
+    """Remove the 0-based indices in ``masked_sites`` from the sequence
+    ``unmasked``, and return the resulting sequence."""
+    return "".join(char for i, char in enumerate(unmasked) if i not in masked_sites)

--- a/historydag/compact_genome.py
+++ b/historydag/compact_genome.py
@@ -1,7 +1,6 @@
 from frozendict import frozendict
 from typing import Dict, Sequence
 from warnings import warn
-import historydag.utils
 
 
 class CompactGenome:
@@ -22,7 +21,13 @@ class CompactGenome:
         return hash(self.mutations)
 
     def __eq__(self, other):
-        return (self.mutations, self.reference) == (other.mutations, other.reference)
+        if isinstance(other, CompactGenome):
+            return (self.mutations, self.reference) == (
+                other.mutations,
+                other.reference,
+            )
+        else:
+            raise NotImplementedError
 
     def __le__(self, other: object) -> bool:
         if isinstance(other, CompactGenome):
@@ -50,6 +55,14 @@ class CompactGenome:
 
     def __str__(self):
         return f"CompactGenome[{', '.join(self.mutations_as_strings())}]"
+
+    def get_site(self, site):
+        """Get the base at the provided (one-based) site index."""
+        mut = self.mutations.get(site)
+        if mut is None:
+            return self.reference[site - 1]
+        else:
+            return mut[-1]
 
     def mutations_as_strings(self):
         """Return mutations as a tuple of strings of the format '<reference
@@ -99,7 +112,21 @@ class CompactGenome:
             self.mutations.set(idx, (ref_base, newbase)), self.reference
         )
 
-    def apply_muts(self, muts: Sequence[str], reverse: bool = False):
+    def apply_muts_raw(self, muts: Sequence[tuple]):
+        """Apply the mutations from the sequence of tuples ``muts``.
+
+        Each tuple should contain (one-based site, from_base, to_base)
+        """
+        res = dict(self.mutations)
+        for site, from_base, to_base in muts:
+            ref = self.reference[site - 1]
+            if ref != to_base:
+                res[site] = (ref, to_base)
+            else:
+                res.pop(site)
+        return CompactGenome(res, self.reference)
+
+    def apply_muts(self, muts: Sequence[str], reverse: bool = False, debug=False):
         """Apply a sequence of mutstrings like 'A110G' to this compact genome.
 
         In this example, A is the old base, G is the new base, and 110 is the 1-based
@@ -112,6 +139,9 @@ class CompactGenome:
             reverse: Apply the mutations in reverse, such as when the provided mutations
                 describe how to achieve this CompactGenome from the desired CompactGenome.
                 If True, the mutations in `muts` will also be applied in reversed order.
+            debug: If True, each mutation is applied individually by
+                :meth:`CompactGenome.apply_mut` and the from base is checked against the
+                current recorded base at each site.
 
         Returns:
             The new CompactGenome
@@ -119,13 +149,26 @@ class CompactGenome:
         newcg = self
         if reverse:
             mod_func = reversed
+
+            def rearrange_func(tup):
+                return tup[0], tup[2], tup[1]
+
         else:
 
             def mod_func(seq):
                 yield from seq
 
-        for mut in mod_func(muts):
-            newcg = newcg.mutate(mut, reverse=reverse)
+            def rearrange_func(tup):
+                return tup
+
+        if debug:
+            for mut in mod_func(muts):
+                newcg = newcg.mutate(mut, reverse=reverse)
+        else:
+            newcg = self.apply_muts_raw(
+                rearrange_func(unpack_mut_string(mut)) for mut in mod_func(muts)
+            )
+
         return newcg
 
     def to_sequence(self):
@@ -169,6 +212,92 @@ class CompactGenome:
             self.reference,
         )
 
+    def subset_sites(self, sites, one_based=True, new_reference=None):
+        """Remove all but those sites in ``sites``, and adjust the reference
+        sequence.
+
+        Args:
+            sites: A collection of sites to be kept
+            one_based: If True, the provided sites will be interpreted as one-based sites. Otherwise,
+                they will be interpreted as 0-based sites.
+            new_reference: If provided, this new reference sequence will be used instead of
+                computing the new reference sequence directly.
+        """
+        if one_based:
+            adjust = 0
+        else:
+            adjust = 1
+        site_map = {
+            old_site + adjust: new_site
+            for new_site, old_site in enumerate(sorted(sites), start=1)
+        }
+        result = {
+            site_map[old_site]: state
+            for old_site, state in self.mutations.items()
+            if old_site - adjust in sites
+        }
+
+        if new_reference is None:
+            new_reference = "".join(
+                self.reference[site + adjust - 1] for site in sorted(sites)
+            )
+
+        return CompactGenome(result, new_reference)
+
+    def remove_sites(self, sites, one_based=True, new_reference=None):
+        """Remove all sites in ``sites``, and adjust the reference sequence.
+
+        Args:
+            sites: A collection of sites to be removed
+            one_based: If True, the provided sites will be interpreted as one-based sites. Otherwise,
+                they will be interpreted as 0-based sites.
+            new_reference: If provided, this new reference sequence will be used instead of
+                computing the new reference sequence directly.
+        """
+        if one_based:
+            site_adjust = 0
+        else:
+            site_adjust = 1
+
+        if new_reference is None:
+            new_reference = "".join(
+                base
+                for site, base in enumerate(self.reference, start=1)
+                if (site - site_adjust) not in sites
+            )
+
+        return CompactGenome(
+            {
+                mod_site: self.mutations[site]
+                for mod_site, site in _iter_adjusted_sites(
+                    self.mutations.keys(), sites, site_adjust
+                )
+            },
+            new_reference,
+        )
+
+
+def unpack_mut_string(mut: str):
+    """Returns (one-based site, from_base, to_base)"""
+    return int(mut[1:-1]), mut[0], mut[-1]
+
+
+def _iter_adjusted_sites(recorded_sites, removed_sites, site_adjust):
+    """Adjusts recorded_sites if removed_sites are removed.
+
+    For each one, returns a pair (modified site, unmodified site).
+    site_adjust is the amount by which removed_sites base index is
+    smaller than recorded_sites' base index.
+    """
+    all_sites = {site: False for site in recorded_sites}
+    all_sites.update({site + site_adjust: True for site in removed_sites})
+    shift = 0
+    for site, removed in sorted(all_sites.items()):
+        if removed:
+            shift += 1
+        else:
+            yield site - shift, site
+
 
 def compact_genome_from_sequence(sequence: str, reference: str):
     """Create a CompactGenome from a sequence and a reference sequence.
@@ -185,46 +314,13 @@ def compact_genome_from_sequence(sequence: str, reference: str):
     return CompactGenome(cg, reference)
 
 
-def cg_hamming_distance(seq1: CompactGenome, seq2: CompactGenome):
-    """An implementation of hamming distance on compact genomes."""
-    if seq1.reference != seq2.reference:
-        raise ValueError("Reference sequences do not match!")
-    s1 = set(seq1.mutations.keys())
-    s2 = set(seq2.mutations.keys())
-    return (
-        len(s1 - s2)
-        + len(s2 - s1)
-        + len(
-            [1 for idx in s1 & s2 if seq1.mutations[idx][1] != seq2.mutations[idx][1]]
-        )
-    )
-
-
-@historydag.utils.access_nodefield_default("compact_genome", 0)
-def wrapped_cg_hamming_distance(s1, s2) -> int:
-    """The sitewise sum of base differences between sequence field contents of
-    two nodes.
-
-    Takes two HistoryDagNodes as arguments.
-
-    If l1 or l2 is a UANode, returns 0.
-    """
-    return cg_hamming_distance(s1, s2)
-
-
 def cg_diff(parent_cg: CompactGenome, child_cg: CompactGenome):
     """Yields mutations in the format (parent_nuc, child_nuc, sequence_index)
     distinguishing two compact genomes, such that applying the resulting
     mutations to `parent_cg` would yield `child_cg`"""
     keys = set(parent_cg.mutations.keys()) | set(child_cg.mutations.keys())
     for key in keys:
-        if key in parent_cg.mutations:
-            parent_base = parent_cg.mutations[key][1]
-        else:
-            parent_base = child_cg.mutations[key][0]
-        if key in child_cg.mutations:
-            new_base = child_cg.mutations[key][1]
-        else:
-            new_base = parent_cg.mutations[key][0]
-        if parent_base != new_base:
-            yield (parent_base, new_base, key)
+        parent_base = parent_cg.get_site(key)
+        child_base = child_cg.get_site(key)
+        if parent_base != child_base:
+            yield (parent_base, child_base, key)

--- a/historydag/mutation_annotated_dag.py
+++ b/historydag/mutation_annotated_dag.py
@@ -14,12 +14,18 @@ from historydag.utils import Weight
 from historydag.compact_genome import (
     CompactGenome,
     compact_genome_from_sequence,
-    wrapped_cg_hamming_distance,
     cg_diff,
+)
+from historydag.parsimony_utils import (
+    hamming_cg_edge_weight,
+    hamming_cg_edge_weight_ambiguous_leaves,
+    compact_genome_hamming_distance_countfuncs,
+    leaf_ambiguous_compact_genome_hamming_distance_countfuncs,
 )
 import historydag.dag_pb2 as dpb
 import json
 from typing import NamedTuple
+
 
 _pb_nuc_lookup = {0: "A", 1: "C", 2: "G", 3: "T"}
 _pb_nuc_codes = {nuc: code for code, nuc in _pb_nuc_lookup.items()}
@@ -80,14 +86,14 @@ class CGHistoryDag(HistoryDag):
     def weight_count(
         self,
         *args,
-        edge_weight_func=wrapped_cg_hamming_distance,
+        edge_weight_func=hamming_cg_edge_weight,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.weight_count`"""
         return super().weight_count(*args, edge_weight_func=edge_weight_func, **kwargs)
 
     def optimal_weight_annotate(
-        self, *args, edge_weight_func=wrapped_cg_hamming_distance, **kwargs
+        self, *args, edge_weight_func=hamming_cg_edge_weight, **kwargs
     ) -> Weight:
         """See :meth:`historydag.HistoryDag.optimal_weight_annotate`"""
         return super().optimal_weight_annotate(
@@ -97,7 +103,7 @@ class CGHistoryDag(HistoryDag):
     def trim_optimal_weight(
         self,
         *args,
-        edge_weight_func=wrapped_cg_hamming_distance,
+        edge_weight_func=hamming_cg_edge_weight,
         **kwargs,
     ) -> Weight:
         """See :meth:`historydag.HistoryDag.trim_optimal_weight`"""
@@ -108,7 +114,7 @@ class CGHistoryDag(HistoryDag):
     def trim_within_range(
         self,
         *args,
-        edge_weight_func=wrapped_cg_hamming_distance,
+        edge_weight_func=hamming_cg_edge_weight,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.trim_within_range`"""
@@ -119,7 +125,7 @@ class CGHistoryDag(HistoryDag):
     def trim_below_weight(
         self,
         *args,
-        edge_weight_func=wrapped_cg_hamming_distance,
+        edge_weight_func=hamming_cg_edge_weight,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.trim_below_weight`"""
@@ -130,7 +136,7 @@ class CGHistoryDag(HistoryDag):
     def insert_node(
         self,
         *args,
-        dist=wrapped_cg_hamming_distance,
+        dist=hamming_cg_edge_weight,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.insert_node`"""
@@ -338,6 +344,98 @@ class CGHistoryDag(HistoryDag):
             fh.write(self.to_json(sort_compact_genomes=sort_compact_genomes))
 
 
+class AmbiguousLeafCGHistoryDag(CGHistoryDag):
+    """A HistoryDag subclass with node labels containing compact genomes.
+
+    The constructor for this class requires that each node label contain a 'compact_genome'
+    field, which is expected to hold a :class:`compact_genome.CompactGenome` object, which is
+    expected to hold an unambiguous sequence if the node is internal. The sequence may contain
+    ambiguities if the node is a leaf.
+
+    A HistoryDag containing 'sequence' node label fields may be automatically converted to
+    this subclass by calling the class method :meth:`CGHistoryDag.from_dag`, providing the
+    HistoryDag object to be converted, and the reference sequence to the keyword argument
+    'reference'.
+    """
+
+    # #### Overridden Methods ####
+
+    def weight_count(
+        self,
+        *args,
+        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
+        **kwargs,
+    ):
+        """See :meth:`historydag.HistoryDag.weight_count`"""
+        return super().weight_count(*args, edge_weight_func=edge_weight_func, **kwargs)
+
+    def optimal_weight_annotate(
+        self, *args, edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves, **kwargs
+    ) -> Weight:
+        """See :meth:`historydag.HistoryDag.optimal_weight_annotate`"""
+        return super().optimal_weight_annotate(
+            *args, edge_weight_func=edge_weight_func, **kwargs
+        )
+
+    def trim_optimal_weight(
+        self,
+        *args,
+        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
+        **kwargs,
+    ) -> Weight:
+        """See :meth:`historydag.HistoryDag.trim_optimal_weight`"""
+        return super().trim_optimal_weight(
+            *args, edge_weight_func=edge_weight_func, **kwargs
+        )
+
+    def trim_within_range(
+        self,
+        *args,
+        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
+        **kwargs,
+    ):
+        """See :meth:`historydag.HistoryDag.trim_within_range`"""
+        return super().trim_within_range(
+            *args, edge_weight_func=edge_weight_func, **kwargs
+        )
+
+    def trim_below_weight(
+        self,
+        *args,
+        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
+        **kwargs,
+    ):
+        """See :meth:`historydag.HistoryDag.trim_below_weight`"""
+        return super().trim_below_weight(
+            *args, edge_weight_func=edge_weight_func, **kwargs
+        )
+
+    def insert_node(
+        self,
+        *args,
+        dist=hamming_cg_edge_weight_ambiguous_leaves,
+        **kwargs,
+    ):
+        """See :meth:`historydag.HistoryDag.insert_node`"""
+        return super().insert_node(*args, dist=dist, **kwargs)
+
+    def hamming_parsimony_count(self):
+        """See :meth:`historydag.sequence_dag.SequenceHistoryDag.hamming_parsim
+        ony_count`"""
+        return self.weight_count(
+            **leaf_ambiguous_compact_genome_hamming_distance_countfuncs
+        )
+
+    def summary(self):
+        HistoryDag.summary(self)
+        min_pars, max_pars = self.weight_range_annotate(
+            **leaf_ambiguous_compact_genome_hamming_distance_countfuncs
+        )
+        print(f"Parsimony score range {min_pars} to {max_pars}")
+
+    # #### End Overridden Methods ####
+
+
 def load_json_file(filename):
     """Load a Mutation Annotated DAG stored in a JSON file and return a
     CGHistoryDag."""
@@ -517,18 +615,3 @@ def load_MAD_protobuf_file(filename):
         pb_data = dpb.data()
         pb_data.ParseFromString(fh.read())
     return load_MAD_protobuf(pb_data)
-
-
-compact_genome_hamming_distance_countfuncs = historydag.utils.AddFuncDict(
-    {
-        "start_func": lambda n: 0,
-        "edge_weight_func": wrapped_cg_hamming_distance,
-        "accum_func": sum,
-    },
-    name="HammingParsimony",
-)
-"""Provides functions to count hamming distance parsimony when sequences are
-stored as CompactGenomes.
-
-For use with :meth:`historydag.CGHistoryDag.weight_count`.
-"""

--- a/historydag/parsimony_utils.py
+++ b/historydag/parsimony_utils.py
@@ -1,0 +1,779 @@
+"""This module provides tools for describing and computing parsimony and
+weighted parsimony, and for describing allowed characters and ambiguity codes.
+
+:class:`AmbiguityMap` stores a collection of ``Characters`` (for example the strings
+``'A'``, ``'G'``, ``'C'``, and ``'T'``) that are considered valid states, as well as
+a mapping between other ``Characters`` ('ambiguity codes') and subsets of these allowed
+characters. This type allows forward- and backward-lookup of ambiguity codes.
+
+:class:`TransitionModel` describes transition weights between an ordered collection of
+``Characters``, and provides methods for computing weighted parsimony. Functions in
+``historydag.parsimony`` accept ``TransitionModel`` objects to customize the implementation
+of Sankoff, for example. This class has two subclasses: :class:`UnitTransitionModel`,
+which describes unit transition costs between non-identical ``Characters``,
+and :class:`SitewiseTransitionModel`, which allows transition costs to depend on the
+location in a sequence in which a transition occurs.
+"""
+import numpy as np
+import historydag.utils as utils
+from historydag.utils import AddFuncDict, Label
+import Bio.Data.IUPACData
+from frozendict import frozendict
+from typing import (
+    Generator,
+    Tuple,
+    Callable,
+    Iterable,
+    Sequence,
+    Any,
+    Mapping,
+    TYPE_CHECKING,
+)
+
+Character = Any
+CharacterSequence = Sequence[Character]
+
+if TYPE_CHECKING:
+    from historydag.dag import HistoryDagNode
+    from historydag.compact_genome import CompactGenome
+
+
+class AmbiguityMap:
+    """Implements a bijection between a subset of the power set of an alphabet
+    of bases, and an expanded alphabet of ambiguity codes.
+
+    To look up the set of bases represented by an ambiguity code, use the object like a dictionary.
+    To look up an ambiguity code representing a set of bases, use the ``reversed`` attribute.
+
+    Args:
+        ambiguity_character_map: A mapping from ambiguity codes to collections of bases represented by that code.
+        bases: A collection of bases. If not provided, this will be inferred from the ambiguity_character_map.
+    """
+
+    def __init__(
+        self,
+        ambiguity_character_map: Mapping[Character, Iterable[Character]],
+        bases: Iterable[Character] = None,
+    ):
+        ambiguous_values = {
+            char: frozenset(bases) for char, bases in ambiguity_character_map.items()
+        }
+        if bases is None:
+            self.bases = frozenset(
+                base for bset in self.ambiguous_values for base in bset
+            )
+        else:
+            self.bases = frozenset(bases)
+
+        ambiguous_values.update({base: frozenset({base}) for base in self.bases})
+        self.ambiguous_values = frozendict(ambiguous_values)
+        self.reversed = ReversedAmbiguityMap(
+            {bases: char for char, bases in self.ambiguous_values.items()}
+        )
+        self.uninformative_chars = frozenset(
+            char
+            for char, base_set in self.ambiguous_values.items()
+            if base_set == self.bases
+        )
+
+    def __getitem__(self, key):
+        try:
+            return self.ambiguous_values[key]
+        except KeyError:
+            raise KeyError(f"{key} is not a valid ambiguity code for this map.")
+
+    def __iter__(self):
+        return self.ambiguous_values.__iter__()
+
+    def items(self):
+        return self.ambiguous_values.items()
+
+    def is_ambiguous(self, sequence: CharacterSequence) -> bool:
+        """Returns whether the provided sequence contains any non-base
+        characters (such as ambiguity codes)."""
+        return any(code not in self.bases for code in sequence)
+
+    def sequence_resolutions(
+        self, sequence: CharacterSequence
+    ) -> Generator[CharacterSequence, None, None]:
+        """Iterates through possible disambiguations of sequence, recursively.
+
+        Recursion-depth-limited by number of ambiguity codes in
+        sequence, not sequence length.
+        """
+
+        def _sequence_resolutions(sequence, _accum=""):
+            if sequence:
+                for index, base in enumerate(sequence):
+                    if base in self.bases:
+                        _accum += base
+                    else:
+                        for newbase in self.ambiguous_values[base]:
+                            yield from _sequence_resolutions(
+                                sequence[index + 1 :], _accum=(_accum + newbase)
+                            )
+                        return
+            yield _accum
+
+        return _sequence_resolutions(sequence)
+
+    def get_sequence_resolution_func(
+        self, field_name: str
+    ) -> Callable[[Label], Generator[Label, None, None]]:
+        """Returns a function which takes a Label, and returns a generator on
+        labels containing all possible resolutions of the sequence in that
+        node's label's ``field_name`` attribute."""
+
+        @utils.explode_label(field_name)
+        def sequence_resolutions(
+            sequence: CharacterSequence,
+        ) -> Generator[CharacterSequence, None, None]:
+            return self.sequence_resolutions(sequence)
+
+        return sequence_resolutions
+
+    def sequence_resolution_count(self, sequence: CharacterSequence) -> int:
+        """Count the number of possible sequence resolutions.
+
+        Equivalent to the number of items yielded by
+        :meth:`sequence_resolutions`.
+        """
+        base_options = [
+            len(self.ambiguous_values[base])
+            for base in sequence
+            if base in self.ambiguous_values
+        ]
+        return utils.prod(base_options)
+
+    def get_sequence_resolution_count_func(
+        self, field_name: str
+    ) -> Callable[[Label], int]:
+        """Returns a function taking a Label and returning the number of
+        resolutions for the sequence held in the label's ``field_name``
+        attribute."""
+
+        @utils.access_field(field_name)
+        def sequence_resolution_count(sequence) -> int:
+            return self.sequence_resolution_count(sequence)
+
+        return sequence_resolution_count
+
+
+class ReversedAmbiguityMap(frozendict):
+    """A subclass of frozendict for holding the reversed map in a
+    :class:`AmbiguityMap` instance."""
+
+    def __getitem__(self, key):
+        try:
+            return super().__getitem__(key)
+        except KeyError:
+            raise KeyError(f"No ambiguity code is defined for the set of bases {key}")
+
+
+_ambiguous_dna_values_gap_as_char = Bio.Data.IUPACData.ambiguous_dna_values.copy()
+_ambiguous_dna_values_gap_as_char.update({"?": "GATC-", "-": "-"})
+_ambiguous_dna_values = Bio.Data.IUPACData.ambiguous_dna_values.copy()
+_ambiguous_dna_values.update({"?": "GATC", "-": "GATC"})
+
+standard_nt_ambiguity_map = AmbiguityMap(_ambiguous_dna_values, "AGCT")
+"""The standard IUPAC nucleotide ambiguity map, in which 'N', '?', and '-' are
+all considered fully ambiguous."""
+
+standard_nt_ambiguity_map_gap_as_char = AmbiguityMap(
+    _ambiguous_dna_values_gap_as_char, "AGCT-"
+)
+"""The standard IUPAC nucleotide ambiguity map, in which '-' is treated as a
+fifth base, '?' is fully ambiguous, and the ambiguity 'N' excludes '-'."""
+
+
+class TransitionModel:
+    """A class describing a collection of states, and the transition costs
+    between them, for weighted parsimony.
+
+    In addition to them methods defined below, there are also attributes which are created by
+    the constructor, which should be ensured to be correct in any subclass of TransitionModel:
+
+    * ``base_indices`` is a dictionary mapping bases in ``self.bases`` to their indices
+    * ``mask_vectors`` is a dictionary mapping ambiguity codes (including non-ambiguous bases)
+    to vectors of floats which are 0 at indices compatible with the ambiguity code, and infinity
+    otherwise.
+    * ``bases`` is a tuple recording the correct order of unambiguous bases
+
+    Args:
+        bases: An ordered collection of valid character states
+        transition_weights: A matrix describing transition costs between bases, with index order (from_base, to_base)
+        ambiguity_map: An :class:`AmbiguityMap` object describing ambiguity codes. If not provided, the default
+            mapping depends on the provided bases. If provided bases are ``AGCT``, then
+            :class:`standard_nt_ambiguity_map` is used. If bases are ``AGCT-``, then
+            :class:`standard_nt_ambiguity_map_gap_as_char` is used. Otherwise, it is assumed that no ambiguity
+            codes are allowed. To override these defaults, provide an :class:`AmbiguityMap` explicitly.
+    """
+
+    def __init__(
+        self,
+        bases: CharacterSequence = tuple("AGCT"),
+        transition_weights: Sequence[Sequence[float]] = None,
+        ambiguity_map: AmbiguityMap = None,
+    ):
+        self.bases = tuple(bases)
+        self.base_indices = frozendict({base: idx for idx, base in enumerate(bases)})
+        self.yey = np.array(
+            [[i != j for i in range(len(self.bases))] for j in range(len(self.bases))]
+        )
+        if transition_weights is None:
+            self.transition_weights = self.yey
+        else:
+            if len(transition_weights) != len(self.bases) or len(
+                transition_weights[0]
+            ) != len(self.bases):
+                raise ValueError(
+                    "transition_weights must be a nxn matrix, with n=len(bases)"
+                )
+            self.transition_weights = transition_weights
+        if ambiguity_map is None:
+            if set(self.bases) == set("AGCT"):
+                self.ambiguity_map = standard_nt_ambiguity_map
+            elif set(self.bases) == set("AGCT-"):
+                self.ambiguity_map = standard_nt_ambiguity_map_gap_as_char
+            else:
+                self.ambiguity_map = AmbiguityMap({}, self.bases)
+        else:
+            if not isinstance(ambiguity_map, AmbiguityMap):
+                raise ValueError(
+                    "ambiguity_map, if provided, must be a historydag.parsimony.AmbiguityMap object"
+                )
+            if ambiguity_map.bases != set(self.bases):
+                raise ValueError(
+                    "ambiguity_map.bases does not match bases provided to TransitionModel constructor"
+                )
+            self.ambiguity_map = ambiguity_map
+
+        # This is applicable even when diagonal entries in transition rate matrix are
+        # nonzero, since it is only a mask on allowable sites based on each base.
+        self.mask_vectors = {
+            code: np.array(
+                [
+                    0 if base in self.ambiguity_map[code] else float("inf")
+                    for base in self.bases
+                ]
+            )
+            for code in self.ambiguity_map
+        }
+
+    def get_adjacency_array(self, seq_len: int) -> np.array:
+        """Return an adjacency array for a sequence of length ``seq_len``.
+
+        This is a matrix containing transition costs, with index order
+        (site, from_base, to_base)
+        """
+        return np.array([self.transition_weights] * seq_len)
+
+    def get_ambiguity_from_tuple(self, tup: Tuple) -> Character:
+        """Retrieve an ambiguity code encoded by tup, which encodes a set of
+        bases with a tuple of 0's and 1's.
+
+        For example, if ``self.bases`` is 'AGCT'``, then ``(0, 1, 1,
+        1)`` would return `A`.
+        """
+        return self.ambiguity_map.reversed[
+            frozenset(self.bases[i] for i, flag in enumerate(tup) if flag == 0)
+        ]
+
+    def character_distance(
+        self, parent_char: Character, child_char: Character, site: int = None
+    ) -> float:
+        """Return the transition cost from parent_char to child_char, two
+        unambiguous characters.
+
+        keyword argument ``site`` is ignored in this base class.
+        """
+        return self.transition_weights[self.base_indices[parent_char]][
+            self.base_indices[child_char]
+        ]
+
+    def weighted_hamming_distance(
+        self, parent_seq: CharacterSequence, child_seq: CharacterSequence
+    ) -> float:
+        """Return the sum of sitewise transition costs, from parent_seq to
+        child_seq.
+
+        Both parent_seq and child_seq are expected to be unambiguous.
+        """
+        if len(parent_seq) != len(child_seq):
+            raise ValueError("sequence lengths do not match!")
+        return sum(
+            self.character_distance(pchar, cchar, site=(idx + 1))
+            for idx, (pchar, cchar) in enumerate(zip(parent_seq, child_seq))
+        )
+
+    def weighted_cg_hamming_distance(
+        self, parent_cg: "CompactGenome", child_cg: "CompactGenome"
+    ) -> float:
+        """Return the sum of sitewise transition costs, from parent_cg to
+        child_cg.
+
+        Both parent_seq and child_seq are expected to be unambiguous,
+        but sites where parent_cg and child_cg both match their
+        reference sequence are ignored, so this method is not suitable
+        for weighted parsimony for transition matrices that contain
+        nonzero entries along the diagonal.
+        """
+        if parent_cg.reference != child_cg.reference:
+            raise ValueError("Reference sequences do not match!")
+        s1 = set(parent_cg.mutations.keys())
+        s2 = set(child_cg.mutations.keys())
+        return sum(
+            self.character_distance(
+                parent_cg.get_site(site), child_cg.get_site(site), site=site
+            )
+            for site in s1 | s2
+        )
+
+    def min_character_distance(
+        self, parent_char: Character, child_char: Character, site=None
+    ) -> float:
+        """Allowing child_char to be ambiguous, returns the minimum possible
+        transition weight between parent_char and child_char.
+
+        Keyword argument ``site`` is ignored in this base class.
+        """
+        child_set = self.ambiguity_map[child_char]
+        p_idx = self.base_indices[parent_char]
+        return min(
+            self.transition_weights[p_idx][self.base_indices[cbase]]
+            for cbase in child_set
+        )
+
+    def min_weighted_hamming_distance(
+        self, parent_seq: CharacterSequence, child_seq: CharacterSequence
+    ) -> float:
+        """Assuming the child_seq may contain ambiguous characters, returns the
+        minimum possible transition weight between parent_seq and child_seq."""
+        if len(parent_seq) != len(child_seq):
+            raise ValueError("sequence lengths do not match!")
+        return sum(
+            self.min_character_distance(pchar, cchar, site=(idx + 1))
+            for idx, (pchar, cchar) in enumerate(zip(parent_seq, child_seq))
+        )
+
+    def min_weighted_cg_hamming_distance(
+        self, parent_cg: "CompactGenome", child_cg: "CompactGenome"
+    ) -> float:
+        """Return the sum of sitewise transition costs, from parent_cg to
+        child_cg.
+
+        child_cg may contain ambiguous characters, and in this case those sites will contribute the minimum
+        possible transition cost to the returned value.
+
+        Sites where parent_cg and child_cg
+        both match their reference sequence are ignored, so this method is not suitable for weighted parsimony
+        for transition matrices that contain nonzero entries along the diagonal.
+        """
+        if parent_cg.reference != child_cg.reference:
+            raise ValueError("Reference sequences do not match!")
+        s1 = set(parent_cg.mutations.keys())
+        s2 = set(child_cg.mutations.keys())
+        return sum(
+            self.min_character_distance(
+                parent_cg.get_site(site), child_cg.get_site(site), site=site
+            )
+            for site in s1 | s2
+        )
+
+    def weighted_hamming_edge_weight(
+        self, field_name: str
+    ) -> Callable[["HistoryDagNode", "HistoryDagNode"], float]:
+        """Returns a function for computing weighted hamming distance between
+        two nodes' sequences.
+
+        Args:
+            field_name: The name of the node label field which contains sequences.
+
+        Returns:
+            A function accepting two :class:`HistoryDagNode` objects ``n1`` and ``n2`` and returning
+            a float: the transition cost from ``n1.label.<field_name>`` to ``n2.label.<field_name>``, or 0 if
+            n1 is the UA node.
+        """
+
+        @utils.access_nodefield_default(field_name, 0)
+        def edge_weight(parent, child):
+            return self.weighted_hamming_distance(parent, child)
+
+        return edge_weight
+
+    def weighted_cg_hamming_edge_weight(
+        self, field_name: str
+    ) -> Callable[["HistoryDagNode", "HistoryDagNode"], float]:
+        """Returns a function for computing weighted hamming distance between
+        two nodes' compact genomes.
+
+        Args:
+            field_name: The name of the node label field which contains compact genomes.
+
+        Returns:
+            A function accepting two :class:`HistoryDagNode` objects ``n1`` and ``n2`` and returning
+            a float: the transition cost from ``n1.label.<field_name>`` to ``n2.label.<field_name>``, or 0 if
+            n1 is the UA node.
+
+        Sites where parent_cg and child_cg
+        both match their reference sequence are ignored, so this method is not suitable for weighted parsimony
+        for transition matrices that contain nonzero entries along the diagonal.
+        """
+
+        @utils.access_nodefield_default(field_name, 0)
+        def edge_weight(parent, child):
+            return self.weighted_cg_hamming_distance(parent, child)
+
+        return edge_weight
+
+    def min_weighted_hamming_edge_weight(
+        self, field_name: str
+    ) -> Callable[["HistoryDagNode", "HistoryDagNode"], float]:
+        """Returns a function for computing weighted hamming distance between
+        two nodes' sequences.
+
+        If the child node is a leaf node, and its sequence contains ambiguities, the minimum possible
+        transition cost from parent to child will be returned.
+
+        Args:
+            field_name: The name of the node label field which contains sequences.
+
+        Returns:
+            A function accepting two :class:`HistoryDagNode` objects ``n1`` and ``n2`` and returning
+            a float: the transition cost from ``n1.label.<field_name>`` to ``n2.label.<field_name>``, or 0 if
+            n1 is the UA node.
+        """
+
+        def edge_weight(parent, child):
+            if parent.is_ua_node():
+                return 0
+            elif child.is_leaf():
+                return self.min_weighted_hamming_distance(
+                    getattr(parent.label, field_name), getattr(child.label, field_name)
+                )
+            else:
+                return self.weighted_hamming_distance(
+                    getattr(parent.label, field_name), getattr(child.label, field_name)
+                )
+
+        return edge_weight
+
+    def min_weighted_cg_hamming_edge_weight(
+        self, field_name: str
+    ) -> Callable[["HistoryDagNode", "HistoryDagNode"], float]:
+        """Returns a function for computing weighted hamming distance between
+        two nodes' compact genomes.
+
+        If the child node is a leaf node, and its compact genome contains ambiguities, the minimum possible
+        transition cost from parent to child will be returned by this function.
+
+        Args:
+            field_name: The name of the node label field which contains compact genomes.
+
+        Returns:
+            A function accepting two :class:`HistoryDagNode` objects ``n1`` and ``n2`` and returning
+            a float: the transition cost from ``n1.label.<field_name>`` to ``n2.label.<field_name>``, or 0 if
+            n1 is the UA node.
+        """
+
+        def edge_weight(parent, child):
+            if parent.is_ua_node():
+                return 0
+            elif child.is_leaf():
+                return self.min_weighted_cg_hamming_distance(
+                    getattr(parent.label, field_name), getattr(child.label, field_name)
+                )
+            else:
+                return self.weighted_cg_hamming_distance(
+                    getattr(parent.label, field_name), getattr(child.label, field_name)
+                )
+
+        return edge_weight
+
+    def get_weighted_cg_parsimony_countfuncs(
+        self,
+        field_name: str,
+        leaf_ambiguities: bool = False,
+        name: str = "WeightedParsimony",
+    ) -> AddFuncDict:
+        """Create a :class:`historydag.utils.AddFuncDict` object for counting
+        weighted parsimony in a HistoryDag with labels containing compact
+        genomes.
+
+        Args:
+            field_name: the label field name in which compact genomes can be found
+            leaf_ambiguities: if True, leaf compact genomes are permitted to contain ambiguity codes
+            name: the name for the returned AddFuncDict object
+        """
+        if leaf_ambiguities:
+            edge_weight = self.min_weighted_cg_hamming_edge_weight(field_name)
+        else:
+            edge_weight = self.weighted_cg_hamming_edge_weight(field_name)
+        return AddFuncDict(
+            {
+                "start_func": lambda n: 0,
+                "edge_weight_func": edge_weight,
+                "accum_func": sum,
+            },
+            name=name,
+        )
+
+    def get_weighted_parsimony_countfuncs(
+        self,
+        field_name: str,
+        leaf_ambiguities: bool = False,
+        name: str = "WeightedParsimony",
+    ):
+        """Create a :class:`historydag.utils.AddFuncDict` object for counting
+        weighted parsimony in a HistoryDag with labels containing sequences.
+
+        Args:
+            field_name: the label field name in which sequences can be found
+            leaf_ambiguities: if True, leaf sequences are permitted to contain ambiguity codes
+            name: the name for the returned AddFuncDict object
+        """
+        if leaf_ambiguities:
+            edge_weight = self.min_weighted_hamming_edge_weight(field_name)
+        else:
+            edge_weight = self.weighted_hamming_edge_weight(field_name)
+        return AddFuncDict(
+            {
+                "start_func": lambda n: 0,
+                "edge_weight_func": edge_weight,
+                "accum_func": sum,
+            },
+            name=name,
+        )
+
+
+class UnitTransitionModel(TransitionModel):
+    """A subclass of :class:`TransitionModel` to be used when all non-identical
+    transitions have unit cost.
+
+    Args:
+        bases: An ordered container of allowed character states
+        ambiguity_map: A :class:`AmbiguityMap` object describing allowed ambiguity codes.
+            If not provided, a default will be chosen by the same method as the constructor for
+            :class:`TransitionModel`.
+    """
+
+    def __init__(
+        self, bases: CharacterSequence = "AGCT", ambiguity_map: AmbiguityMap = None
+    ):
+        super().__init__(bases=bases, ambiguity_map=None)
+
+    def character_distance(
+        self, parent_char: Character, child_char: Character, site: int = None
+    ) -> int:
+        """Return the transition cost from parent_char to child_char, two
+        unambiguous characters.
+
+        keyword argument ``site`` is ignored in this subclass.
+        """
+        return int(parent_char != child_char)
+
+    def min_character_distance(
+        self, parent_char: Character, child_char: Character, site: int = None
+    ) -> int:
+        """Allowing child_char to be ambiguous, returns the minimum possible
+        transition weight between parent_char and child_char.
+
+        Keyword argument ``site`` is ignored in this subclass.
+        """
+        if parent_char == child_char:
+            return 0  # TODO do we really want this?
+        else:
+            return int(parent_char not in self.ambiguity_map[child_char])
+
+    def get_weighted_cg_parsimony_countfuncs(
+        self,
+        field_name: str,
+        leaf_ambiguities: AmbiguityMap = False,
+        name: str = "HammingParsimony",
+    ) -> AddFuncDict:
+        """Create a :class:`historydag.utils.AddFuncDict` object for counting
+        parsimony in a HistoryDag with labels containing compact genomes.
+
+        Args:
+            field_name: the label field name in which compact genomes can be found
+            leaf_ambiguities: if True, leaf compact genomes are permitted to contain ambiguity codes
+            name: the name for the returned AddFuncDict object
+        """
+        return super().get_weighted_cg_parsimony_countfuncs(
+            field_name, leaf_ambiguities=leaf_ambiguities, name=name
+        )
+
+    def get_weighted_parsimony_countfuncs(
+        self,
+        field_name: str,
+        leaf_ambiguities: AmbiguityMap = False,
+        name: str = "HammingParsimony",
+    ) -> AddFuncDict:
+        """Create a :class:`historydag.utils.AddFuncDict` object for counting
+        weighted parsimony in a HistoryDag with labels containing sequences.
+
+        Args:
+            field_name: the label field name in which sequences can be found
+            leaf_ambiguities: if True, leaf sequences are permitted to contain ambiguity codes
+            name: the name for the returned AddFuncDict object
+        """
+        return super().get_weighted_parsimony_countfuncs(
+            field_name, leaf_ambiguities=leaf_ambiguities, name=name
+        )
+
+
+class SitewiseTransitionModel(TransitionModel):
+    """A subclass of :class:`TransitionModel` to be used when transition costs
+    depend on site.
+
+    Args:
+        bases: An ordered container of allowed character states
+        transition_matrix: A matrix of transition costs between provided bases, in which
+            index order is (site, from_base, to_base)
+        ambiguity_map: An :class:`AmbiguityMap` object describing ambiguous characters. If not provided
+            a default will be chosen as in the constructor for :class:`TransitionModel`.
+    """
+
+    def __init__(
+        self,
+        bases: CharacterSequence = "AGCT",
+        transition_matrix: Sequence[Sequence[Sequence[float]]] = None,
+        ambiguity_map: AmbiguityMap = None,
+    ):
+        assert transition_matrix.shape[1:] == (len(bases), len(bases))
+        super().__init__(bases=bases, ambiguity_map=None)
+        self.transition_weights = None
+        self.sitewise_transition_matrix = transition_matrix
+        self._seq_len = len(self.sitewise_transition_matrix)
+
+    def character_distance(
+        self, parent_char: Character, child_char: Character, site: int
+    ) -> float:
+        """Returns the transition cost from ``parent_char`` to ``child_char``,
+        assuming each character is at the one-based ``site`` in their
+        respective sequences.
+
+        Both parent_char and child_char are expected to be unambiguous.
+        """
+        return self.sitewise_transition_matrix[site - 1][parent_char][child_char]
+
+    def min_character_distance(
+        self, parent_char: Character, child_char: Character, site: int
+    ) -> float:
+        """Allowing child_char to be ambiguous, returns the minimum possible
+        transition weight between parent_char and child_char, given that these
+        characters are found at the (one-based) site in their respective
+        sequences."""
+        child_set = self.ambiguity_map[child_char]
+        p_idx = self.base_indices[parent_char]
+        return min(
+            self.transition_weights[site - 1][p_idx][self.base_indices[cbase]]
+            for cbase in child_set
+        )
+
+    def get_adjacency_array(self, seq_len):
+        """Return an adjacency array for a sequence of length ``seq_len``.
+
+        This is a matrix containing transition costs, with index order
+        (site, from_base, to_base)
+        """
+        if seq_len != self._seq_len:
+            raise ValueError(
+                f"SitewiseTransitionModel instance supports sequence length of {self._seq_len}"
+            )
+        return self.sitewise_transition_matrix
+
+
+default_nt_transitions = UnitTransitionModel(bases="AGCT")
+"""A transition model for nucleotides using unit transition weights, and the
+standard IUPAC ambiguity codes, with base order ``AGCT`` and ``N``, ``?`` and
+``-`` treated as fully ambiguous characters."""
+
+default_nt_gaps_transitions = UnitTransitionModel(bases="AGCT-")
+"""A transition model for nucleotides using unit transition weights, and the
+standard IUPAC nucleotide ambiguity map, with '-' is treated as a fifth base,
+'?' fully ambiguous, and the ambiguity 'N' excluding only '-'."""
+
+hamming_edge_weight = default_nt_transitions.weighted_hamming_edge_weight("sequence")
+"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes,
+and returning the hamming distance between the sequences stored in the
+``sequence`` attributes of their labels."""
+hamming_edge_weight_ambiguous_leaves = (
+    default_nt_transitions.min_weighted_hamming_edge_weight("sequence")
+)
+"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes,
+and returning the hamming distance between the sequences stored in the
+``sequence`` attributes of their labels.
+
+This edge weight function allows leaf nodes to have ambiguous sequences.
+"""
+
+hamming_cg_edge_weight = default_nt_transitions.weighted_cg_hamming_edge_weight(
+    "compact_genome"
+)
+"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes,
+and returning the hamming distance between the compact genomes stored in the
+``compact_genome`` attributes of their labels."""
+
+hamming_cg_edge_weight_ambiguous_leaves = (
+    default_nt_transitions.min_weighted_cg_hamming_edge_weight("compact_genome")
+)
+"""An edge weight function accepting (parent, child) pairs of HistoryDagNodes,
+and returning the hamming distance between the compact genomes stored in the
+``compact_genome`` attributes of their labels.
+
+This edge weight function allows leaf nodes to have ambiguous compact
+genomes.
+"""
+
+hamming_distance_countfuncs = AddFuncDict(
+    {
+        "start_func": lambda n: 0,
+        "edge_weight_func": hamming_edge_weight,
+        "accum_func": sum,
+    },
+    name="HammingParsimony",
+)
+"""Provides functions to count hamming distance parsimony when leaf sequences
+may be ambiguous.
+
+For use with :meth:`historydag.AmbiguousLeafSequenceHistoryDag.weight_count`.
+"""
+
+leaf_ambiguous_hamming_distance_countfuncs = AddFuncDict(
+    {
+        "start_func": lambda n: 0,
+        "edge_weight_func": hamming_edge_weight_ambiguous_leaves,
+        "accum_func": sum,
+    },
+    name="HammingParsimony",
+)
+"""Provides functions to count hamming distance parsimony when leaf sequences
+may be ambiguous.
+
+For use with :meth:`historydag.AmbiguousLeafSequenceHistoryDag.weight_count`.
+"""
+
+
+compact_genome_hamming_distance_countfuncs = (
+    default_nt_transitions.get_weighted_cg_parsimony_countfuncs(
+        "compact_genome", leaf_ambiguities=False
+    )
+)
+"""Provides functions to count hamming distance parsimony when sequences are
+stored as CompactGenomes.
+
+For use with :meth:`historydag.CGHistoryDag.weight_count`.
+"""
+
+
+leaf_ambiguous_compact_genome_hamming_distance_countfuncs = (
+    default_nt_transitions.get_weighted_cg_parsimony_countfuncs(
+        "compact_genome", leaf_ambiguities=True
+    )
+)
+"""Provides functions to count hamming distance parsimony when leaf compact
+genomes may be ambiguous.
+
+For use with :meth:`historydag.AmbiguousLeafCGHistoryDag.weight_count`.
+"""

--- a/historydag/sankoff_cli.py
+++ b/historydag/sankoff_cli.py
@@ -1,4 +1,5 @@
-import parsimony as pars
+import historydag.parsimony as pars
+import historydag.parsimony_utils as pars_utils
 import click
 import pickle
 
@@ -95,12 +96,16 @@ def _cli_build_trees(
         reference_id=root_id,
         ignore_internal_sequences=(not include_internal_sequences),
     )
+    if gap_as_char:
+        transition_model = pars_utils.default_nt_gaps_transitions
+    else:
+        transition_model = pars_utils.default_nt_gaps_transitions
     trees = (
         pars.disambiguate(
             tree,
-            gap_as_char=gap_as_char,
             min_ambiguities=preserve_ambiguities,
             remove_cvs=clean_trees,
+            transition_model=transition_model,
         )
         for tree in trees
     )
@@ -185,6 +190,10 @@ def _cli_parsimony_score_from_files(
         print(treepath)
         print(score)
 
+    if gap_as_char:
+        transition_model = pars_utils.default_nt_gaps_transitions
+    else:
+        transition_model = pars_utils.default_nt_gaps_transitions
     if save_to_dag is not None:
         trees = pars.build_trees_from_files(
             treefiles,
@@ -194,7 +203,9 @@ def _cli_parsimony_score_from_files(
         )
         trees = (
             pars.disambiguate(
-                tree, gap_as_char=gap_as_char, min_ambiguities=preserve_ambiguities
+                tree,
+                transition_model=transition_model,
+                min_ambiguities=preserve_ambiguities,
             )
             for tree in trees
         )

--- a/historydag/sequence_dag.py
+++ b/historydag/sequence_dag.py
@@ -1,54 +1,6 @@
 from historydag import HistoryDag
-from functools import lru_cache
-import historydag.utils
+import historydag.parsimony_utils as parsimony_utils
 from historydag.utils import Weight
-
-
-def nonleaf_sequence_resolutions(node):
-    if node.is_leaf():
-        yield node.label
-    else:
-        yield from historydag.utils.sequence_resolutions(node.label)
-
-
-@lru_cache(maxsize=20000)
-def _ambiguous_hamming_distance(node1, node2):
-    return sum(
-        pbase not in historydag.utils.ambiguous_dna_values[cbase]
-        for pbase, cbase in zip(node1.label.sequence, node2.label.sequence)
-    )
-
-
-def ambiguous_hamming_distance(node1, node2):
-    """Returns the hamming distance between node1.label.sequence and
-    node2.label.sequence.
-
-    If node2 is a leaf node, then its sequence may be ambiguous, and the
-    minimum possible distance will be returned.
-    """
-    if node1.is_ua_node():
-        return 0
-    if node2.is_leaf():
-        return _ambiguous_hamming_distance(node1, node2)
-    else:
-        return historydag.utils.hamming_distance(
-            node1.label.sequence, node2.label.sequence
-        )
-
-
-leaf_ambiguous_hamming_distance_countfuncs = historydag.utils.AddFuncDict(
-    {
-        "start_func": lambda n: 0,
-        "edge_weight_func": ambiguous_hamming_distance,
-        "accum_func": sum,
-    },
-    name="HammingParsimony",
-)
-"""Provides functions to count hamming distance parsimony when leaf sequences
-may be ambiguous.
-
-For use with :meth:`historydag.AmbiguousLeafSequenceHistoryDag.weight_count`.
-"""
 
 
 class SequenceHistoryDag(HistoryDag):
@@ -75,12 +27,12 @@ class SequenceHistoryDag(HistoryDag):
 
         Returns a Counter with integer keys.
         """
-        return self.weight_count(**historydag.utils.hamming_distance_countfuncs)
+        return self.weight_count(**parsimony_utils.hamming_distance_countfuncs)
 
     def summary(self):
         HistoryDag.summary(self)
         min_pars, max_pars = self.weight_range_annotate(
-            **historydag.utils.hamming_distance_countfuncs
+            **parsimony_utils.hamming_distance_countfuncs
         )
         print(f"Parsimony score range {min_pars} to {max_pars}")
 
@@ -104,14 +56,17 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     def weight_count(
         self,
         *args,
-        edge_weight_func=ambiguous_hamming_distance,
+        edge_weight_func=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.weight_count`"""
         return super().weight_count(*args, edge_weight_func=edge_weight_func, **kwargs)
 
     def optimal_weight_annotate(
-        self, *args, edge_weight_func=ambiguous_hamming_distance, **kwargs
+        self,
+        *args,
+        edge_weight_func=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
+        **kwargs,
     ) -> Weight:
         """See :meth:`historydag.HistoryDag.optimal_weight_annotate`"""
         return super().optimal_weight_annotate(
@@ -121,7 +76,7 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     def trim_optimal_weight(
         self,
         *args,
-        edge_weight_func=ambiguous_hamming_distance,
+        edge_weight_func=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
         **kwargs,
     ) -> Weight:
         """See :meth:`historydag.HistoryDag.trim_optimal_weight`"""
@@ -132,7 +87,7 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     def trim_within_range(
         self,
         *args,
-        edge_weight_func=ambiguous_hamming_distance,
+        edge_weight_func=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.trim_within_range`"""
@@ -143,7 +98,7 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     def trim_below_weight(
         self,
         *args,
-        edge_weight_func=ambiguous_hamming_distance,
+        edge_weight_func=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.trim_below_weight`"""
@@ -154,7 +109,7 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     def insert_node(
         self,
         *args,
-        dist=ambiguous_hamming_distance,
+        dist=parsimony_utils.hamming_edge_weight_ambiguous_leaves,
         **kwargs,
     ):
         """See :meth:`historydag.HistoryDag.insert_node`"""
@@ -163,11 +118,13 @@ class AmbiguousLeafSequenceHistoryDag(SequenceHistoryDag):
     def hamming_parsimony_count(self):
         """See :meth:`historydag.sequence_dag.SequenceHistoryDag.hamming_parsim
         ony_count`"""
-        return self.weight_count(**leaf_ambiguous_hamming_distance_countfuncs)
+        return self.weight_count(
+            **parsimony_utils.leaf_ambiguous_hamming_distance_countfuncs
+        )
 
     def summary(self):
         HistoryDag.summary(self)
         min_pars, max_pars = self.weight_range_annotate(
-            **leaf_ambiguous_hamming_distance_countfuncs
+            **parsimony_utils.leaf_ambiguous_hamming_distance_countfuncs
         )
         print(f"Parsimony score range {min_pars} to {max_pars}")

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -2,7 +2,6 @@
 
 import ete3
 from math import log
-from Bio.Data.IUPACData import ambiguous_dna_values
 from collections import Counter
 from functools import wraps
 import operator
@@ -47,10 +46,6 @@ class UALabel(str):
 
     def _asdict(self):
         raise RuntimeError("Attempted to iterate from dag root UALabel")
-
-
-bases = "AGCT-"
-ambiguous_dna_values.update({"?": bases, "-": "-"})
 
 
 # ######## Decorators ########
@@ -154,47 +149,6 @@ def explode_label(labelfield: str):
 # ######## Distances and comparisons... ########
 
 
-def hamming_distance(s1: str, s2: str) -> int:
-    """The sitewise sum of base differences between s1 and s2."""
-    if len(s1) != len(s2):
-        raise ValueError("Sequences must have the same length!")
-    return sum(x != y for x, y in zip(s1, s2))
-
-
-@access_nodefield_default("sequence", 0)
-def wrapped_hamming_distance(s1, s2) -> int:
-    """The sitewise sum of base differences between sequence field contents of
-    two nodes.
-
-    Takes two HistoryDagNodes as arguments.
-
-    If l1 or l2 is a UANode, returns 0.
-    """
-    return hamming_distance(s1, s2)
-
-
-def hamming_distance_leaf_ambiguous(n1, n2):
-    """Same as wrapped_hamming_distance, but correctly calculates parsimony
-    scores if leaf nodes have ambiguous sequences."""
-    if n2.is_leaf():
-        # Then its sequence may be ambiguous
-        s1 = n1.label.sequence
-        s2 = n2.label.sequence
-        if len(s1) != len(s2):
-            raise ValueError("Sequences must have the same length!")
-        return sum(
-            pbase not in ambiguous_dna_values[cbase] for pbase, cbase in zip(s1, s2)
-        )
-    else:
-        return wrapped_hamming_distance(n1, n2)
-
-
-def is_ambiguous(sequence: str) -> bool:
-    """Returns whether the provided sequence contains IUPAC nucleotide
-    ambiguity codes."""
-    return any(code not in bases for code in sequence)
-
-
 def cartesian_product(
     optionlist: List[Callable[[], Iterable]], accum=tuple()
 ) -> Generator[Tuple, None, None]:
@@ -210,42 +164,6 @@ def cartesian_product(
             yield from cartesian_product(optionlist[1:], accum=(accum + (term,)))
     else:
         yield accum
-
-
-@explode_label("sequence")
-def sequence_resolutions(sequence: str) -> Generator[str, None, None]:
-    """Iterates through possible disambiguations of sequence, recursively.
-
-    Recursion-depth-limited by number of ambiguity codes in sequence,
-    not sequence length.
-    """
-
-    def _sequence_resolutions(sequence, _accum=""):
-        if sequence:
-            for index, base in enumerate(sequence):
-                if base in bases:
-                    _accum += base
-                else:
-                    for newbase in ambiguous_dna_values[base]:
-                        yield from _sequence_resolutions(
-                            sequence[index + 1 :], _accum=(_accum + newbase)
-                        )
-                    return
-        yield _accum
-
-    return _sequence_resolutions(sequence)
-
-
-@access_field("sequence")
-def sequence_resolutions_count(sequence: str) -> int:
-    """Count the number of possible sequence resolutions Equivalent to the
-    length of the list returned by :meth:`sequence_resolutions`."""
-    base_options = [
-        len(ambiguous_dna_values[base])
-        for base in sequence
-        if base in ambiguous_dna_values
-    ]
-    return prod(base_options)
 
 
 def hist(c: Counter, samples: int = 1):
@@ -277,10 +195,7 @@ def collapse_adjacent_sequences(tree: ete3.TreeNode) -> ete3.TreeNode:
     to_delete = []
     for node in tree.get_descendants():
         # This must stay invariably hamming distance, since it's measuring equality of strings
-        if (
-            not node.is_leaf()
-            and hamming_distance(node.up.sequence, node.sequence) == 0
-        ):
+        if not node.is_leaf() and node.up.sequence == node.sequence:
             to_delete.append(node)
     for node in to_delete:
         node.delete()
@@ -299,7 +214,7 @@ class AddFuncDict(UserDict):
     annotate a :meth:`historydag.HistoryDag` according to the weight that the
     contained functions implement.
 
-    For example, `dag.weight_count(**(utils.hamming_distance_countfuncs + make_newickcountfuncs()))`
+    For example, `dag.weight_count(**(parsimony_utils.hamming_distance_countfuncs + make_newickcountfuncs()))`
     would return a Counter object in which the weights are tuples containing hamming parsimony and newickstrings.
 
     Args:
@@ -576,19 +491,6 @@ class HistoryDagFilter:
     #     ret.ordering_names = ((new_optimal_func_name, n),)
     #     return ret
 
-
-hamming_distance_countfuncs = AddFuncDict(
-    {
-        "start_func": lambda n: 0,
-        "edge_weight_func": wrapped_hamming_distance,
-        "accum_func": sum,
-    },
-    name="HammingParsimony",
-)
-"""Provides functions to count hamming distance parsimony.
-
-For use with :meth:`historydag.HistoryDag.weight_count`.
-"""
 
 node_countfuncs = AddFuncDict(
     {

--- a/tests/test_collapse.py
+++ b/tests/test_collapse.py
@@ -1,6 +1,6 @@
 import ete3
 import historydag.dag as hdag
-from historydag import utils
+from historydag import utils, parsimony_utils
 import pickle
 from test_factory import deterministic_newick
 
@@ -22,7 +22,10 @@ def collapse_adjacent_sequences(tree: ete3.TreeNode) -> ete3.TreeNode:
         # This must stay invariably hamming distance, since it's measuring equality of strings
         if (
             not node.is_leaf()
-            and utils.hamming_distance(node.up.sequence, node.sequence) == 0
+            and parsimony_utils.default_nt_transitions.weighted_hamming_distance(
+                node.up.sequence, node.sequence
+            )
+            == 0
         ):
             to_delete.append(node)
     for node in to_delete:

--- a/tests/test_compact_genome.py
+++ b/tests/test_compact_genome.py
@@ -1,8 +1,9 @@
 import historydag.compact_genome as compact_genome
-from frozendict import frozendict
+from historydag.compact_genome import CompactGenome
+from historydag.parsimony_utils import default_nt_transitions
 
 
-def _test_sequence_cg_convert():
+def test_sequence_cg_convert():
     seqs = [
         "AAAA",
         "TAAT",
@@ -11,7 +12,7 @@ def _test_sequence_cg_convert():
     ]
     for refseq in seqs:
         for seq in seqs:
-            cg = compact_genome.sequence_to_cg(seq, refseq)
+            cg = compact_genome.compact_genome_from_sequence(seq, refseq)
             reseq = cg.to_sequence()
             if reseq != seq:
                 print("\nUnmatched reconstructed sequence:")
@@ -22,29 +23,32 @@ def _test_sequence_cg_convert():
                 assert False
 
 
-def _test_cg_diff():
+def test_cg_diff():
+    refseq = "C" * 1000
     cgs = [
-        frozendict({287: ("C", "G")}),
-        frozendict({287: ("C", "G"), 318: ("C", "A"), 495: ("C", "T")}),
-        frozendict({287: ("C", "G"), 80: ("A", "C"), 257: ("C", "G"), 591: ("G", "A")}),
-        frozendict(
+        CompactGenome({287: ("C", "G")}, refseq),
+        CompactGenome({287: ("C", "G"), 318: ("C", "A"), 495: ("C", "T")}, refseq),
+        CompactGenome(
+            {287: ("C", "G"), 80: ("C", "T"), 257: ("C", "G"), 591: ("C", "A")}, refseq
+        ),
+        CompactGenome(
             {
                 287: ("C", "G"),
-                191: ("A", "G"),
+                191: ("C", "G"),
                 492: ("C", "G"),
                 612: ("C", "G"),
-                654: ("A", "G"),
-            }
+                654: ("C", "G"),
+            },
+            refseq,
         ),
-        frozendict({287: ("C", "G"), 318: ("C", "A"), 495: ("C", "T")}),
+        CompactGenome({287: ("C", "G"), 318: ("C", "A"), 495: ("C", "T")}, refseq),
     ]
     for parent_cg in cgs:
         for child_cg in cgs:
             assert (
                 parent_cg.apply_muts(
-                    compact_genome.str_mut_from_tups(
-                        compact_genome.cg_diff(parent_cg, child_cg)
-                    )
+                    str(p) + str(key) + str(c)
+                    for p, c, key in compact_genome.cg_diff(parent_cg, child_cg)
                 )
                 == child_cg
             )
@@ -54,3 +58,20 @@ def _test_cg_diff():
                     parent_cg, child_cg
                 )
             )
+
+
+def test_ambiguous_cg_distance():
+    reference_seq = "AAAAAAAN"
+
+    s1 = compact_genome.CompactGenome({1: ("A", "T"), 2: ("A", "G")}, reference_seq)
+    s2 = compact_genome.CompactGenome({1: ("A", "T"), 2: ("A", "N")}, reference_seq)
+    s3 = compact_genome.CompactGenome({1: ("A", "T")}, reference_seq)
+    s4 = compact_genome.CompactGenome({8: ("N", "C")}, reference_seq)
+
+    assert default_nt_transitions.min_weighted_cg_hamming_distance(s1, s2) == 0
+    assert default_nt_transitions.min_weighted_cg_hamming_distance(s1, s3) == 1
+    assert default_nt_transitions.min_weighted_cg_hamming_distance(s1, s4) == 3
+    assert default_nt_transitions.min_weighted_cg_hamming_distance(s4, s1) == 2
+    assert default_nt_transitions.min_weighted_cg_hamming_distance(s3, s2) == 0
+    assert default_nt_transitions.min_weighted_cg_hamming_distance(s4, s2) == 1
+    assert default_nt_transitions.min_weighted_cg_hamming_distance(s4, s3) == 1

--- a/tests/test_dag_sankoff.py
+++ b/tests/test_dag_sankoff.py
@@ -3,9 +3,12 @@ import random
 import numpy as np
 import historydag as hdag
 import historydag.parsimony as dag_parsimony
+import historydag.parsimony_utils as parsimony_utils
 
 
-def compare_dag_and_tree_parsimonies(dag, transition_weights=None):
+def compare_dag_and_tree_parsimonies(
+    dag, transition_model=parsimony_utils.default_nt_transitions
+):
     # extract sample tree
     s = dag.sample().copy()
     s.recompute_parents()
@@ -14,10 +17,8 @@ def compare_dag_and_tree_parsimonies(dag, transition_weights=None):
 
     # compute cost vectors for sample tree in dag and in ete3.Tree format to compare
     seq_len = len(next(s.get_leaves()).label.sequence)
-    a = dag_parsimony.sankoff_upward(s, seq_len, transition_weights=transition_weights)
-    b = dag_parsimony.sankoff_upward(
-        s_ete, seq_len, transition_weights=transition_weights
-    )
+    a = dag_parsimony.sankoff_upward(s, seq_len, transition_model=transition_model)
+    b = dag_parsimony.sankoff_upward(s_ete, seq_len, transition_model=transition_model)
     assert a == b, (
         "Upward Sankoff on ete_Tree vs on the dag version of the tree produced different results: "
         + "%lf from the dag and %lf from the ete_Tree" % (a, b)
@@ -27,25 +28,18 @@ def compare_dag_and_tree_parsimonies(dag, transition_weights=None):
     s_weight = dag_parsimony.sankoff_downward(
         s,
         compute_cvs=False,
-        transition_weights=transition_weights,
+        transition_model=transition_model,
     )
     s_ete = dag_parsimony.disambiguate(
-        s_ete, compute_cvs=False, transition_weights=transition_weights
+        s_ete, compute_cvs=False, transition_model=transition_model
     )
     # convert ete3.Tree back to a HistoryDag object so as to compare, but keeping the data calculated using ete3 structure
     s_ete_as_dag = hdag.history_dag_from_etes([s_ete], label_features=["sequence"])
 
-    # parsimony score depends on the choice of `transition_weights` arg
-    if transition_weights is not None:
-        weight_func = dag_parsimony.make_weighted_hamming_edge_func(
-            transition_weights, bases=dag_parsimony.bases
-        )
+    # parsimony score depends on the choice of `transition_model` arg
 
-        s_ete_weight = s_ete_as_dag.optimal_weight_annotate(
-            edge_weight_func=weight_func
-        )
-    else:
-        s_ete_weight = s_ete_as_dag.optimal_weight_annotate()
+    weight_func = transition_model.weighted_hamming_edge_weight("sequence")
+    s_ete_weight = s_ete_as_dag.optimal_weight_annotate(edge_weight_func=weight_func)
     assert s_weight == s_ete_weight, (
         "Downward sankoff on ete_Tree vs on the dag version of the tree produced different results: "
         + "%lf from the dag and %lf from the ete_Tree" % (s_weight, s_ete_weight)
@@ -60,11 +54,13 @@ def compare_dag_and_tree_parsimonies(dag, transition_weights=None):
     ), "DAG Sankoff missed a label that occurs in the tree Sankoff."
 
 
-def check_sankoff_on_dag(dag, expected_score, transition_weights=None):
+def check_sankoff_on_dag(
+    dag, expected_score, transition_model=parsimony_utils.default_nt_gaps_transitions
+):
     # perform upward sweep of sankoff to calculate overall parsimony score and assign cost vectors to internal nodes
     seq_len = len(next(dag.get_leaves()).label.sequence)
     upward_pass_min_cost = dag_parsimony.sankoff_upward(
-        dag, seq_len, transition_weights=transition_weights
+        dag, seq_len, transition_model=transition_model
     )
     assert np.isclose([upward_pass_min_cost], [expected_score]), (
         "Upward pass of Sankoff on dag did not yield expected score: computed %lf, but expected %lf"
@@ -74,7 +70,7 @@ def check_sankoff_on_dag(dag, expected_score, transition_weights=None):
     # perform downward sweep of sankoff to calculate all possible internal node sequences.
     downward_pass_min_cost = dag_parsimony.sankoff_downward(
         dag,
-        transition_weights=transition_weights,
+        transition_model=transition_model,
         compute_cvs=False,
     )
     dag._check_valid()
@@ -96,36 +92,42 @@ def test_sankoff_on_dag():
     dg.convert_to_collapsed()
 
     tw_options = [
-        (75, None),
+        (75, parsimony_utils.default_nt_transitions),
         (
             93,
-            np.array(
-                [
-                    [0, 1, 2.5, 1, 1],
-                    [1, 0, 1, 2.5, 1],
-                    [2.5, 1, 0, 1, 1],
-                    [1, 2.5, 1, 0, 1],
-                    [1, 1, 1, 1, 0],
-                ]
+            parsimony_utils.TransitionModel(
+                bases="AGCT-",
+                transition_weights=np.array(
+                    [
+                        [0, 1, 2.5, 1, 1],
+                        [1, 0, 1, 2.5, 1],
+                        [2.5, 1, 0, 1, 1],
+                        [1, 2.5, 1, 0, 1],
+                        [1, 1, 1, 1, 0],
+                    ]
+                ),
             ),
         ),
         (
             106,
-            np.array(
-                [
-                    [0, 1, 5, 1, 1],
-                    [1, 0, 1, 5, 1],
-                    [5, 1, 0, 1, 1],
-                    [1, 5, 1, 0, 1],
-                    [1, 1, 1, 1, 0],
-                ]
+            parsimony_utils.TransitionModel(
+                bases="AGCT-",
+                transition_weights=np.array(
+                    [
+                        [0, 1, 5, 1, 1],
+                        [1, 0, 1, 5, 1],
+                        [5, 1, 0, 1, 1],
+                        [1, 5, 1, 0, 1],
+                        [1, 1, 1, 1, 0],
+                    ]
+                ),
             ),
         ),
     ]
 
-    for w, tw in tw_options:
-        check_sankoff_on_dag(dg.copy(), w, transition_weights=tw)
-        compare_dag_and_tree_parsimonies(dg.copy(), transition_weights=tw)
+    for w, tm in tw_options:
+        check_sankoff_on_dag(dg.copy(), w, transition_model=tm)
+        compare_dag_and_tree_parsimonies(dg.copy(), transition_model=tm)
 
 
 def test_partial_sankoff_on_dag():
@@ -190,19 +192,18 @@ def test_sankoff_with_alternative_sequence_name():
             i = i + 1
 
     dg = dg.add_label_fields(["location"], vals)
+    transition_model = parsimony_utils.TransitionModel(bases="AB")
 
     upward_cost = dag_parsimony.sankoff_upward(
         dg,
         seq_len=1,
         sequence_attr_name="location",
-        bases=["A", "B"],
-        transition_weights=np.array([[0, 1], [1, 0]]),
+        transition_model=transition_model,
     )
     downward_cost = dag_parsimony.sankoff_downward(
         dg,
         sequence_attr_name="location",
-        bases=["A", "B"],
-        transition_weights=np.array([[0, 1], [1, 0]]),
+        transition_model=transition_model,
     )
     assert (
         upward_cost == downward_cost

--- a/tests/test_disambiguate.py
+++ b/tests/test_disambiguate.py
@@ -2,6 +2,7 @@ from historydag import utils
 from historydag import dag as hdag
 import ete3
 from Bio.Data.IUPACData import ambiguous_dna_values
+from historydag import parsimony_utils
 
 bases = "AGCT-"
 ambiguous_dna_values.update({"?": "GATC-", "-": "-"})
@@ -112,7 +113,10 @@ def disambiguate_sitewise(tree: ete3.TreeNode) -> ete3.TreeNode:
     return disambiguated
 
 
-def disambiguate(tree: ete3.Tree, dist_func=utils.hamming_distance):
+def disambiguate(
+    tree: ete3.Tree,
+    dist_func=parsimony_utils.default_nt_transitions.weighted_hamming_distance,
+):
     """Resolve ambiguous bases using a two-pass Sankoff Algorithm on entire tree and entire sequence at each node.
     This does not disambiguate sitewise, so trees with many ambiguities may make this run very slowly.
     Returns a list of all possible disambiguations, minimizing the passed distance function dist_func.
@@ -136,7 +140,9 @@ def disambiguate(tree: ete3.Tree, dist_func=utils.hamming_distance):
 
     def incremental_disambiguate(ambig_tree):
         for node in ambig_tree.traverse(strategy="preorder"):
-            if not utils.is_ambiguous(node.sequence):
+            if not parsimony_utils.default_nt_transitions.ambiguity_map.is_ambiguous(
+                node.sequence
+            ):
                 continue
             else:
                 if not node.is_root():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,15 @@
 from historydag.utils import (
-    hamming_distance,
     hist,
     AddFuncDict,
-    hamming_distance_countfuncs,
     prod,
 )
 from collections import Counter
+from historydag.parsimony_utils import (
+    hamming_distance_countfuncs,
+    default_nt_transitions,
+)
+
+hamming_distance = default_nt_transitions.weighted_hamming_distance
 
 
 def test_hamming_distance():


### PR DESCRIPTION
This is the squashed version of #60

(Copied from #60):

This PR adds basic support for loading trees from BEAST.

In addition, in order to make transition matrix and ambiguity code options more explicit, and to reduce overhead in functions which require those options, this PR introduces some new classes in `parsimony.py`:

* `AmbiguityMap`, which contains an immutable mapping from ambiguity codes to sets of bases, a reversed version of that map, and a set of bases. (the new class `ReversedAmbiguityMap` holds the reversed map, but it's a barely-modified subclass of frozendict)
* `TransitionAlphabet` holds a tuple of bases, a transition weight matrix, and an ambiguity map, as well as a variety of useful derived data structures and methods. In particular, methods to produce edge weight functions that implement weighted parsimony according to the options encapsulated in a particular TransitionAlphabet instance
    * `UnitTransitionAlphabet` is a subclass for unit transition costs, which allow some optimizations for computing hamming distance
    * `VariableTransitionAlphabet` is a subclass that generalizes `AmbiguityMap` to allow different transition costs for each site. This subclass enforces a fixed sequence length for considered sequences.


I'm very bad at naming, so let me know if you have suggestions @marybarker. In particular, I was using `transition_model` lots for variables that expect `TransitionAlphabet`, so I should probably change the class name to match... but is `TransitionModel` the best we can come up with?