### PR TITLE
Binary tree resolutions and fast sampling

### DIFF
--- a/historydag/beast_loader.py
+++ b/historydag/beast_loader.py
@@ -1,8 +1,11 @@
-"""Provides utilities for parsing BEAST outputs and storing sampled trees in HistoryDag objects.
+"""Provides utilities for parsing BEAST outputs and storing sampled trees in
+HistoryDag objects.
+
 This module uses ``dendropy`` to parse the newick strings found in BEAST output files, since
 ``ete3`` is incompatible with newick strings containing commas other than those which separate
 nodes. The ``historydag`` package does not require ``dendropy``, so to use this module, you must
-manually ensure that ``dendropy`` is installed in your environment."""
+manually ensure that ``dendropy`` is installed in your environment.
+"""
 
 import historydag as hdag
 from warnings import warn

--- a/historydag/compact_genome.py
+++ b/historydag/compact_genome.py
@@ -1,8 +1,12 @@
-"""This module provides a CompactGenome class, intended as a convenient and compact representation of
-a nucleotide sequence as a collection of mutations relative to a reference sequence. This object also
-provides methods to conveniently mutate CompactGenome objects according to a list of mutations, produce
-mutations defining the difference between two CompactGenome objects, and efficiently access the base
-at a site (or the entire sequence, as a string) implied by a CompactGenome.
+"""This module provides a CompactGenome class, intended as a convenient and
+compact representation of a nucleotide sequence as a collection of mutations
+relative to a reference sequence.
+
+This object also provides methods to conveniently mutate CompactGenome
+objects according to a list of mutations, produce mutations defining the
+difference between two CompactGenome objects, and efficiently access the
+base at a site (or the entire sequence, as a string) implied by a
+CompactGenome.
 """
 
 from frozendict import frozendict

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -101,11 +101,15 @@ def convert(dag, newclass):
 # Preorder tree creation class
 
 TreeBuilderNode = Any
+
+
 class PreorderTreeBuilder:
-    """Any class implementing a PreorderTreeBuilder interface can be used as a tree sample
-    constructor in :meth:`HistoryDag.fast_sample`. Subclasses implementing this interface may
-    implement an arbitrary constructor interface, as the user will be responsible for creating
-    instances to be used for sampling. In addition, subclasses must implement the following methods:
+    """Any class implementing a PreorderTreeBuilder interface can be used as a
+    tree sample constructor in :meth:`HistoryDag.fast_sample`. Subclasses
+    implementing this interface may implement an arbitrary constructor
+    interface, as the user will be responsible for creating instances to be
+    used for sampling. In addition, subclasses must implement the following
+    methods:
 
     Methods:
         add_node: This method must accept a :class:HistoryDagNode object ``dag_node`` and, optionally
@@ -119,11 +123,11 @@ class PreorderTreeBuilder:
             sampled tree, after any necessary clean-up or final tree construction steps. Its
             return value is the return value of :meth:`HistoryDag.fast_sample`.
     """
+
     pass
 
 
 class EteTreeBuilder(PreorderTreeBuilder):
-
     def __init__(
         self,
         name_func: Callable[[HistoryDagNode], str] = lambda n: "unnamed",
@@ -138,6 +142,7 @@ class EteTreeBuilder(PreorderTreeBuilder):
 
             def feature_func(node):
                 return getattr(node.label, feature)
+
             self.feature_funcs[feature] = feature_func
 
         self.feature_funcs = tuple(self.feature_funcs.items())
@@ -163,6 +168,7 @@ class EteTreeBuilder(PreorderTreeBuilder):
 
     def get_finished_tree(self):
         return self.treeroot
+
 
 class PreorderHistoryBuilder(PreorderTreeBuilder):
     def __init__(
@@ -191,7 +197,6 @@ class PreorderHistoryBuilder(PreorderTreeBuilder):
             parent.add_edge(child)
         return self.dag_type(self.root_node)
 
-        
 
 class HistoryDag:
     r"""An object to represent a collection of internally labeled trees. A
@@ -400,9 +405,9 @@ class HistoryDag:
 
     def get_histories_by_index(self, key_iterator, tree_builder_func=None):
         """Retrieving a history by index is slow, since each retrieval requires
-        running the ``trim_optimal_weight`` method on the entire DAG to populate
-        node counts. This method instead runs that method a single time and
-        yields a history for each index yielded by ``key_iterator``.
+        running the ``trim_optimal_weight`` method on the entire DAG to
+        populate node counts. This method instead runs that method a single
+        time and yields a history for each index yielded by ``key_iterator``.
 
         Args:
             key_iterator: An iterator on desired history indices. May be consumable, as
@@ -410,7 +415,8 @@ class HistoryDag:
             tree_builder_func: A function accepting an index and returning a
                 :class:`PreorderTreeBuilder` instance to be used to build the history
                 with that index. If None (default), then tree-shaped HistoryDag objects
-                will be yielded using :class:`PreorderHistoryBuilder`."""
+                will be yielded using :class:`PreorderHistoryBuilder`.
+        """
         if tree_builder_func is None:
 
             def tree_builder_func(idx):
@@ -422,11 +428,12 @@ class HistoryDag:
             if key < 0:
                 key = length + key
             if not (key >= 0 and key < length):
-                raise IndexError(f"Invalid index {key} in DAG containing {length} histories")
+                raise IndexError(
+                    f"Invalid index {key} in DAG containing {length} histories"
+                )
             builder = tree_builder_func(key)
             self.dagroot._get_subhistory_by_subid(key, builder)
             yield builder.get_finished_tree()
-
 
     def get_label_type(self) -> type:
         """Return the type for labels on this dag's nodes."""
@@ -811,14 +818,13 @@ class HistoryDag:
 
     def fast_sample(
         self,
-        tree_builder: PreorderTreeBuilder=None,
+        tree_builder: PreorderTreeBuilder = None,
         log_probabilities=False,
     ):
-        """This is a non-recursive alternative to :meth:`HistoryDag.sample`, which is likely
-        to be slower on small DAGs, but may allow significant optimizations on large DAGs, or
-        in the case that the data format being sampled is something other than a tree-shaped
-        HistoryDag object.
-
+        """This is a non-recursive alternative to :meth:`HistoryDag.sample`,
+        which is likely to be slower on small DAGs, but may allow significant
+        optimizations on large DAGs, or in the case that the data format being
+        sampled is something other than a tree-shaped HistoryDag object.
 
         This method does not provide an edge_selector argument like :meth:`HistoryDag.sample`.
         Instead, any masking of edges should be done prior to sampling using the :meth:`HistoryDag.set_sample_mask`
@@ -827,7 +833,8 @@ class HistoryDag:
         Args:
             tree_builder: a PreorderTreeBuilder instance to handle construction of the sampled tree.
             log_probabilities: Whether edge probabilities annotated on this DAG (using, for example,
-                :meth:`HistoryDag.probability_annotate`) are on a log-scale."""
+                :meth:`HistoryDag.probability_annotate`) are on a log-scale.
+        """
         if tree_builder is None:
             tree_builder = PreorderHistoryBuilder(type(self))
 
@@ -845,7 +852,6 @@ class HistoryDag:
                 node_queue.append((child, child_repr))
 
         return tree_builder.get_finished_tree()
-
 
     def sample(
         self, edge_selector=lambda e: True, log_probabilities=False
@@ -1341,17 +1347,18 @@ class HistoryDag:
         """
         # First build a dictionary of ete3 nodes keyed by HDagNodes.
         if features is None:
-            features = list(
-                list(self.dagroot.children())[0].label._asdict().keys()
-            )
+            features = list(list(self.dagroot.children())[0].label._asdict().keys())
 
-
-        tree_builder = EteTreeBuilder(name_func=name_func, features=features, feature_funcs=feature_funcs)
+        tree_builder = EteTreeBuilder(
+            name_func=name_func, features=features, feature_funcs=feature_funcs
+        )
         nodes_to_process = [(self.dagroot, tree_builder.add_node(self.dagroot))]
         while len(nodes_to_process) > 0:
             node, node_repr = nodes_to_process.pop()
             for child in node.children():
-                nodes_to_process.append((child, tree_builder.add_node(child, parent=node_repr)))
+                nodes_to_process.append(
+                    (child, tree_builder.add_node(child, parent=node_repr))
+                )
 
         return tree_builder.get_finished_tree()
 
@@ -3110,8 +3117,9 @@ class HistoryDag:
         return {key: aggregate_func(val) for key, val in edge_probabilities.items()}
 
     def set_sample_mask(self, edge_selector, log_probabilities=False):
-        """Zero out edge weights for masked edges before calling :meth:`HistoryDag.fast_sample`.
-        This should be equivalent to passing the same edge_selector function to :meth:`HistoryDag.sample`.
+        """Zero out edge weights for masked edges before calling
+        :meth:`HistoryDag.fast_sample`. This should be equivalent to passing
+        the same edge_selector function to :meth:`HistoryDag.sample`.
 
         Args:
             edge_selector: A function accepting an edge (a tuple of HistoryDagNode objects) and
@@ -3121,7 +3129,8 @@ class HistoryDag:
                 whether those probabilities are on a log scale.
 
         Take care to verify that you shouldn't instead use :meth:`HistoryDag.probability_annotate` with
-        a choice of ``edge_weight_func`` that takes into account the masking preferences."""
+        a choice of ``edge_weight_func`` that takes into account the masking preferences.
+        """
 
         if log_probabilities:
             mask_value = float("-inf")
@@ -3136,7 +3145,6 @@ class HistoryDag:
                     for i, val in enumerate(mask):
                         if not val:
                             eset.probs[i] = mask_value
-
 
     def probability_annotate(
         self,
@@ -3634,7 +3642,6 @@ class HistoryDag:
         if skip_ua_node:
             next(gen)
         yield from gen
-
 
 
 # DAG creation functions

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -3696,7 +3696,7 @@ def history_dag_from_nodes(nodes: Sequence[HistoryDagNode]) -> HistoryDag:
     ua_node = UANode(EdgeSet())
     if ua_node in nodes:
         ua_node = nodes[ua_node].empty_copy()
-    nodes.pop(ua_node)
+        nodes.pop(ua_node)
     clade_dict = _clade_union_dict(nodes.keys())
     edge_dict = {
         node: [child for clade in node.clades for child in clade_dict[clade]]
@@ -3711,3 +3711,37 @@ def history_dag_from_nodes(nodes: Sequence[HistoryDagNode]) -> HistoryDag:
             node.add_edge(child)
 
     return HistoryDag(ua_node)
+
+
+def make_binary_complete_dag(leaf_labels):
+    """Produce a history DAG containing all binary topologies on the provided iterable of
+    leaf labels."""
+    leaf_labels = list(leaf_labels)
+    model_label = leaf_labels[0]
+    if not isinstance(model_label, tuple):
+        raise ValueError("Provided labels must be a historydag Label type (a typing.NamedTuple instance)")
+    field_values = tuple(Ellipsis for _ in model_label)
+    internal_label = type(model_label)(*field_values)
+
+    node_set = {UANode(EdgeSet())}
+    for clade in utils.powerset(leaf_labels, start_size=1):
+        # Now need to get all splits of this clade into two child clades
+        cladesize = len(clade)
+        for child_mask in utils.powerset(range(cladesize), start_size=1, end_size=cladesize - 1):
+            splitter_mask = [False] * cladesize
+            for idx in child_mask:
+                splitter_mask[idx] = True
+            clade1 = frozenset(clade[idx] for idx, flag in enumerate(splitter_mask) if flag)
+            clade2 = frozenset(clade[idx] for idx, flag in enumerate(splitter_mask) if not flag)
+            node_set.add(
+                HistoryDagNode(
+                    internal_label, {clade1: EdgeSet(), clade2: EdgeSet()}, {},
+                )
+            )
+    for leaf_label in leaf_labels:
+        node_set.add(
+            HistoryDagNode(
+                leaf_label, {}, {},
+            )
+        )
+    return history_dag_from_nodes(node_set)

--- a/historydag/dag.py
+++ b/historydag/dag.py
@@ -3714,12 +3714,14 @@ def history_dag_from_nodes(nodes: Sequence[HistoryDagNode]) -> HistoryDag:
 
 
 def make_binary_complete_dag(leaf_labels):
-    """Produce a history DAG containing all binary topologies on the provided iterable of
-    leaf labels."""
+    """Produce a history DAG containing all binary topologies on the provided
+    iterable of leaf labels."""
     leaf_labels = list(leaf_labels)
     model_label = leaf_labels[0]
     if not isinstance(model_label, tuple):
-        raise ValueError("Provided labels must be a historydag Label type (a typing.NamedTuple instance)")
+        raise ValueError(
+            "Provided labels must be a historydag Label type (a typing.NamedTuple instance)"
+        )
     field_values = tuple(Ellipsis for _ in model_label)
     internal_label = type(model_label)(*field_values)
 
@@ -3727,21 +3729,31 @@ def make_binary_complete_dag(leaf_labels):
     for clade in utils.powerset(leaf_labels, start_size=1):
         # Now need to get all splits of this clade into two child clades
         cladesize = len(clade)
-        for child_mask in utils.powerset(range(cladesize), start_size=1, end_size=cladesize - 1):
+        for child_mask in utils.powerset(
+            range(cladesize), start_size=1, end_size=cladesize - 1
+        ):
             splitter_mask = [False] * cladesize
             for idx in child_mask:
                 splitter_mask[idx] = True
-            clade1 = frozenset(clade[idx] for idx, flag in enumerate(splitter_mask) if flag)
-            clade2 = frozenset(clade[idx] for idx, flag in enumerate(splitter_mask) if not flag)
+            clade1 = frozenset(
+                clade[idx] for idx, flag in enumerate(splitter_mask) if flag
+            )
+            clade2 = frozenset(
+                clade[idx] for idx, flag in enumerate(splitter_mask) if not flag
+            )
             node_set.add(
                 HistoryDagNode(
-                    internal_label, {clade1: EdgeSet(), clade2: EdgeSet()}, {},
+                    internal_label,
+                    {clade1: EdgeSet(), clade2: EdgeSet()},
+                    {},
                 )
             )
     for leaf_label in leaf_labels:
         node_set.add(
             HistoryDagNode(
-                leaf_label, {}, {},
+                leaf_label,
+                {},
+                {},
             )
         )
     return history_dag_from_nodes(node_set)

--- a/historydag/dag_node.py
+++ b/historydag/dag_node.py
@@ -527,8 +527,7 @@ class EdgeSet:
     ) -> Tuple[HistoryDagNode, float]:
         """Returns a randomly sampled child edge, and its corresponding weight.
 
-        When possible, only edges pointing to child nodes on which
-        ``selection_function`` evaluates to True will be sampled.
+        When possible, only edges with nonzero mask value will be sampled.
         """
         if log_probabilities:
             weights = [exp(weight) for weight in self.probs]

--- a/historydag/dag_node.py
+++ b/historydag/dag_node.py
@@ -183,11 +183,12 @@ class HistoryDagNode:
                 prob_norm=prob_norm,
             )
 
-    def _get_subhistory_by_subid(self, subid: int) -> "HistoryDagNode":
+    def _get_subhistory_by_subid(self, subid: int, tree_builder, parent_repr=None) -> "HistoryDagNode":
         r"""Returns the subtree below the current HistoryDagNode corresponding
         to the given index."""
+        this_repr = tree_builder.add_node(self, parent=parent_repr)
         if self.is_leaf():  # base case - the node is a leaf
-            return self
+            return
         else:
             history = self.empty_copy()
 
@@ -205,13 +206,10 @@ class HistoryDagNode:
                         curr_index = curr_index - child._dp_data
                     else:
                         # add this edge to the tree somehow
-                        history.clades[clade].add_to_edgeset(
-                            child._get_subhistory_by_subid(curr_index)
-                        )
+                        child._get_subhistory_by_subid(curr_index, tree_builder, parent_repr=this_repr)
                         break
 
                 subid = subid / num_subtrees
-        return history
 
     def remove_edge_by_clade_and_id(self, target: "HistoryDagNode", clade: frozenset):
         key: frozenset

--- a/historydag/parsimony.py
+++ b/historydag/parsimony.py
@@ -107,7 +107,8 @@ def sankoff_upward(
         seq_len: The length of sequence for each leaf node.
         sequence_attr_name: the field name of the label attribute that is used to store sequences on nodes.
             Default value is set to 'sequence'
-        transition_model: The type of ``TransitionModel`` to use for Sankoff. See docstring for more information.
+        transition_model: The type of :meth:`parsimony_utils.TransitionModel` to use for Sankoff.
+            See docstring for more information.
         use_internal_node_sequences: (used when tree is of type ``ete3.TreeNode``) If True, then compute the
             transition cost for sequences assigned to internal nodes.
     """
@@ -385,10 +386,15 @@ def disambiguate(
         remove_cvs: Remove sankoff cost vectors from tree nodes after disambiguation.
         adj_dist: Recompute hamming parsimony distances on tree after disambiguation, and store them
             in ``dist`` node attributes.
+        transition_model: The type of :meth:`parsimony_utils.TransitionModel` to use for Sankoff.
+            See docstring for more information.
         min_ambiguities: If True, leaves ambiguities in reconstructed sequences, expressing which
             bases are possible at each site in a maximally parsimonious disambiguation of the given
             topology. In the history DAG paper, this is known as a strictly min-weight ambiguous labeling.
             Otherwise, sequences are resolved in one possible way, and include no ambiguities.
+        use_internal_node_sequences: If True, then instead of overwriting internal node sequences, only
+            disambiguate ambiguous bases in those sequences. For example, to fix a root sequence, this
+            option must be True.
     """
     if random_state is None:
         random.seed(tree.write(format=1))

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -1,6 +1,7 @@
 """Utility functions and classes for working with HistoryDag objects."""
 
 import ete3
+import math
 from math import log, exp, isfinite
 from collections import Counter
 from functools import wraps
@@ -1163,6 +1164,25 @@ def binary_support(clade_size, total_leaves, normalized=True):
         return count / count_labeled_binary_topologies(total_leaves)
     else:
         return count
+
+
+def count_resolved_clade_supports(n_child_clades, threshold=-1):
+    """Returns a generator on clade size, support pairs, for clades which would
+    result from binary resolution of a node posessing child clade sets in
+    node_child_clades.
+
+    Summing over the first element of yielded tuples gives the number of
+    elements which would be yielded by iter_resolved_clade_supports
+    provided with n_child_clades child clades and the same threshold
+    value.
+    """
+    num_children = n_child_clades
+    for unflattened_clade_size in range(1, num_children + 1):
+        # support will be the same for all clades of this size...
+        support = binary_support(unflattened_clade_size, num_children)
+        # ... so this check need only be done num_children times
+        if support > threshold:
+            yield (math.comb(num_children, unflattened_clade_size), support)
 
 
 def iter_resolved_clade_supports(node_child_clades, threshold=-1):

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -1,7 +1,6 @@
 """Utility functions and classes for working with HistoryDag objects."""
 
 import ete3
-import math
 from math import log, exp, isfinite
 from collections import Counter
 from functools import wraps
@@ -23,6 +22,29 @@ from typing import (
     Optional,
 )
 from typing import TYPE_CHECKING
+
+
+try:
+    from math import comb
+except ImportError:
+
+    def comb(n, k):
+        """
+        A fast way to calculate binomial coefficients
+        from https://stackoverflow.com/a/3025547
+        https://en.wikipedia.org/wiki/Binomial_coefficient#Multiplicative_formula
+        """
+        if 0 <= k <= n:
+            ntok = 1
+            ktok = 1
+            for t in range(1, min(k, n - k) + 1):
+                ntok *= n
+                ktok *= t
+                n -= 1
+            return ntok // ktok
+        else:
+            return 0
+
 
 if TYPE_CHECKING:
     from historydag.dag import HistoryDagNode, HistoryDag
@@ -1207,7 +1229,7 @@ def count_resolved_clade_supports(
         support = binary_support(unflattened_clade_size, num_children)
         # ... so this check need only be done num_children times
         if support > threshold:
-            yield (math.comb(num_children, unflattened_clade_size), support)
+            yield (comb(num_children, unflattened_clade_size), support)
 
 
 def iter_resolved_clade_supports(

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -1131,40 +1131,50 @@ def count_labeled_binary_topologies(n):
     """
     return prod(range(1, 2 * n - 2, 2))
 
+
 def powerset(iterable, start_size=0, end_size=None):
     """Produce all subsets of iterable (as tuples of elements), with sizes
-    starting at start_size and ending at end_size (inclusive), or the size of the passed
-    iterable if end_size is None."""
+    starting at start_size and ending at end_size (inclusive), or the size of
+    the passed iterable if end_size is None."""
     items = list(iterable)
     if end_size is None:
         end_size = len(items)
-    return chain.from_iterable(combinations(items, r) for r in range(start_size, end_size + 1))
+    return chain.from_iterable(
+        combinations(items, r) for r in range(start_size, end_size + 1)
+    )
+
 
 def binary_support(clade_size, total_leaves, normalized=True):
-    """Calculate the fraction of binary trees on total_leaves
-    containing a particular clade containing clade_size leaves.
-    If normalized is False, instead returns the number of binary topologies
-    which would contain a particular clade of size clade_size."""
+    """Calculate the fraction of binary trees on total_leaves containing a
+    particular clade containing clade_size leaves.
+
+    If normalized is False, instead returns the number of binary
+    topologies which would contain a particular clade of size
+    clade_size.
+    """
     if clade_size > total_leaves:
         raise ValueError("Clade size cannot exceed total number of leaves in tree")
 
-    count = (count_labeled_binary_topologies(clade_size) *
-             count_labeled_binary_topologies(total_leaves - clade_size + 1))
+    count = count_labeled_binary_topologies(
+        clade_size
+    ) * count_labeled_binary_topologies(total_leaves - clade_size + 1)
     # This could certainly be more numerically stable
     if normalized:
         return count / count_labeled_binary_topologies(total_leaves)
     else:
         return count
 
-def iter_resolved_clade_supports(node_child_clades, threshold=-1):
-    """Returns a generator on clade, support pairs, for clades which
-    would result from binary resolution of a node posessing child clade
-    sets in node_child_clades. All clades with support > threshold are
-    yielded, avoiding iteration through too many clades on large multifurcations.
 
-    Note that the root clade, including all leaves contained in node_child_clades,
-    as well as all the clades contained in node_child_clades, are included and each
-    have a support of 1."""
+def iter_resolved_clade_supports(node_child_clades, threshold=-1):
+    """Returns a generator on clade, support pairs, for clades which would
+    result from binary resolution of a node posessing child clade sets in
+    node_child_clades. All clades with support > threshold are yielded,
+    avoiding iteration through too many clades on large multifurcations.
+
+    Note that the root clade, including all leaves contained in
+    node_child_clades, as well as all the clades contained in
+    node_child_clades, are included and each have a support of 1.
+    """
     num_children = len(node_child_clades)
     if num_children < 3:
         yield from []
@@ -1173,8 +1183,16 @@ def iter_resolved_clade_supports(node_child_clades, threshold=-1):
             # support will be the same for all clades of this size
             support = binary_support(unflattened_clade_size, num_children)
             if support > threshold:
-                for clade in map(lambda ns: frozenset(chain.from_iterable(ns)), powerset(node_child_clades, start_size=unflattened_clade_size, end_size=unflattened_clade_size)):
+                for clade in map(
+                    lambda ns: frozenset(chain.from_iterable(ns)),
+                    powerset(
+                        node_child_clades,
+                        start_size=unflattened_clade_size,
+                        end_size=unflattened_clade_size,
+                    ),
+                ):
                     yield (clade, support)
+
 
 def read_fasta(fastapath, sequence_type=str):
     """Load a fasta file as a generator which yields (sequence ID, sequence)

--- a/historydag/utils.py
+++ b/historydag/utils.py
@@ -1176,22 +1176,20 @@ def iter_resolved_clade_supports(node_child_clades, threshold=-1):
     node_child_clades, are included and each have a support of 1.
     """
     num_children = len(node_child_clades)
-    if num_children < 3:
-        yield from []
-    else:
-        for unflattened_clade_size in range(1, num_children + 1):
-            # support will be the same for all clades of this size
-            support = binary_support(unflattened_clade_size, num_children)
-            if support > threshold:
-                for clade in map(
-                    lambda ns: frozenset(chain.from_iterable(ns)),
-                    powerset(
-                        node_child_clades,
-                        start_size=unflattened_clade_size,
-                        end_size=unflattened_clade_size,
-                    ),
-                ):
-                    yield (clade, support)
+    for unflattened_clade_size in range(1, num_children + 1):
+        # support will be the same for all clades of this size...
+        support = binary_support(unflattened_clade_size, num_children)
+        # ... so this check need only be done num_children times
+        if support > threshold:
+            for clade in map(
+                lambda ns: frozenset(chain.from_iterable(ns)),
+                powerset(
+                    node_child_clades,
+                    start_size=unflattened_clade_size,
+                    end_size=unflattened_clade_size,
+                ),
+            ):
+                yield (clade, support)
 
 
 def read_fasta(fastapath, sequence_type=str):

--- a/tests/test_binary_tree.py
+++ b/tests/test_binary_tree.py
@@ -32,24 +32,38 @@ def test_binary_support():
 def test_iter_resolved_clade_supports():
     # Check there are no duplicates and this works on nontrivial child clade
     # sets:
-    child_clade_set = {
-        frozenset({Label(i) for i in range(4)}),
-        frozenset({Label(i) for i in range(4, 6)}),
-        frozenset({Label(i) for i in range(6, 10)}),
-        frozenset({Label(10)}),
-        frozenset({Label(11)}),
-        frozenset({Label(12)}),
-        frozenset({Label(13)}),
-        frozenset({Label(14)}),
-    }
-    # Make sure child clades are pairwise disjoint
-    assert sum(len(s) for s in child_clade_set) == len(set(chain(*child_clade_set)))
+    for child_clade_set in (
+        {
+            frozenset({Label(i) for i in range(4)}),
+        },
+        {
+            frozenset({Label(i) for i in range(4)}),
+            frozenset({Label(i) for i in range(4, 6)}),
+        },
+        {
+            frozenset({Label(i) for i in range(4)}),
+            frozenset({Label(i) for i in range(4, 6)}),
+            frozenset({Label(i) for i in range(6, 10)}),
+        },
+        {
+            frozenset({Label(i) for i in range(4)}),
+            frozenset({Label(i) for i in range(4, 6)}),
+            frozenset({Label(i) for i in range(6, 10)}),
+            frozenset({Label(10)}),
+            frozenset({Label(11)}),
+            frozenset({Label(12)}),
+            frozenset({Label(13)}),
+            frozenset({Label(14)}),
+        },
+    ):
+        # Make sure child clades are pairwise disjoint
+        assert sum(len(s) for s in child_clade_set) == len(set(chain(*child_clade_set)))
 
-    clade_supports = list(
-        hdag.utils.iter_resolved_clade_supports(child_clade_set, threshold=0.02)
-    )
-    # Make sure there are no duplicated clades
-    assert len(clade_supports) == len(set(clade for clade, _ in clade_supports))
+        clade_supports = list(
+            hdag.utils.iter_resolved_clade_supports(child_clade_set, threshold=0.02)
+        )
+        # Make sure there are no duplicated clades
+        assert len(clade_supports) == len(set(clade for clade, _ in clade_supports))
 
     # Check that clade supports match those computed by actually counting
     num_leaves = 8

--- a/tests/test_binary_tree.py
+++ b/tests/test_binary_tree.py
@@ -1,0 +1,84 @@
+import historydag as hdag
+from typing import NamedTuple, Any
+from itertools import chain
+import math
+
+Label = NamedTuple("Label", [("leaf_id", Any)])  # type: ignore
+
+
+def make_binary_complete_dag(num_leaves):
+    labels = [Label(i) for i in range(num_leaves)]
+    return hdag.dag.make_binary_complete_dag(labels)
+
+
+def test_binary_resolutions_count():
+    for i in range(3, 8):
+        dag = make_binary_complete_dag(i)
+        assert hdag.utils.count_labeled_binary_topologies(i) == dag.count_histories()
+
+
+def test_binary_support():
+    num_leaves = 9
+    dag = make_binary_complete_dag(num_leaves)
+    node_counts = dag.count_nodes(collapse=True)
+    for clade, count in node_counts.items():
+        estimate = hdag.utils.binary_support(len(clade), num_leaves, normalized=False)
+        if count != estimate:
+            raise AssertionError(
+                f"{clade} was counted {count} times in DAG, but estimated to occur {estimate} times"
+            )
+
+
+def test_iter_resolved_clade_supports():
+    # Check there are no duplicates and this works on nontrivial child clade
+    # sets:
+    child_clade_set = {
+        frozenset({Label(i) for i in range(4)}),
+        frozenset({Label(i) for i in range(4, 6)}),
+        frozenset({Label(i) for i in range(6, 10)}),
+        frozenset({Label(10)}),
+        frozenset({Label(11)}),
+        frozenset({Label(12)}),
+        frozenset({Label(13)}),
+        frozenset({Label(14)}),
+    }
+    # Make sure child clades are pairwise disjoint
+    assert sum(len(s) for s in child_clade_set) == len(set(chain(*child_clade_set)))
+
+    clade_supports = list(
+        hdag.utils.iter_resolved_clade_supports(child_clade_set, threshold=0.02)
+    )
+    # Make sure there are no duplicated clades
+    assert len(clade_supports) == len(set(clade for clade, _ in clade_supports))
+
+    # Check that clade supports match those computed by actually counting
+    num_leaves = 8
+    dag = make_binary_complete_dag(num_leaves)
+    child_clade_sets = frozenset({frozenset({Label(i)}) for i in range(num_leaves)})
+    # print(child_clade_sets)
+
+    node_counts = dag.count_nodes(collapse=True)
+    num_histories = dag.count_histories()
+    # print("====== true supports")
+    # for clade, count in sorted(node_counts.items(), key=lambda s: len(s[0])):
+    #     print(clade, count / num_histories)
+
+    for tolerance in [0, 0.05]:
+        assert len(child_clade_sets) == num_leaves
+        estimated_counts = dict(
+            hdag.utils.iter_resolved_clade_supports(
+                child_clade_sets, threshold=tolerance
+            )
+        )
+        # print("====== estimated supports")
+        # for clade, count in sorted(estimated_counts.items(), key=lambda s: len(s[0])):
+        #     print(clade, count)
+
+        print(tolerance, len(estimated_counts))
+
+        for clade, count in node_counts.items():
+            true_support = count / num_histories
+            if true_support > tolerance:
+                assert math.isclose(true_support, estimated_counts[clade])
+            else:
+                assert clade not in estimated_counts

--- a/tests/test_binary_tree.py
+++ b/tests/test_binary_tree.py
@@ -29,6 +29,29 @@ def test_binary_support():
             )
 
 
+def test_count_resolved_clade_supports():
+    def num_clades_above_threshold(n_leaves, threshold):
+        return sum(
+            1
+            for _ in hdag.utils.iter_resolved_clade_supports(
+                {frozenset({i}) for i in range(n_leaves)}, threshold=threshold
+            )
+        )
+
+    def count_clades_above_threshold(n_leaves, threshold):
+        return sum(
+            tup[0]
+            for tup in hdag.utils.count_resolved_clade_supports(
+                n_leaves, threshold=threshold
+            )
+        )
+
+    for count, threshold in zip(range(20), [0.001, 0.005, 0.01, 0.05, 0.1]):
+        assert num_clades_above_threshold(
+            count, threshold
+        ) == count_clades_above_threshold(count, threshold)
+
+
 def test_iter_resolved_clade_supports():
     # Check there are no duplicates and this works on nontrivial child clade
     # sets:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -394,8 +394,10 @@ def test_fast_sample_with_node():
     ]
     for node in least_supported_nodes:
         mask_true = dag.nodes_above_node(node)
+
         def edge_selector(edge):
             return edge[-1] in mask_true
+
         dag.make_uniform()
         dag.set_sample_mask(edge_selector)
         tree_samples = [dag.fast_sample() for _ in range(min_count * 7)]
@@ -410,6 +412,7 @@ def test_fast_sample_with_node():
         # norms, avg = normalize_counts(Counter(tree.to_newick() for tree in tree_samples))
         # print(norms)
         # assert all(is_close(norm, avg) for norm in norms)
+
 
 def test_sample_with_node():
     random.seed(1)

--- a/tests/test_historydag.py
+++ b/tests/test_historydag.py
@@ -241,6 +241,18 @@ def test_sample():
     sample.to_graphviz(namedict=namedict)
 
 
+def test_fast_sample():
+    newicks = ["((a, b)b, c)c;", "((a, b)c, c)c;", "((a, b)a, c)c;", "((a, b)r, c)r;"]
+    newicks = ["((1, 2)2, 3)3;", "((1, 2)3, 3)3;", "((1, 2)1, 3)3;", "((1, 2)4, 3)4;"]
+    namedict = {(str(x),): x for x in range(5)}
+    dag = history_dag_from_newicks(newicks, ["name"])
+    for i in range(10):
+        assert dag.fast_sample().is_history()
+    sample = dag.fast_sample()
+    sample._check_valid()
+    sample.to_graphviz(namedict=namedict)
+
+
 def test_unifurcation():
     # Make sure that unifurcations are handled correctly
     # First make sure the call works when the problem is fixed:


### PR DESCRIPTION
This PR includes:
* machinery to iterate through nodes which would be produced by resolving a multifurcation, and compute their supports, without explicitly choosing a single binary resolution (`historydag.utils.iter_resolved_clade_supports`)
* (for fun/testing) a function to produce complete DAGs containing all possible binary topologies on a set of leaf labels (`historydag.dag.make_binary_complete_dag`)
* a new general interface for passing data of sampled histories to an arbitrary target object without an intermediate history DAG representation (`historydag.dag.PreorderTreeBuilder` and subclasses)
* a faster, and non-recursive sampling method `HistoryDag.fast_sample`