### PR TITLE
IntState vs FloatState fix for RF distances

### DIFF
--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -2500,7 +2500,7 @@ class HistoryDag:
         Note that when computing one-sided distances, or when the one_sided_coefficients values are not
         equal, this 'distance' is no longer symmetric.
         """
-        s, t, _, _= utils._process_rf_one_sided_coefficients(
+        s, t, _, _ = utils._process_rf_one_sided_coefficients(
             one_sided, one_sided_coefficients
         )
 

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -2500,7 +2500,7 @@ class HistoryDag:
         Note that when computing one-sided distances, or when the one_sided_coefficients values are not
         equal, this 'distance' is no longer symmetric.
         """
-        s, t, _ = utils._process_rf_one_sided_coefficients(
+        s, t, _, _= utils._process_rf_one_sided_coefficients(
             one_sided, one_sided_coefficients
         )
 


### PR DESCRIPTION
@harryrichman pointed out that if `one_sided_coefficients` are not integers, the RF distance won't be integer-valued, but will be coerced to an integer because it's put in an IntState object by the RF distance functions. This fixes that issue, using FloatState if necessary, but keeping IntState when possible.