### PR TITLE
Generalized node support

### DIFF
--- a/historydag/__init__.py
+++ b/historydag/__init__.py
@@ -15,6 +15,7 @@ from . import _version
 
 from . import (  # noqa
     utils,
+    parsimony_utils,
     parsimony,
     mutation_annotated_dag,
     sequence_dag,
@@ -28,3 +29,18 @@ except ModuleNotFoundError:
     pass
 
 __version__ = _version.get_versions()["version"]
+
+# patching deprecated call paths here to avoid circular import in utils:
+utils.sequence_resolutions_count = utils._deprecate_message(
+    "`utils.sequence_resolutions_count` deprecated. Use the `get_sequence_resolution_count_func` method from an "
+    "appropriate `parsimony_utils.AmbiguityMap` object`"
+)(
+    parsimony_utils.standard_nt_ambiguity_map.get_sequence_resolution_count_func(
+        "sequence"
+    )
+)
+
+utils.sequence_resolutions = utils._deprecate_message(
+    "`utils.sequence_resolutions` deprecated. Use the `get_sequence_resolution_func` method from an "
+    "appropriate `parsimony_utils.AmbiguityMap` object`"
+)(parsimony_utils.standard_nt_ambiguity_map.get_sequence_resolution_func("sequence"))

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -2894,7 +2894,7 @@ class HistoryDag:
 
     def node_probabilities(
         self,
-        log_probabilities=True,
+        log_probabilities=False,
         edge_weight_func=None,
         normalize_edgeweights=None,
         accum_func=None,
@@ -2982,7 +2982,7 @@ class HistoryDag:
 
     def edge_probabilities(
         self,
-        log_probabilities=True,
+        log_probabilities=False,
         edge_weight_func=None,
         normalize_edgeweights=None,
         accum_func=None,
@@ -3019,7 +3019,7 @@ class HistoryDag:
     def probability_annotate(
         self,
         edge_weight_func,
-        log_probabilities=True,
+        log_probabilities=False,
         normalize_edgeweights=None,
         accum_func=None,
         aggregate_func=None,

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -2217,7 +2217,7 @@ class HistoryDag:
         """Counts the number of trees each node takes part in.
 
         For node supports with respect to a uniform distribution on trees, use
-        :meth:`HistoryDag.uniform_annotate` and :meth:`HistoryDag.node_probabilities`.
+        :meth:`HistoryDag.uniform_distribution_annotate` and :meth:`HistoryDag.node_probabilities`.
 
         Args:
             collapse: A flag that when set to true, treats nodes as clade unions and
@@ -3078,6 +3078,12 @@ class HistoryDag:
         )
 
     def natural_distribution_annotate(self, log_probabilities=False):
+        """Set edge probabilities to 1/n, where n is the count of edges
+        descending from the corresponding node-clade pair.
+
+        This induces the 'natural' distribution on histories, determined
+        by the topology of the dag.
+        """
         if log_probabilities:
 
             def edgeweights(weightlist):
@@ -3098,7 +3104,7 @@ class HistoryDag:
             log_probabilities=log_probabilities,
         )
 
-    def uniform_annotate(self, log_probabilities=False):
+    def uniform_distribution_annotate(self, log_probabilities=False):
         """Adjust edge probabilities so that the DAG expresses a uniform
         distribution on expressed trees.
 
@@ -3111,8 +3117,9 @@ class HistoryDag:
         )
 
     def make_uniform(self):
-        """Deprecated name for :meth:`HistoryDag.uniform_annotate`"""
-        return self.uniform_annotate()
+        """Deprecated name for
+        :meth:`HistoryDag.uniform_distribution_annotate`"""
+        return self.uniform_distribution_annotate()
 
     # #### End probability methods ####
 

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -2095,9 +2095,9 @@ class HistoryDag:
         """
         return self.unlabel().count_histories()
 
-    def count_trees(self):
+    def count_trees(self, *args, **kwargs):
         """Deprecated name for :meth:`count_histories`"""
-        return self.count_histories()
+        return self.count_histories(*args, **kwargs)
 
     def count_histories(
         self,

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -2,7 +2,6 @@
 
 import pickle
 from functools import wraps
-import scipy
 from math import log, exp
 import graphviz as gv
 import ete3
@@ -2856,7 +2855,7 @@ class HistoryDag:
             self, log_probabilities=log_probabilities
         )
         if log_probabilities:
-            aggregate_func = scipy.special.logsumexp
+            aggregate_func = utils.logsumexp
         else:
             aggregate_func = sum
         return self.optimal_weight_annotate(**kwargs, optimal_func=aggregate_func)
@@ -2922,7 +2921,7 @@ class HistoryDag:
 
         ua_node_val = get_option(ua_node_val, 0, 1)
         accum_func = get_option(accum_func, sum, prod)
-        aggregate_func = get_option(aggregate_func, scipy.special.logsumexp, sum)
+        aggregate_func = get_option(aggregate_func, utils.logsumexp, sum)
 
         self.recompute_parents()
         node_probs = {self.dagroot: ua_node_val}
@@ -2997,7 +2996,7 @@ class HistoryDag:
                     return if_not_log
 
         def normalize_log_edgeweights(weightlist):
-            normalization = scipy.special.logsumexp(weightlist)
+            normalization = utils.logsumexp(weightlist)
             res = [weight - normalization for weight in weightlist]
             return res
 
@@ -3005,7 +3004,7 @@ class HistoryDag:
             normalize_edgeweights, normalize_log_edgeweights, None
         )
         accum_func = get_option(accum_func, sum, prod)
-        aggregate_func = get_option(aggregate_func, scipy.special.logsumexp, sum)
+        aggregate_func = get_option(aggregate_func, utils.logsumexp, sum)
         start_func = get_option(start_func, lambda n: 0, lambda n: 1)
 
         return self.postorder_history_accum(

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -829,7 +829,9 @@ def prod(ls: list):
 
 
 def logsumexp(ls: List[float]):
-    """An implementation of logsumexp, similar to Scipy's."""
+    """A numerically stable implementation of logsumexp, similar to Scipy's."""
+    if len(ls) == 1:
+        return ls[0]
     max_log = max(ls)
     if not isfinite(max_log):
         max_log = 0

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -7,6 +7,7 @@ from functools import wraps
 import operator
 from collections import UserDict
 from decimal import Decimal
+from warnings import warn
 from typing import (
     List,
     Any,
@@ -964,3 +965,15 @@ def load_fasta(fastapath):
             else:
                 fasta_records[-1][-1] += line.strip()
     return dict(fasta_records)
+
+
+def _deprecate_message(message):
+    def _deprecate(func):
+        @wraps(func)
+        def deprecated(*args, **kwargs):
+            warn(message)
+            return func(*args, **kwargs)
+
+        return deprecated
+
+    return _deprecate

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -1,7 +1,7 @@
 """Utility functions and classes for working with HistoryDag objects."""
 
 import ete3
-from math import log
+from math import log, exp, isfinite
 from collections import Counter
 from functools import wraps
 import operator
@@ -826,6 +826,17 @@ def prod(ls: list):
     else:
         accum = 1
     return accum
+
+
+def logsumexp(ls: List[float]):
+    """An implementation of logsumexp, similar to Scipy's."""
+    max_log = max(ls)
+    if not isfinite(max_log):
+        max_log = 0
+
+    exponentiated = [exp(a - max_log) for a in ls]
+    shifted_log_sum = log(sum(exponentiated))
+    return shifted_log_sum + max_log
 
 
 # Unfortunately these can't be made with a class factory (just a bit too meta for Python)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -3,12 +3,12 @@ import pickle
 import historydag
 import historydag.dag as hdag
 import historydag.utils as dagutils
+from historydag.utils import logsumexp
 from collections import Counter, namedtuple
 import pytest
 import random
 from historydag import parsimony_utils
 from math import exp
-from scipy.special import logsumexp
 
 
 def normalize_counts(counter):

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -7,6 +7,8 @@ from collections import Counter, namedtuple
 import pytest
 import random
 from historydag import parsimony_utils
+from math import exp
+from scipy.special import logsumexp
 
 
 def normalize_counts(counter):
@@ -818,3 +820,79 @@ def test_intersection():
 
     assert len(idag | dag1) == len(dag1)
     assert len(idag | dag2) == len(dag2)
+
+
+def test_node_support():
+    dag = dags[-1].copy()
+    # first compare to uniform:
+    dag.probability_annotate(lambda n1, n2: 1, log_probabilities=False)
+    nd = dag.node_probabilities(log_probabilities=False)
+    od = dag.count_nodes()
+    hists = dag.count_histories()
+    od = {n: count / hists for n, count in od.items()}
+    for node in dag.postorder():
+        assert is_close(nd[node], od[node], tol=0.0001)
+
+    # now try log version for uniform:
+    dag.probability_annotate(lambda n1, n2: 0, log_probabilities=True)
+    nd = dag.node_probabilities(log_probabilities=True)
+    print(nd[dag.dagroot])
+    for node in dag.postorder():
+        assert is_close(exp(nd[node]), od[node], tol=0.0001)
+
+    # hamming parsimony weighted support:
+    def edge_weight_func(n1, n2):
+        if n1.is_ua_node():
+            return 1
+        else:
+            return exp(-3 * parsimony_utils.hamming_edge_weight(n1, n2))
+
+    kwargs = {
+        "accum_func": dagutils.prod,
+        "start_func": lambda n: 1,
+        "edge_weight_func": edge_weight_func,
+        "optimal_func": sum,
+    }
+
+    dag.probability_annotate(edge_weight_func, log_probabilities=False)
+    conditional_edge_probs = dag.export_edge_probabilities()
+
+    normalization_constant = dag.optimal_weight_annotate(**kwargs)
+    check_kwargs = kwargs.copy()
+    check_kwargs["edge_weight_func"] = lambda n1, n2: conditional_edge_probs[(n1, n2)]
+    for tree in dag:
+        assert is_close(
+            tree.optimal_weight_annotate(**kwargs) / normalization_constant,
+            tree.optimal_weight_annotate(**check_kwargs),
+            tol=0.00001,
+        )
+    cdag = dag.copy()
+    cdag.trim_optimal_weight()
+    print(cdag.optimal_weight_annotate(**kwargs) / normalization_constant)
+
+    # now hamming parsimony log version:
+    def edge_weight_func(n1, n2):
+        if n1.is_ua_node():
+            return 0
+        else:
+            return -3 * parsimony_utils.hamming_edge_weight(n1, n2)
+
+    kwargs = {
+        "accum_func": sum,
+        "start_func": lambda n: 0,
+        "edge_weight_func": edge_weight_func,
+        "optimal_func": logsumexp,
+    }
+
+    dag.probability_annotate(edge_weight_func, log_probabilities=True)
+    conditional_edge_probs = dag.export_edge_probabilities()
+
+    normalization_constant = dag.optimal_weight_annotate(**kwargs)
+    check_kwargs = kwargs.copy()
+    check_kwargs["edge_weight_func"] = lambda n1, n2: conditional_edge_probs[(n1, n2)]
+    for tree in dag:
+        assert is_close(
+            tree.optimal_weight_annotate(**kwargs) - normalization_constant,
+            tree.optimal_weight_annotate(**check_kwargs),
+            tol=0.00001,
+        )

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -901,7 +901,7 @@ def test_node_support():
 def test_count_nodes():
     dag = dags[-1].copy()
     node_counts = dag.count_nodes()
-    dag.uniform_annotate(log_probabilities=False)
+    dag.uniform_distribution_annotate(log_probabilities=False)
     node_supports = dag.node_probabilities(log_probabilities=False)
     n_histories = dag.count_histories()
     for node in node_counts:
@@ -915,7 +915,7 @@ def test_count_nodes():
     # now with some collapsing
     dag = dags[-1].copy()
     node_counts = dag.count_nodes(collapse=True)
-    dag.uniform_annotate(log_probabilities=False)
+    dag.uniform_distribution_annotate(log_probabilities=False)
     node_supports = dag.node_probabilities(
         log_probabilities=False, collapse_key=hdag.HistoryDagNode.clade_union
     )

--- a/tests/test_historydag.py
+++ b/tests/test_historydag.py
@@ -343,6 +343,15 @@ def test_make_uniform():
     take2norms, avg2 = normalize_counts(take2)
     assert all(is_close(norm, avg2) for norm in take2norms)
 
+    # now check that sampling with log probabilities works:
+    dag.probability_annotate(lambda n1, n2: 0, log_probabilities=True)
+    dag._check_valid()
+    take2 = Counter(
+        [dag.sample(log_probabilities=True).to_newick() for _ in range(1000)]
+    )
+    take2norms, avg2 = normalize_counts(take2)
+    assert all(is_close(norm, avg2) for norm in take2norms)
+
 
 def test_summary():
     dag = history_dag_from_newicks(


### PR DESCRIPTION
Previously, we could compute node support only with respect to a uniform distribution on histories in the DAG. This PR allows node support to be computed with respect to the distribution expressed by downward conditional edge probabilities annotated on DAG edges, and provides tools for setting these edge probabilities to express an exponential distribution on arbitrary edge weights.

## Questions remaining:
* All methods using probabilities now take an argument `log_probabilities` which determines whether log probabilities will be used. For some methods, this argument only determines how existing probabilities on the DAG should be interpreted. However, whether current probabilities are log-probabilities could be recorded by a flag on the DAG. Would this be better?
* Is there a way to make computations on (even log-) probabilities more numerically stable?