### PR TITLE
HistoryDag subclass defaults

### DIFF
--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -1,10 +1,12 @@
 """A module providing the class HistoryDag, and supporting functions."""
 
 import pickle
+from functools import wraps
 from math import log
 import graphviz as gv
 import ete3
 import random
+from frozendict import frozendict
 import warnings
 from typing import (
     List,
@@ -399,6 +401,43 @@ class UANode(HistoryDagNode):
         return True
 
 
+def get_default_args(argnamelist, positional_count=0):
+    def weight_count_args(func):
+        @wraps(func)
+        def wrapper(instance, *args, **kwargs):
+            nargs = len(args)
+            # To make argument management simpler, we require this:
+            if nargs < positional_count or nargs > positional_count:
+                raise TypeError(
+                    f"{func.__qualname__} requires exactly {positional_count} "
+                    f"positional argument but received {nargs}"
+                )
+            for argname in argnamelist:
+                if argname not in kwargs or kwargs[argname] is None:
+                    try:
+                        kwargs[argname] = instance._default_args[argname]
+                    except KeyError:
+                        raise TypeError(
+                            f"{func.__qualname__} requires a value for the keyword argument "
+                            f"{argname}, since {type(instance)} does not define a default"
+                        )
+            return func(instance, *args, **kwargs)
+
+        return wrapper
+
+    return weight_count_args
+
+
+def convert(dag, newclass):
+    """Convert ``dag`` to the HistoryDag subclass ``newclass``.
+
+    This is a wrapper for the ``newclass.from_history_dag`` method,
+    which for most subclasses should be identical to
+    :meth:`HistoryDag.from_history_dag`.
+    """
+    return newclass.from_history_dag(dag)
+
+
 class HistoryDag:
     r"""An object to represent a collection of internally labeled trees. A
     wrapper object to contain exposed HistoryDag methods and point to a
@@ -423,6 +462,20 @@ class HistoryDag:
     conversion functions and their keywords, in each subclass's docstring.
     """
     _required_label_fields = dict()
+    _default_args = frozendict(parsimony_utils.hamming_distance_countfuncs) | {
+        "start_func": (lambda n: 0),
+        "edge_func": lambda l1, l2: (
+            0
+            if isinstance(l1, UALabel)
+            else parsimony_utils.default_nt_transitions.weighted_hamming_distance(
+                l1.sequence, l2.sequence
+            )
+        ),
+        "expand_func": parsimony_utils.default_nt_transitions.ambiguity_map.get_sequence_resolution_func(
+            "sequence"
+        ),
+        "optimal_func": min,
+    }
 
     @classmethod
     def from_history_dag(
@@ -588,6 +641,7 @@ class HistoryDag:
         """Return the type for labels on this dag's nodes."""
         return type(next(self.dagroot.children()).label)
 
+    @get_default_args(["start_func", "edge_weight_func"])
     def trim_within_range(
         self,
         min_weight=None,
@@ -615,13 +669,12 @@ class HistoryDag:
                 min_possible_weight=-max_possible_weight,
             )
 
+    @get_default_args(["start_func", "edge_weight_func"], positional_count=1)
     def trim_below_weight(
         self,
         max_weight,
-        start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
-        edge_weight_func: Callable[
-            [HistoryDagNode, HistoryDagNode], Weight
-        ] = parsimony_utils.hamming_edge_weight,
+        start_func: Callable[["HistoryDagNode"], Weight] = None,
+        edge_weight_func: Callable[[HistoryDagNode, HistoryDagNode], Weight] = None,
         min_possible_weight=-float("inf"),
     ):
         """Trim the dag to contain at least all the histories within the
@@ -1765,14 +1818,13 @@ class HistoryDag:
         """Deprecated name for :meth:`HistoryDag.postorder_history_accum`"""
         return self.postorder_history_accum(*args, **kwargs)
 
+    @get_default_args(["start_func", "edge_weight_func", "accum_func", "optimal_func"])
     def optimal_weight_annotate(
         self,
-        start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
-        edge_weight_func: Callable[
-            ["HistoryDagNode", "HistoryDagNode"], Weight
-        ] = parsimony_utils.hamming_edge_weight,
-        accum_func: Callable[[List[Weight]], Weight] = sum,
-        optimal_func: Callable[[List[Weight]], Weight] = min,
+        start_func: Callable[["HistoryDagNode"], Weight] = None,
+        edge_weight_func: Callable[["HistoryDagNode", "HistoryDagNode"], Weight] = None,
+        accum_func: Callable[[List[Weight]], Weight] = None,
+        optimal_func: Callable[[List[Weight]], Weight] = None,
         **kwargs,
     ) -> Weight:
         r"""A template method for finding the optimal tree weight in the DAG.
@@ -1799,14 +1851,13 @@ class HistoryDag:
             accum_func,
         )
 
+    @get_default_args(["start_func", "edge_weight_func", "accum_func", "optimal_func"])
     def count_optimal_histories(
         self,
-        start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
-        edge_weight_func: Callable[
-            ["HistoryDagNode", "HistoryDagNode"], Weight
-        ] = parsimony_utils.hamming_edge_weight,
-        accum_func: Callable[[List[Weight]], Weight] = sum,
-        optimal_func: Callable[[List[Weight]], Weight] = min,
+        start_func: Callable[["HistoryDagNode"], Weight] = None,
+        edge_weight_func: Callable[["HistoryDagNode", "HistoryDagNode"], Weight] = None,
+        accum_func: Callable[[List[Weight]], Weight] = None,
+        optimal_func: Callable[[List[Weight]], Weight] = None,
         eq_func: Callable[[Weight, Weight], bool] = lambda w1, w2: w1 == w2,
         **kwargs,
     ):
@@ -1854,13 +1905,12 @@ class HistoryDag:
             _between_clade_accum,
         )
 
+    @get_default_args(["start_func", "edge_weight_func", "accum_func"])
     def weight_count(
         self,
-        start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
-        edge_weight_func: Callable[
-            ["HistoryDagNode", "HistoryDagNode"], Weight
-        ] = parsimony_utils.hamming_edge_weight,
-        accum_func: Callable[[List[Weight]], Weight] = sum,
+        start_func: Callable[["HistoryDagNode"], Weight] = None,
+        edge_weight_func: Callable[["HistoryDagNode", "HistoryDagNode"], Weight] = None,
+        accum_func: Callable[[List[Weight]], Weight] = None,
         **kwargs,
     ):
         r"""A template method for counting weights of trees expressed in the
@@ -1868,9 +1918,12 @@ class HistoryDag:
 
         Weights must be hashable, but may otherwise be of arbitrary type.
 
+        Default arguments are contained in this HistoryDag subclass's _default_args
+        variable, and are documented in the subclass docstring.
+
         Args:
             start_func: A function which assigns a weight to each leaf node
-            edge_func: A function which assigns a weight to pairs of labels, with the
+            edge_weight_func: A function which assigns a weight to pairs of labels, with the
                 parent node label the first argument
             accum_func: A way to 'add' a list of weights together
 
@@ -1884,11 +1937,12 @@ class HistoryDag:
             lambda x: counter_prod(x, accum_func),
         )
 
+    @get_default_args(["start_func", "edge_weight_func", "accum_func"])
     def weight_range_annotate(
         self,
-        edge_weight_func: Callable[["HistoryDagNode", "HistoryDagNode"], Weight],
-        start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
-        accum_func: Callable[[List[Weight]], Weight] = sum,
+        start_func: Callable[["HistoryDagNode"], Weight] = None,
+        edge_weight_func: Callable[["HistoryDagNode", "HistoryDagNode"], Weight] = None,
+        accum_func: Callable[[List[Weight]], Weight] = None,
         min_func: Callable[[List[Weight]], Weight] = min,
         max_func: Callable[[List[Weight]], Weight] = max,
         **kwargs,
@@ -1900,9 +1954,9 @@ class HistoryDag:
         a tuple containing the minimum and maximum weights of any sub-history beneath that node.
 
         Args:
-            edge_func: A function which assigns a weight to pairs of labels, with the
-                parent node label the first argument
             start_func: A function which assigns a weight to each leaf node
+            edge__weight_func: A function which assigns a weight to pairs of labels, with the
+                parent node label the first argument
             accum_func: A way to 'add' a list of weights together
             min_func: A function which takes a list of weights and returns their "minimum"
             max_func: A function which takes a list of weights and returns their "maximum"
@@ -2188,22 +2242,13 @@ class HistoryDag:
             sum,
         )
 
+    @get_default_args(["start_func", "edge_func", "accum_func", "expand_func"])
     def weight_counts_with_ambiguities(
         self,
-        start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
-        edge_func: Callable[[Label, Label], Weight] = lambda l1, l2: (
-            0
-            if isinstance(l1, UALabel)
-            else parsimony_utils.default_nt_transitions.weighted_hamming_distance(
-                l1.sequence, l2.sequence
-            )
-        ),
-        accum_func: Callable[[List[Weight]], Weight] = sum,
-        expand_func: Callable[
-            [Label], Iterable[Label]
-        ] = parsimony_utils.default_nt_transitions.ambiguity_map.get_sequence_resolution_func(
-            "sequence"
-        ),
+        start_func: Callable[["HistoryDagNode"], Weight] = None,
+        edge_func: Callable[[Label, Label], Weight] = None,
+        accum_func: Callable[[List[Weight]], Weight] = None,
+        expand_func: Callable[[Label], Iterable[Label]] = None,
     ):
         r"""Template method for counting tree weights in the DAG, with exploded
         labels. Like :meth:`HistoryDag.weight_count`, but creates dictionaries
@@ -2512,14 +2557,13 @@ class HistoryDag:
             normalize_num = n1 * n2
         return sum_pairwise_distance / max(1, normalize_num)
 
+    @get_default_args(["start_func", "edge_weight_func", "accum_func", "optimal_func"])
     def trim_optimal_weight(
         self,
-        start_func: Callable[["HistoryDagNode"], Weight] = lambda n: 0,
-        edge_weight_func: Callable[
-            [HistoryDagNode, HistoryDagNode], Weight
-        ] = parsimony_utils.hamming_edge_weight,
-        accum_func: Callable[[List[Weight]], Weight] = sum,
-        optimal_func: Callable[[List[Weight]], Weight] = min,
+        start_func: Callable[["HistoryDagNode"], Weight] = None,
+        edge_weight_func: Callable[[HistoryDagNode, HistoryDagNode], Weight] = None,
+        accum_func: Callable[[List[Weight]], Weight] = None,
+        optimal_func: Callable[[List[Weight]], Weight] = None,
         # max_weight: Weight = None,
         eq_func: Callable[[Weight, Weight], bool] = lambda w1, w2: w1 == w2,
     ) -> Weight:
@@ -2762,11 +2806,12 @@ class HistoryDag:
                     dagnodes[nodecopy] = nodecopy
             self.__init__(history_dag_from_nodes(dict(dagnodes)).dagroot)
 
+    @get_default_args(["edge_weight_func"], positional_count=1)
     def insert_node(
         self,
         new_leaf_id,
         id_name: str = "sequence",
-        dist: Callable[
+        edge_weight_func: Callable[
             [HistoryDagNode, HistoryDagNode], Weight
         ] = parsimony_utils.hamming_edge_weight,
     ):
@@ -2894,7 +2939,7 @@ class HistoryDag:
             incompatible_nodes_so_far = set(postorder)
             while len(incompatible_nodes_so_far) > 0:
                 min_dist_nodes = find_min_dist_nodes(
-                    new_node, incompatible_nodes_so_far, dist
+                    new_node, incompatible_nodes_so_far, edge_weight_func
                 )
                 for other_node in min_dist_nodes:
                     if other_node in incompatible_nodes_so_far:

--- a/historydag/mutation_annotated_dag.py
+++ b/historydag/mutation_annotated_dag.py
@@ -10,15 +10,12 @@ import functools
 from frozendict import frozendict
 from historydag.dag import HistoryDag, HistoryDagNode, UANode, EdgeSet
 import historydag.utils
-from historydag.utils import Weight
 from historydag.compact_genome import (
     CompactGenome,
     compact_genome_from_sequence,
     cg_diff,
 )
 from historydag.parsimony_utils import (
-    hamming_cg_edge_weight,
-    hamming_cg_edge_weight_ambiguous_leaves,
     compact_genome_hamming_distance_countfuncs,
     leaf_ambiguous_compact_genome_hamming_distance_countfuncs,
 )
@@ -74,7 +71,16 @@ class CGHistoryDag(HistoryDag):
         ]
     }
 
+    _default_args = frozendict(compact_genome_hamming_distance_countfuncs) | {
+        "start_func": (lambda n: 0),
+        "optimal_func": min,
+    }
     # #### Overridden Methods ####
+
+    def weight_counts_with_ambiguities(self, *args, **kwargs):
+        raise NotImplementedError(
+            "This method is only implemented for DAGs with node labels containing sequences."
+        )
 
     def summary(self):
         HistoryDag.summary(self)
@@ -82,65 +88,6 @@ class CGHistoryDag(HistoryDag):
             **compact_genome_hamming_distance_countfuncs
         )
         print(f"Parsimony score range {min_pars} to {max_pars}")
-
-    def weight_count(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.weight_count`"""
-        return super().weight_count(*args, edge_weight_func=edge_weight_func, **kwargs)
-
-    def optimal_weight_annotate(
-        self, *args, edge_weight_func=hamming_cg_edge_weight, **kwargs
-    ) -> Weight:
-        """See :meth:`historydag.HistoryDag.optimal_weight_annotate`"""
-        return super().optimal_weight_annotate(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def trim_optimal_weight(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight,
-        **kwargs,
-    ) -> Weight:
-        """See :meth:`historydag.HistoryDag.trim_optimal_weight`"""
-        return super().trim_optimal_weight(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def trim_within_range(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.trim_within_range`"""
-        return super().trim_within_range(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def trim_below_weight(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.trim_below_weight`"""
-        return super().trim_below_weight(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def insert_node(
-        self,
-        *args,
-        dist=hamming_cg_edge_weight,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.insert_node`"""
-        return super().insert_node(*args, dist=dist, **kwargs)
 
     def hamming_parsimony_count(self):
         """See :meth:`historydag.sequence_dag.SequenceHistoryDag.hamming_parsim
@@ -358,67 +305,14 @@ class AmbiguousLeafCGHistoryDag(CGHistoryDag):
     'reference'.
     """
 
+    _default_args = frozendict(
+        leaf_ambiguous_compact_genome_hamming_distance_countfuncs
+    ) | {
+        "start_func": (lambda n: 0),
+        "optimal_func": min,
+    }
+
     # #### Overridden Methods ####
-
-    def weight_count(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.weight_count`"""
-        return super().weight_count(*args, edge_weight_func=edge_weight_func, **kwargs)
-
-    def optimal_weight_annotate(
-        self, *args, edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves, **kwargs
-    ) -> Weight:
-        """See :meth:`historydag.HistoryDag.optimal_weight_annotate`"""
-        return super().optimal_weight_annotate(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def trim_optimal_weight(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ) -> Weight:
-        """See :meth:`historydag.HistoryDag.trim_optimal_weight`"""
-        return super().trim_optimal_weight(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def trim_within_range(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.trim_within_range`"""
-        return super().trim_within_range(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def trim_below_weight(
-        self,
-        *args,
-        edge_weight_func=hamming_cg_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.trim_below_weight`"""
-        return super().trim_below_weight(
-            *args, edge_weight_func=edge_weight_func, **kwargs
-        )
-
-    def insert_node(
-        self,
-        *args,
-        dist=hamming_cg_edge_weight_ambiguous_leaves,
-        **kwargs,
-    ):
-        """See :meth:`historydag.HistoryDag.insert_node`"""
-        return super().insert_node(*args, dist=dist, **kwargs)
-
     def hamming_parsimony_count(self):
         """See :meth:`historydag.sequence_dag.SequenceHistoryDag.hamming_parsim
         ony_count`"""

--- a/historydag/parsimony_utils.py
+++ b/historydag/parsimony_utils.py
@@ -726,13 +726,8 @@ This edge weight function allows leaf nodes to have ambiguous compact
 genomes.
 """
 
-hamming_distance_countfuncs = AddFuncDict(
-    {
-        "start_func": lambda n: 0,
-        "edge_weight_func": hamming_edge_weight,
-        "accum_func": sum,
-    },
-    name="HammingParsimony",
+hamming_distance_countfuncs = default_nt_transitions.get_weighted_parsimony_countfuncs(
+    "sequence", leaf_ambiguities=False
 )
 """Provides functions to count hamming distance parsimony when leaf sequences
 may be ambiguous.
@@ -740,13 +735,10 @@ may be ambiguous.
 For use with :meth:`historydag.AmbiguousLeafSequenceHistoryDag.weight_count`.
 """
 
-leaf_ambiguous_hamming_distance_countfuncs = AddFuncDict(
-    {
-        "start_func": lambda n: 0,
-        "edge_weight_func": hamming_edge_weight_ambiguous_leaves,
-        "accum_func": sum,
-    },
-    name="HammingParsimony",
+leaf_ambiguous_hamming_distance_countfuncs = (
+    default_nt_transitions.get_weighted_parsimony_countfuncs(
+        "sequence", leaf_ambiguities=False
+    )
 )
 """Provides functions to count hamming distance parsimony when leaf sequences
 may be ambiguous.


### PR DESCRIPTION
This PR proposes a convenient interface for defining default arguments for weight counting-related methods of HistoryDag subclasses.

* Default arguments are read from a subclass's `_default_args` dictionary, and applied by the method decorator `dag.get_default_args`
* Using `get_default_args` on a method causes positional arguments to be positional-only, and keyword arguments to be keyword-only
* `get_default_args` takes a list of arguments to be potentially overridden, as well as a count of (non-self) positional arguments.
* the convenience function `dag.convert` is added as a wrapper for `HistoryDag.from_history_dag`.