### PR TITLE
One Sided RF distances

### DIFF
--- a/historydag/beast_loader.py
+++ b/historydag/beast_loader.py
@@ -34,7 +34,6 @@ def dag_from_beast_trees(
         include_sequence_names_in_labels: If True, augment leaf node labels with a ``name`` attribute
             containing the name of the corresponding sequence. Useful for distinguishing leaves when
             observed sequences are not unique.
-
     """
     dp_trees = load_beast_trees(
         beast_xml_file,

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -2296,6 +2296,8 @@ class HistoryDag:
         self,
         history: "HistoryDag",
         rooted: bool = False,
+        one_sided: str = None,
+        one_sided_coefficients: Tuple[float, float] = (1, 1),
         optimal_func: Callable[[List[Weight]], Weight] = min,
     ):
         """Trims this history DAG to the optimal (min or max) RF distance to a
@@ -2309,13 +2311,20 @@ class HistoryDag:
         instead of making multiple calls to this method with the same reference
         history.
         """
-        kwargs = utils.make_rfdistance_countfuncs(history, rooted=rooted)
+        kwargs = utils.make_rfdistance_countfuncs(
+            history,
+            rooted=rooted,
+            one_sided=one_sided,
+            one_sided_coefficients=one_sided_coefficients
+        )
         return self.trim_optimal_weight(**kwargs, optimal_func=optimal_func)
 
     def optimal_rf_distance(
         self,
         history: "HistoryDag",
         rooted: bool = False,
+        one_sided: str = None,
+        one_sided_coefficients: Tuple[float, float] = (1, 1),
         optimal_func: Callable[[List[Weight]], Weight] = min,
     ):
         """Returns the optimal (min or max) RF distance to a given history.
@@ -2326,10 +2335,21 @@ class HistoryDag:
         instead of making multiple calls to this method with the same reference
         history.
         """
-        kwargs = utils.make_rfdistance_countfuncs(history, rooted=rooted)
+        kwargs = utils.make_rfdistance_countfuncs(
+            history,
+            rooted=rooted,
+            one_sided=one_sided,
+            one_sided_coefficients=one_sided_coefficients
+        )
         return self.optimal_weight_annotate(**kwargs, optimal_func=optimal_func)
 
-    def count_rf_distances(self, history: "HistoryDag", rooted: bool = False):
+    def count_rf_distances(
+        self,
+        history: "HistoryDag",
+        rooted: bool = False,
+        one_sided: str = None,
+        one_sided_coefficients: Tuple[float, float] = (1, 1),
+    ):
         """Returns a Counter containing all RF distances to a given history.
 
         The given history must be on the same taxa as all trees in the DAG.
@@ -2339,7 +2359,12 @@ class HistoryDag:
         instead of making multiple calls to this method with the same reference
         history.
         """
-        kwargs = utils.make_rfdistance_countfuncs(history, rooted=rooted)
+        kwargs = utils.make_rfdistance_countfuncs(
+            history,
+            rooted=rooted,
+            one_sided=one_sided,
+            one_sided_coefficients=one_sided_coefficients
+        )
         return self.weight_count(**kwargs)
 
     def count_sum_rf_distances(self, reference_dag: "HistoryDag", rooted: bool = False):

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -2315,7 +2315,7 @@ class HistoryDag:
             history,
             rooted=rooted,
             one_sided=one_sided,
-            one_sided_coefficients=one_sided_coefficients
+            one_sided_coefficients=one_sided_coefficients,
         )
         return self.trim_optimal_weight(**kwargs, optimal_func=optimal_func)
 
@@ -2339,7 +2339,7 @@ class HistoryDag:
             history,
             rooted=rooted,
             one_sided=one_sided,
-            one_sided_coefficients=one_sided_coefficients
+            one_sided_coefficients=one_sided_coefficients,
         )
         return self.optimal_weight_annotate(**kwargs, optimal_func=optimal_func)
 
@@ -2363,7 +2363,7 @@ class HistoryDag:
             history,
             rooted=rooted,
             one_sided=one_sided,
-            one_sided_coefficients=one_sided_coefficients
+            one_sided_coefficients=one_sided_coefficients,
         )
         return self.weight_count(**kwargs)
 

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -541,7 +541,12 @@ log_natural_probability_funcs = AddFuncDict(
 according to the natural distribution induced by the DAG topology."""
 
 
-def sum_rfdistance_funcs(reference_dag: "HistoryDag"):
+def sum_rfdistance_funcs(
+    reference_dag: "HistoryDag",
+    rooted: bool = False,
+    one_sided: str = None,
+    one_sided_coefficients: Tuple[float, float] = (1, 1),
+):
     """Provides functions to compute the sum over all histories in the provided
     reference DAG, of rooted RF distances to those histories.
 
@@ -559,6 +564,8 @@ def sum_rfdistance_funcs(reference_dag: "HistoryDag"):
     The weights are represented by an IntState object and are shifted by a constant K,
     which is the sum of number of clades in each tree in the DAG.
     """
+    # TODO rooted is not used
+    # TODO one_sided and one_sided_coefficients not used
     N = reference_dag.count_nodes(collapse=True)
 
     # Remove the UA node clade union from N

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -665,27 +665,28 @@ def make_rfdistance_countfuncs(
     of the IntState is computed as `a + sign(b) + |B|`, which on the UA node of the hDAG gives RF distance.
     """
 
-    rf_type_suffix = 'distance'
-    if one_sided_coefficients != (1,1):
-        rf_type_suffix = 'nonstandard'
+    rf_type_suffix = "distance"
+    if one_sided_coefficients != (1, 1):
+        rf_type_suffix = "nonstandard"
 
     if one_sided is None:
         pass
-    elif one_sided.lower() == 'left':
+    elif one_sided.lower() == "left":
         one_sided_coefficients = (1, 0)
-        one_sided_suffix = 'left_difference'
-    elif one_sided.lower() == 'right':
+        rf_type_suffix = "left_difference"
+    elif one_sided.lower() == "right":
         one_sided_coefficients = (0, 1)
-        one_sided_suffix = 'right_difference'
+        rf_type_suffix = "right_difference"
     else:
-        raise ValueError(f"Argument `one_sided` must have value 'left', 'right', or None, not {one_sided}")
+        raise ValueError(
+            f"Argument `one_sided` must have value 'left', 'right', or None, not {one_sided}"
+        )
 
     s, t = one_sided_coefficients
 
     taxa = frozenset(n.label for n in ref_tree.get_leaves())
 
     if not rooted:
-        # TODO sidedness not tested for rooted
 
         def split(node):
             cu = node.clade_union()
@@ -742,10 +743,9 @@ def make_rfdistance_countfuncs(
                     summer(w.state for w in wlist)
                 ),
             },
-            name="RF_unrooted_distance",
+            name="RF_unrooted_distance_" + rf_type_suffix,
         )
     else:
-        # TODO sidedness not tested for unrooted
         ref_cus = frozenset(
             node.clade_union() for node in ref_tree.preorder(skip_ua_node=True)
         )

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -487,11 +487,24 @@ def test_remove_label_fields():
     assert old_fieldset == new_fieldset
 
 
+# ############# RF Distance Tests: ###############
 def rooted_rf_distance(history1, history2):
     cladeset1 = {n.clade_union() for n in history1.preorder(skip_ua_node=True)}
     cladeset2 = {n.clade_union() for n in history2.preorder(skip_ua_node=True)}
     return len(cladeset1 ^ cladeset2)
 
+def test_right_left_rf_add_correctly():
+    # In both the rooted and unrooted cases, left and right RF distances should
+    # sum to the normal RF distance.
+    for dag in dags:
+        ref_tree = dag.sample()
+        left_kwargs = dagutils.make_rfdistance_countfuncs(ref_tree, rooted=True, one_sided='left')
+        right_kwargs = dagutils.make_rfdistance_countfuncs(ref_tree, rooted=True, one_sided='left')
+        kwargs = dagutils.make_rfdistance_countfuncs(ref_tree, rooted=True)
+
+        assert Counter((tree.optimal_weight_annotate(**left_kwargs) + 
+                       tree.optimal_weight_annotate(**right_kwargs))
+                       for tree in dag) == dag.weight_count(**kwargs)
 
 def test_rf_rooted_distances():
     for dag in dags:
@@ -590,6 +603,7 @@ def test_optimal_sum_rf_distance():
             calculated_sum = tree.optimal_sum_rf_distance(dag)
             assert calculated_sum == expected_sum
 
+# ############# END RF Distance Tests: ###############
 
 def test_trim_range():
     for curr_dag in [dags[-1], cdags[-1]]:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -493,18 +493,30 @@ def rooted_rf_distance(history1, history2):
     cladeset2 = {n.clade_union() for n in history2.preorder(skip_ua_node=True)}
     return len(cladeset1 ^ cladeset2)
 
+
 def test_right_left_rf_add_correctly():
     # In both the rooted and unrooted cases, left and right RF distances should
     # sum to the normal RF distance.
     for rooted in (True, False):
         for dag in dags:
             ref_tree = dag.sample()
-            left_kwargs = dagutils.make_rfdistance_countfuncs(ref_tree, rooted=rooted, one_sided='left')
-            right_kwargs = dagutils.make_rfdistance_countfuncs(ref_tree, rooted=rooted, one_sided='right')
+            left_kwargs = dagutils.make_rfdistance_countfuncs(
+                ref_tree, rooted=rooted, one_sided="left"
+            )
+            right_kwargs = dagutils.make_rfdistance_countfuncs(
+                ref_tree, rooted=rooted, one_sided="right"
+            )
             kwargs = dagutils.make_rfdistance_countfuncs(ref_tree, rooted=rooted)
 
             for tree in dag:
-                assert tree.optimal_weight_annotate(**left_kwargs) + tree.optimal_weight_annotate(**right_kwargs) == tree.optimal_weight_annotate(**kwargs)
+                assert tree.optimal_weight_annotate(
+                    **left_kwargs
+                ) + tree.optimal_weight_annotate(
+                    **right_kwargs
+                ) == tree.optimal_weight_annotate(
+                    **kwargs
+                )
+
 
 def test_right_left_rf_collapse():
     """
@@ -533,16 +545,23 @@ def test_right_left_rf_collapse():
                     continue
                 else:
                     count += 1
-                    left_kwargs = dagutils.make_rfdistance_countfuncs(ctree, rooted=rooted, one_sided='left')
+                    left_kwargs = dagutils.make_rfdistance_countfuncs(
+                        ctree, rooted=rooted, one_sided="left"
+                    )
                     assert tree.optimal_weight_annotate(**left_kwargs) == 0
-                    oleft_kwargs = dagutils.make_rfdistance_countfuncs(tree, rooted=rooted, one_sided='left')
+                    oleft_kwargs = dagutils.make_rfdistance_countfuncs(
+                        tree, rooted=rooted, one_sided="left"
+                    )
                     assert ctree.optimal_weight_annotate(**oleft_kwargs) > 0
-                    right_kwargs = dagutils.make_rfdistance_countfuncs(ctree, rooted=rooted, one_sided='right')
+                    right_kwargs = dagutils.make_rfdistance_countfuncs(
+                        ctree, rooted=rooted, one_sided="right"
+                    )
                     assert tree.optimal_weight_annotate(**right_kwargs) > 0
-                    oright_kwargs = dagutils.make_rfdistance_countfuncs(tree, rooted=rooted, one_sided='right')
+                    oright_kwargs = dagutils.make_rfdistance_countfuncs(
+                        tree, rooted=rooted, one_sided="right"
+                    )
                     assert ctree.optimal_weight_annotate(**oright_kwargs) == 0
         assert count > 0
-
 
 
 def test_rf_rooted_distances():
@@ -642,7 +661,9 @@ def test_optimal_sum_rf_distance():
             calculated_sum = tree.optimal_sum_rf_distance(dag)
             assert calculated_sum == expected_sum
 
+
 # ############# END RF Distance Tests: ###############
+
 
 def test_trim_range():
     for curr_dag in [dags[-1], cdags[-1]]:


### PR DESCRIPTION
This PR includes @clarisw's contributions of computation of one-sided RF distances in the history DAG. I rearranged the implementation so that all of the new code is contained in `utils.make_rfdistance_countfuncs`. Left and right one-sided RF distances are available through the new keyword argument `one_sided`, which takes either `left`, `right`, or `None`. The docstring explains what these options mean, hopefully in enough detail to figure out which one is needed.

I also extended these additions to the sum RF distance countfuncs function in utils, as well as the sum and average RF distance methods on the whole DAG.

In addition, all dag methods for RF distance and now accept and forward these new keyword arguments to the appropriate countfunc function. All methods are tested as before, first using a ground-truth method (counting clades or ete's RF distance implementation) and building up transitively to the whole-dag sums, but now each step includes checks for left, right, and standard rooted-and-unrooted-RF distances